### PR TITLE
cddl_gen.py: Add support for the .bits operator.

### DIFF
--- a/tests/scripts/run_tests.py
+++ b/tests/scripts/run_tests.py
@@ -26,8 +26,8 @@ p_optional = Path(p_tests, 'cases/optional.cddl')
 class Testn(TestCase):
     def decode(self, ccdl_path, data_path):
         with open(ccdl_path, 'r') as f:
-            my_types = cddl_gen.DataTranslator.from_cddl(f.read(), 16)
-        cddl = my_types["SUIT_Envelope_Tagged"]
+            cddl_res = cddl_gen.DataTranslator.from_cddl(f.read(), 16)
+        cddl = cddl_res.my_types["SUIT_Envelope_Tagged"]
         with open(data_path, 'r') as f:
             data = bytes.fromhex(f.read().replace("\n", ""))
         self.decoded = cddl.decode_str(data)
@@ -210,8 +210,8 @@ class TestCLI(TestCase):
 class TestOptional(TestCase):
     def test_0(self):
         with open(p_optional, 'r') as f:
-            my_types = cddl_gen.DataTranslator.from_cddl(f.read(), 16)
-        cddl = my_types['cfg']
+            cddl_res = cddl_gen.DataTranslator.from_cddl(f.read(), 16)
+        cddl = cddl_res.my_types['cfg']
         test_yaml = """
             mem_config:
                 - 0


### PR DESCRIPTION
This allows specifying and naming the bits that can be set in an
integer value. It involves validating that only the given bits have
been set.

The change involves:
 - Adding parsing code for .bits
 - Adding special separation of the parsing of the bits control group &()
   It needs to be kept in a list separate from my_types since it needs
   entirely different handling.
 - Adding the validation to the code generation, i.e. checking that only
   the allowed bits have been set. This is done together with the regular
   range checks (min/max value and min/max size).

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>