### PR TITLE
Rename zcbor_string_typte_t and zcbor_state_backups_t

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -153,7 +153,7 @@ For example:
 A CodeGenerator object operates in one of two modes: `"encode"` or `"decode"`.
 The generated code for the two is not very different, but they call into different libraries.
 
-Base types, like `"UINT"`, `"BOOL"`, `"FLOAT"` are represented by native C types. `"BSTR"`s and `"TSTR"`s are represented by a proprietary `zcbor_string_type_t` which is just a `uint8_t` pointer and length.
+Base types, like `"UINT"`, `"BOOL"`, `"FLOAT"` are represented by native C types. `"BSTR"`s and `"TSTR"`s are represented by a proprietary `struct zcbor_string` which is just a `uint8_t` pointer and length.
 These types are decoded/encoded with C code that is not generated.
 More on this in the Architecture of the generated C code below.
 
@@ -166,7 +166,7 @@ These types are called "entry types" and they are typically the "outermost" type
 The user can also use entry types when there are `"BSTR"`s that are CBOR encoded, specified as `Foo = bstr .cbor Bar`.
 Usually such strings are automatically decoded/encoded by the generated code, and the objects part of the encompassing struct.
 However, if the user instead wants to manually decode/encode such strings, they can add them to `self.entry_types`.
-In this case, the strings will be stored as a regular `zcbor_string_type_t` instead of being decoded/encoded.
+In this case, the strings will be stored as a regular `struct zcbor_string` instead of being decoded/encoded.
 
 CodeRenderer
 ------------

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ res = res && zcbor_tstr_put(&state, "first");
 res = res && zcbor_tstr_put(&state, "second");
 res = res && zcbor_list_end_encode(&state, 0);
 uint8_t timestamp[8] = {1, 2, 3, 4, 5, 6, 7, 8};
-zcbor_string_type_t timestamp_str = {
+struct zcbor_string timestamp_str = {
   .value = timestamp,
   .len = sizeof(timestamp),
 };

--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -14,11 +14,11 @@
 /** Convenience type that allows pointing to strings directly inside the payload
  *  without the need to copy out.
  */
-typedef struct
+struct zcbor_string
 {
 	const uint8_t *value;
 	size_t len;
-} zcbor_string_type_t;
+};
 
 #ifdef ZCBOR_VERBOSE
 #include <sys/printk.h>
@@ -50,9 +50,8 @@ do { \
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 #endif
 
-struct zcbor_state_backups_s;
 
-typedef struct zcbor_state_backups_s zcbor_state_backups_t;
+struct zcbor_state_constant;
 
 typedef struct {
 union {
@@ -70,10 +69,11 @@ union {
 	uint8_t const *payload_end; /**< The end of the payload. This will be
 	                                 checked against payload before
 	                                 processing each element. */
-	zcbor_state_backups_t *backups;
+	struct zcbor_state_constant *constant_state; /**< The part of the state that is
+	                                                  not backed up and duplicated. */
 } zcbor_state_t;
 
-struct zcbor_state_backups_s {
+struct zcbor_state_constant {
 	zcbor_state_t *backup_list;
 	uint_fast32_t current_backup;
 	uint_fast32_t num_backups;
@@ -150,7 +150,7 @@ bool zcbor_union_elem_code(zcbor_state_t *state);
 bool zcbor_union_end_code(zcbor_state_t *state);
 
 /** Initialize a state with backups.
- *  One of the states in the array is used as a zcbor_state_backups_t object.
+ *  One of the states in the array is used as a struct zcbor_state_constant object.
  *  This means that you get a state with (n_states - 2) backups.
  *  It also means that (n_states = 2) is an invalid input, which is handled as
  *  if (n_states = 1).

--- a/include/zcbor_decode.h
+++ b/include/zcbor_decode.h
@@ -116,10 +116,10 @@ bool zcbor_uint32_expect_union(zcbor_state_t *state, uint32_t result);
 bool zcbor_uint64_expect_union(zcbor_state_t *state, uint64_t result);
 
 /** Decode and consume a BSTR/TSTR */
-bool zcbor_bstr_decode(zcbor_state_t *state, zcbor_string_type_t *result);
-bool zcbor_bstr_expect(zcbor_state_t *state, zcbor_string_type_t *result);
-bool zcbor_tstr_decode(zcbor_state_t *state, zcbor_string_type_t *result);
-bool zcbor_tstr_expect(zcbor_state_t *state, zcbor_string_type_t *result);
+bool zcbor_bstr_decode(zcbor_state_t *state, struct zcbor_string *result);
+bool zcbor_bstr_expect(zcbor_state_t *state, struct zcbor_string *result);
+bool zcbor_tstr_decode(zcbor_state_t *state, struct zcbor_string *result);
+bool zcbor_tstr_expect(zcbor_state_t *state, struct zcbor_string *result);
 
 /** Consume and expect a BSTR/TSTR with the value of the provided string literal.
  *
@@ -128,9 +128,9 @@ bool zcbor_tstr_expect(zcbor_state_t *state, zcbor_string_type_t *result);
  *                       that sizeof(string) - 1 is the length of the string.
  */
 #define zcbor_bstr_expect_lit(state, string) zcbor_bstr_expect(state, \
-		&(zcbor_string_type_t){.value = string, .len = (sizeof(string) - 1)})
+		&(struct zcbor_string){.value = string, .len = (sizeof(string) - 1)})
 #define zcbor_tstr_expect_lit(state, string) zcbor_tstr_expect(state, \
-		&(zcbor_string_type_t){.value = string, .len = (sizeof(string) - 1)})
+		&(struct zcbor_string){.value = string, .len = (sizeof(string) - 1)})
 
 /** Consume and expect a BSTR/TSTR with the value of the provided null-terminated string.
  *
@@ -139,9 +139,9 @@ bool zcbor_tstr_expect(zcbor_state_t *state, zcbor_string_type_t *result);
  *                       so that strlen can be used.
  */
 #define zcbor_bstr_expect_term(state, string) zcbor_bstr_expect(state, \
-		&(zcbor_string_type_t){.value = string, .len = strlen(string)})
+		&(struct zcbor_string){.value = string, .len = strlen(string)})
 #define zcbor_tstr_expect_term(state, string) zcbor_tstr_expect(state, \
-		&(zcbor_string_type_t){.value = string, .len = strlen(string)})
+		&(struct zcbor_string){.value = string, .len = strlen(string)})
 
 /** Consume and expect a BSTR/TSTR with the value of the provided char array literal.
  *
@@ -150,9 +150,9 @@ bool zcbor_tstr_expect(zcbor_state_t *state, zcbor_string_type_t *result);
  *                       so that sizeof(string) is the length of the string.
  */
 #define zcbor_bstr_expect_arr(state, string) zcbor_bstr_expect(state, \
-		&(zcbor_string_type_t){.value = string, .len = (sizeof(string))})
+		&(struct zcbor_string){.value = string, .len = (sizeof(string))})
 #define zcbor_tstr_expect_arr(state, string) zcbor_tstr_expect(state, \
-		&(zcbor_string_type_t){.value = string, .len = (sizeof(string))})
+		&(struct zcbor_string){.value = string, .len = (sizeof(string))})
 
 /** Decode and consume a tag. */
 bool zcbor_tag_decode(zcbor_state_t *state, uint32_t *result);
@@ -191,7 +191,7 @@ bool zcbor_any_decode(zcbor_state_t *state, void *unused);
  * @retval true   Header decoded correctly
  * @retval false  Header decoded incorrectly, or backup failed.
  */
-bool zcbor_bstr_start_decode(zcbor_state_t *state, zcbor_string_type_t *result);
+bool zcbor_bstr_start_decode(zcbor_state_t *state, struct zcbor_string *result);
 
 /** Finalize decoding a CBOR-encoded bstr.
  *
@@ -232,7 +232,7 @@ bool zcbor_map_end_decode(zcbor_state_t *state);
  *
  * @code{c}
  *     uint32_t ints[3];
- *     zcbor_string_type_t bstrs[2];
+ *     struct zcbor_string bstrs[2];
  *     uint32_t num_decode;
  *     bool res;
  *

--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -43,9 +43,9 @@ bool zcbor_uint32_encode(zcbor_state_t *state, const uint32_t *result);
 bool zcbor_uint64_encode(zcbor_state_t *state, const uint64_t *input);
 
 /** Encode a BSTR. */
-bool zcbor_bstr_encode(zcbor_state_t *state, const zcbor_string_type_t *input);
+bool zcbor_bstr_encode(zcbor_state_t *state, const struct zcbor_string *input);
 /** Encode a TSTR. */
-bool zcbor_tstr_encode(zcbor_state_t *state, const zcbor_string_type_t *input);
+bool zcbor_tstr_encode(zcbor_state_t *state, const struct zcbor_string *input);
 
 /** Encode a string literal as a BSTR/TSTR.
  *
@@ -55,10 +55,10 @@ bool zcbor_tstr_encode(zcbor_state_t *state, const zcbor_string_type_t *input);
  */
 #define zcbor_bstr_put_lit(state, string) \
 	zcbor_bstr_encode(state, \
-		&(zcbor_string_type_t){.value = string, .len = (sizeof(string) - 1)})
+		&(struct zcbor_string){.value = string, .len = (sizeof(string) - 1)})
 #define zcbor_tstr_put_lit(state, string) \
 	zcbor_tstr_encode(state, \
-		&(zcbor_string_type_t){.value = string, .len = (sizeof(string) - 1)})
+		&(struct zcbor_string){.value = string, .len = (sizeof(string) - 1)})
 
 /** Encode null-terminated string as a BSTR/TSTR.
  *
@@ -67,9 +67,9 @@ bool zcbor_tstr_encode(zcbor_state_t *state, const zcbor_string_type_t *input);
  *                       so that strlen can be used.
  */
 #define zcbor_bstr_put_term(state, string) \
-	zcbor_bstr_encode(state, &(zcbor_string_type_t){.value = string, .len = strlen(string)})
+	zcbor_bstr_encode(state, &(struct zcbor_string){.value = string, .len = strlen(string)})
 #define zcbor_tstr_put_term(state, string) \
-	zcbor_tstr_encode(state, &(zcbor_string_type_t){.value = string, .len = strlen(string)})
+	zcbor_tstr_encode(state, &(struct zcbor_string){.value = string, .len = strlen(string)})
 
 /** Encode a char array literal as a BSTR/TSTR.
  *
@@ -78,9 +78,9 @@ bool zcbor_tstr_encode(zcbor_state_t *state, const zcbor_string_type_t *input);
  *                       so that sizeof(string) is the length of the string.
  */
 #define zcbor_bstr_put_arr(state, string) \
-	zcbor_bstr_encode(state, &(zcbor_string_type_t){.value = string, .len = sizeof(string)})
+	zcbor_bstr_encode(state, &(struct zcbor_string){.value = string, .len = sizeof(string)})
 #define zcbor_tstr_put_arr(state, string) \
-	zcbor_tstr_encode(state, &(zcbor_string_type_t){.value = string, .len = sizeof(string)})
+	zcbor_tstr_encode(state, &(struct zcbor_string){.value = string, .len = sizeof(string)})
 
 /** Encode a tag. Must be called before encoding the value being tagged. */
 bool zcbor_tag_encode(zcbor_state_t *state, uint32_t input);
@@ -165,14 +165,14 @@ bool zcbor_map_end_encode(zcbor_state_t *state, uint_fast32_t max_num);
  *
  * @code{c}
  *     uint32_t ints[3] = <initialize>;
- *     zcbor_string_type_t bstrs[2] = <initialize>;
+ *     struct zcbor_string bstrs[2] = <initialize>;
  *     bool res;
  *
  *     res = zcbor_list_start_encode(state, 5);
  *     res = res && zcbor_multi_encode(3, zcbor_uint32_encode, state,
  *                  ints, sizeof(uint32_t));
  *     res = res && zcbor_multi_encode(2, zcbor_bstr_encode, state,
- *                  bstrs, sizeof(zcbor_string_type_t));
+ *                  bstrs, sizeof(struct zcbor_string));
  *     res = res && zcbor_list_end_encode(state, 5);
  *     // check res
  * @endcode

--- a/src/zcbor_common.c
+++ b/src/zcbor_common.c
@@ -13,23 +13,23 @@
 _Static_assert((sizeof(size_t) == sizeof(void *)),
 	"This code needs size_t to be the same length as pointers.");
 
-_Static_assert((sizeof(zcbor_state_t) >= sizeof(zcbor_state_backups_t)),
+_Static_assert((sizeof(zcbor_state_t) >= sizeof(struct zcbor_state_constant)),
 	"This code needs zcbor_state_t to be at least as large as zcbor_backups_t.");
 
 bool zcbor_new_backup(zcbor_state_t *state, uint_fast32_t new_elem_count)
 {
-	if (!state->backups || ((state->backups->current_backup)
-		>= state->backups->num_backups)) {
+	if (!state->constant_state || ((state->constant_state->current_backup)
+		>= state->constant_state->num_backups)) {
 		ZCBOR_FAIL();
 	}
 
-	(state->backups->current_backup)++;
+	(state->constant_state->current_backup)++;
 
 	/* use the backup at current_backup - 1, since otherwise, the 0th
 	 * backup would be unused. */
-	uint_fast32_t i = (state->backups->current_backup) - 1;
+	uint_fast32_t i = (state->constant_state->current_backup) - 1;
 
-	memcpy(&state->backups->backup_list[i], state,
+	memcpy(&state->constant_state->backup_list[i], state,
 		sizeof(zcbor_state_t));
 
 	state->elem_count = new_elem_count;
@@ -44,21 +44,21 @@ bool zcbor_process_backup(zcbor_state_t *state, uint32_t flags,
 	const uint8_t *payload = state->payload;
 	const uint_fast32_t elem_count = state->elem_count;
 
-	if (!state->backups || (state->backups->current_backup == 0)) {
+	if (!state->constant_state || (state->constant_state->current_backup == 0)) {
 		ZCBOR_FAIL();
 	}
 
 	if (flags & ZCBOR_FLAG_RESTORE) {
 		/* use the backup at current_backup - 1, since otherwise, the
 		 * 0th backup would be unused. */
-		uint_fast32_t i = state->backups->current_backup - 1;
+		uint_fast32_t i = state->constant_state->current_backup - 1;
 
-		memcpy(state, &state->backups->backup_list[i],
+		memcpy(state, &state->constant_state->backup_list[i],
 			sizeof(zcbor_state_t));
 	}
 
 	if (flags & ZCBOR_FLAG_CONSUME) {
-		state->backups->current_backup--;
+		state->constant_state->current_backup--;
 	}
 
 	if (elem_count > max_elem_count) {
@@ -106,12 +106,12 @@ void zcbor_new_state(zcbor_state_t *state_array, uint_fast32_t n_states,
 	state_array[0].payload = payload;
 	state_array[0].payload_end = payload + payload_len;
 	state_array[0].elem_count = elem_count;
-	state_array[0].backups = NULL;
+	state_array[0].constant_state = NULL;
 	if (n_states > 2) {
-		/* Use the last state as a zcbor_state_backups_t object. */
-		state_array[0].backups = (zcbor_state_backups_t *)&state_array[n_states - 1];
-		state_array[0].backups->backup_list = &state_array[1];
-		state_array[0].backups->num_backups = n_states - 2;
-		state_array[0].backups->current_backup = 0;
+		/* Use the last state as a struct zcbor_state_constant object. */
+		state_array[0].constant_state = (struct zcbor_state_constant *)&state_array[n_states - 1];
+		state_array[0].constant_state->backup_list = &state_array[1];
+		state_array[0].constant_state->num_backups = n_states - 2;
+		state_array[0].constant_state->current_backup = 0;
 	}
 }

--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -278,7 +278,7 @@ bool zcbor_uint64_expect(zcbor_state_t *state, uint64_t result)
 
 
 static bool strx_start_decode(zcbor_state_t *state,
-		zcbor_string_type_t *result, zcbor_major_type_t exp_major_type)
+		struct zcbor_string *result, zcbor_major_type_t exp_major_type)
 {
 	FAIL_IF(state->payload >= state->payload_end);
 	uint8_t major_type = MAJOR_TYPE(*state->payload);
@@ -303,7 +303,7 @@ static bool strx_start_decode(zcbor_state_t *state,
 }
 
 
-bool zcbor_bstr_start_decode(zcbor_state_t *state, zcbor_string_type_t *result)
+bool zcbor_bstr_start_decode(zcbor_state_t *state, struct zcbor_string *result)
 {
 	if(!strx_start_decode(state, result, ZCBOR_MAJOR_TYPE_BSTR)) {
 		ZCBOR_FAIL();
@@ -334,7 +334,7 @@ bool zcbor_bstr_end_decode(zcbor_state_t *state)
 }
 
 
-bool strx_decode(zcbor_state_t *state, zcbor_string_type_t *result,
+bool strx_decode(zcbor_state_t *state, struct zcbor_string *result,
 		zcbor_major_type_t exp_major_type)
 {
 	if (!strx_start_decode(state, result, exp_major_type)) {
@@ -347,10 +347,10 @@ bool strx_decode(zcbor_state_t *state, zcbor_string_type_t *result,
 }
 
 
-bool strx_expect(zcbor_state_t *state, zcbor_string_type_t *result,
+bool strx_expect(zcbor_state_t *state, struct zcbor_string *result,
 		zcbor_major_type_t exp_major_type)
 {
-	zcbor_string_type_t tmp_result;
+	struct zcbor_string tmp_result;
 
 	if (!strx_decode(state, &tmp_result, exp_major_type)) {
 		ZCBOR_FAIL();
@@ -363,25 +363,25 @@ bool strx_expect(zcbor_state_t *state, zcbor_string_type_t *result,
 }
 
 
-bool zcbor_bstr_decode(zcbor_state_t *state, zcbor_string_type_t *result)
+bool zcbor_bstr_decode(zcbor_state_t *state, struct zcbor_string *result)
 {
 	return strx_decode(state, result, ZCBOR_MAJOR_TYPE_BSTR);
 }
 
 
-bool zcbor_bstr_expect(zcbor_state_t *state, zcbor_string_type_t *result)
+bool zcbor_bstr_expect(zcbor_state_t *state, struct zcbor_string *result)
 {
 	return strx_expect(state, result, ZCBOR_MAJOR_TYPE_BSTR);
 }
 
 
-bool zcbor_tstr_decode(zcbor_state_t *state, zcbor_string_type_t *result)
+bool zcbor_tstr_decode(zcbor_state_t *state, struct zcbor_string *result)
 {
 	return strx_decode(state, result, ZCBOR_MAJOR_TYPE_TSTR);
 }
 
 
-bool zcbor_tstr_expect(zcbor_state_t *state, zcbor_string_type_t *result)
+bool zcbor_tstr_expect(zcbor_state_t *state, struct zcbor_string *result)
 {
 	return strx_expect(state, result, ZCBOR_MAJOR_TYPE_TSTR);
 }

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -234,7 +234,7 @@ bool zcbor_uint64_put(zcbor_state_t *state, uint64_t input)
 
 
 static bool strx_start_encode(zcbor_state_t *state,
-		const zcbor_string_type_t *input, zcbor_major_type_t major_type)
+		const struct zcbor_string *input, zcbor_major_type_t major_type)
 {
 	if (input->value && ((get_result_len(&input->len, sizeof(input->len))
 			+ 1 + input->len + (size_t)state->payload)
@@ -290,7 +290,7 @@ bool zcbor_bstr_end_encode(zcbor_state_t *state)
 	if (!zcbor_process_backup(state, ZCBOR_FLAG_RESTORE | ZCBOR_FLAG_CONSUME, 0xFFFFFFFF)) {
 		ZCBOR_FAIL();
 	}
-	zcbor_string_type_t value;
+	struct zcbor_string value;
 
 	value.value = state->payload_end - remaining_str_len(state);
 	value.len = (size_t)payload - (size_t)value.value;
@@ -304,7 +304,7 @@ bool zcbor_bstr_end_encode(zcbor_state_t *state)
 
 
 static bool strx_encode(zcbor_state_t *state,
-		const zcbor_string_type_t *input, zcbor_major_type_t major_type)
+		const struct zcbor_string *input, zcbor_major_type_t major_type)
 {
 	if (!strx_start_encode(state, input, major_type)) {
 		ZCBOR_FAIL();
@@ -322,13 +322,13 @@ static bool strx_encode(zcbor_state_t *state,
 }
 
 
-bool zcbor_bstr_encode(zcbor_state_t *state, const zcbor_string_type_t *input)
+bool zcbor_bstr_encode(zcbor_state_t *state, const struct zcbor_string *input)
 {
 	return strx_encode(state, input, ZCBOR_MAJOR_TYPE_BSTR);
 }
 
 
-bool zcbor_tstr_encode(zcbor_state_t *state, const zcbor_string_type_t *input)
+bool zcbor_tstr_encode(zcbor_state_t *state, const struct zcbor_string *input)
 {
 	return strx_encode(state, input, ZCBOR_MAJOR_TYPE_TSTR);
 }

--- a/tests/decode/test5_strange/src/main.c
+++ b/tests/decode/test5_strange/src/main.c
@@ -278,7 +278,7 @@ void test_string_overflow(void)
 		0x5A, 0xFF, 0xFF, 0xF0, 0x00, /* overflows to before this string. */
 	};
 
-	zcbor_string_type_t result_overflow;
+	struct zcbor_string result_overflow;
 	size_t out_len;
 
 	zassert_false(cbor_decode_SingleBstr(payload_overflow, sizeof(payload_overflow), &result_overflow, &out_len), NULL);
@@ -1016,7 +1016,7 @@ void test_single(void)
 	uint8_t payload_single2_inv[] = {0x18, 53};
 	uint8_t payload_single3[] = {9};
 	uint8_t payload_single4_inv[] = {10};
-	zcbor_string_type_t result_bstr;
+	struct zcbor_string result_bstr;
 	uint_fast32_t result_int;
 	size_t out_len;
 

--- a/tests/encode/test1_suit/src/main.c
+++ b/tests/encode/test1_suit/src/main.c
@@ -228,15 +228,15 @@ uint32_t num_test_vectors = sizeof(test_vector)/sizeof(uint8_t*);
 
 static uint8_t output[2000];
 
-void test_command_sequence(zcbor_string_type_t *sequence_str,
+void test_command_sequence(struct zcbor_string *sequence_str,
 			bool present, char *name)
 {
 	struct SUIT_Command_Sequence sequence1;
-	zcbor_string_type_t *run_seq;
+	struct zcbor_string *run_seq;
 	bool run_seq_present;
-	zcbor_string_type_t *try_each1;
+	struct zcbor_string *try_each1;
 	bool try_each1_present;
-	zcbor_string_type_t *try_each2;
+	struct zcbor_string *try_each2;
 	bool try_each2_present;
 	size_t out_len;
 
@@ -315,25 +315,25 @@ void test_manifest(const uint8_t *input, uint32_t len)
 	struct SUIT_Outer_Wrapper outerwrapper1 = {0};
 	struct SUIT_Manifest *manifest;
 	// struct SUIT_Component_Identifier *component;
-	zcbor_string_type_t *dependency1;
+	struct zcbor_string *dependency1;
 	bool dependency1_present;
-	zcbor_string_type_t *fetch1;
+	struct zcbor_string *fetch1;
 	bool fetch1_present;
-	zcbor_string_type_t *install1;
+	struct zcbor_string *install1;
 	bool install1_present;
-	zcbor_string_type_t *common_seq;
+	struct zcbor_string *common_seq;
 	bool common_seq_present;
-	zcbor_string_type_t *dependency2;
+	struct zcbor_string *dependency2;
 	bool dependency2_present;
-	zcbor_string_type_t *fetch2;
+	struct zcbor_string *fetch2;
 	bool fetch2_present;
-	zcbor_string_type_t *install2;
+	struct zcbor_string *install2;
 	bool install2_present;
-	zcbor_string_type_t *validate;
+	struct zcbor_string *validate;
 	bool validate_present;
-	zcbor_string_type_t *load;
+	struct zcbor_string *load;
 	bool load_present;
-	zcbor_string_type_t *run;
+	struct zcbor_string *run;
 	bool run_present;
 	bool res;
 	size_t out_len;

--- a/tests/encode/test2_simple/src/main.c
+++ b/tests/encode/test2_simple/src/main.c
@@ -214,7 +214,7 @@ void test_pet_raw(void)
 	res = res && zcbor_list_end_encode(state, 0);
 	zassert_true(res, NULL);
 	uint8_t timestamp[8] = {1, 2, 3, 4, 5, 6, 7, 8};
-	zcbor_string_type_t timestamp_str = {
+	struct zcbor_string timestamp_str = {
 		.value = timestamp,
 		.len = sizeof(timestamp),
 	};

--- a/tests/encode/test3_strange/src/main.c
+++ b/tests/encode/test3_strange/src/main.c
@@ -904,7 +904,7 @@ void test_single(void)
 	uint8_t exp_payload_single2[] = {9};
 	uint8_t output[10];
 	size_t out_len;
-	zcbor_string_type_t input_single0 = {
+	struct zcbor_string input_single0 = {
 		.value = "hello",
 		.len = 5
 	};
@@ -960,7 +960,7 @@ void test_unabstracted(void)
 
 void test_string_overflow(void)
 {
-	zcbor_string_type_t input_overflow0 = {
+	struct zcbor_string input_overflow0 = {
 		.value = "",
 		.len = 0xFFFFFF00, /* overflows to before this object. */
 	};

--- a/tests/unit/test1_unit_tests/src/main.c
+++ b/tests/unit/test1_unit_tests/src/main.c
@@ -109,8 +109,8 @@ void test_size64(void)
 {
 	uint8_t *large_payload = malloc(PAYL_SIZE);
 	uint8_t *large_string = malloc(STR_SIZE);
-	zcbor_string_type_t tstr = {.value = large_string, .len = STR_SIZE};
-	zcbor_string_type_t tstr_res;
+	struct zcbor_string tstr = {.value = large_string, .len = STR_SIZE};
+	struct zcbor_string tstr_res;
 	zcbor_state_t state_d;
 	zcbor_state_t state_e;
 

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -1715,8 +1715,8 @@ class CodeGenerator(CddlXcoder):
             "UINT": lambda: f"uint{self.bit_size()}_t",
             "NINT": lambda: f"int{self.bit_size()}_t",
             "FLOAT": lambda: "float_t",
-            "BSTR": lambda: "zcbor_string_type_t",
-            "TSTR": lambda: "zcbor_string_type_t",
+            "BSTR": lambda: "struct zcbor_string",
+            "TSTR": lambda: "struct zcbor_string",
             "BOOL": lambda: "bool",
             "NIL": lambda: None,
             "ANY": lambda: None,
@@ -2382,7 +2382,7 @@ static bool {xcoder.func_name}(
             if struct_ptr_name(self.mode) in body else "void"} *{struct_ptr_name(self.mode)})
 {{
 	zcbor_print("%s\\r\\n", __func__);
-	{"zcbor_string_type_t tmp_str;" if "tmp_str" in body else ""}
+	{"struct zcbor_string tmp_str;" if "tmp_str" in body else ""}
 	{"bool int_res;" if "int_res" in body else ""}
 
 	bool tmp_result = ({ body });


### PR DESCRIPTION
 - Rename zcbor_string_type_t to struct zcbor_string.
 - Rename zcbor_state_backups_t to struct zcbor_state_constant.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>