### PR TITLE
cddl_gen: make -t really supports multiple values

### DIFF
--- a/cddl_gen/cddl_gen.py
+++ b/cddl_gen/cddl_gen.py
@@ -2399,7 +2399,7 @@ This script requires 'regex' for lookaround functionality not present in 're'.''
         "--output-h-types", "--oht", required=False, type=FileType('w'),
         help="Path to output header file with typedefs (shared between decode and encode).")
     code_parser.add_argument(
-        "-t", "--entry-types", required=True, type=str, nargs="+",
+        "-t", "--entry-types", required=True, type=str, action='append',
         help="Names of the types which should have their xcode functions exposed.")
     code_parser.add_argument(
         "-d", "--decode", required=False, action="store_true", default=False,


### PR DESCRIPTION
nargs='+' seems to apply operation on variable, however, the type
is a list, so it's a bit strange to me. However, using action='append'
make the type being a list and all the -t foo -t bar land to this
list ['foo', 'bar'], instead of ['bar'] for nargs.