### PR TITLE
Add/fix float support

### DIFF
--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -114,6 +114,11 @@ do {\
 
 
 #define ZCBOR_VALUE_IN_HEADER 23 ///! Values below this are encoded directly in the header.
+#define ZCBOR_VALUE_IS_1_BYTE 24 ///! The next 1 byte contains the value.
+#define ZCBOR_VALUE_IS_2_BYTES 25 ///! The next 2 bytes contain the value.
+#define ZCBOR_VALUE_IS_4_BYTES 26 ///! The next 4 bytes contain the value.
+#define ZCBOR_VALUE_IS_8_BYTES 27 ///! The next 8 bytes contain the value.
+
 #define ZCBOR_BOOL_TO_PRIM 20 ///! In CBOR, false/true have the values 20/21
 
 #define ZCBOR_FLAG_RESTORE 1UL ///! Restore from the backup. Overwrite the current state with the state from the backup.

--- a/include/zcbor_decode.h
+++ b/include/zcbor_decode.h
@@ -163,6 +163,10 @@ bool zcbor_bool_decode(zcbor_state_t *state, bool *result);
 bool zcbor_bool_expect(zcbor_state_t *state, bool result);
 
 /** Decode and consume a float */
+bool zcbor_float32_decode(zcbor_state_t *state, float *result);
+bool zcbor_float32_expect(zcbor_state_t *state, float result);
+bool zcbor_float64_decode(zcbor_state_t *state, double *result);
+bool zcbor_float64_expect(zcbor_state_t *state, double result);
 bool zcbor_float_decode(zcbor_state_t *state, double *result);
 bool zcbor_float_expect(zcbor_state_t *state, double result);
 

--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -90,8 +90,10 @@ bool zcbor_bool_put(zcbor_state_t *state, bool input);
 bool zcbor_bool_encode(zcbor_state_t *state, const bool *input);
 
 /** Encode a float */
-bool zcbor_float_put(zcbor_state_t *state, double input);
-bool zcbor_float_encode(zcbor_state_t *state, const double *input);
+bool zcbor_float32_put(zcbor_state_t *state, float input);
+bool zcbor_float32_encode(zcbor_state_t *state, const float *input);
+bool zcbor_float64_put(zcbor_state_t *state, double input);
+bool zcbor_float64_encode(zcbor_state_t *state, const double *input);
 
 /** Encode a "nil" primitive value. @p unused should be NULL.
  *

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -461,7 +461,7 @@ bool zcbor_bool_put(zcbor_state_t *state, bool input)
 }
 
 
-bool double_encode(zcbor_state_t *state, double *input)
+bool zcbor_float64_encode(zcbor_state_t *state, const double *input)
 {
 	if (!value_encode(state, ZCBOR_MAJOR_TYPE_PRIM, input,
 			sizeof(*input))) {
@@ -472,9 +472,26 @@ bool double_encode(zcbor_state_t *state, double *input)
 }
 
 
-bool double_put(zcbor_state_t *state, double input)
+bool zcbor_float64_put(zcbor_state_t *state, double input)
 {
-	return double_encode(state, &input);
+	return zcbor_float64_encode(state, &input);
+}
+
+
+bool zcbor_float32_encode(zcbor_state_t *state, const float *input)
+{
+	if (!value_encode(state, ZCBOR_MAJOR_TYPE_PRIM, input,
+			sizeof(*input))) {
+		ZCBOR_FAIL();
+	}
+
+	return true;
+}
+
+
+bool zcbor_float32_put(zcbor_state_t *state, float input)
+{
+	return zcbor_float32_encode(state, &input);
 }
 
 

--- a/tests/cases/strange.cddl
+++ b/tests/cases/strange.cddl
@@ -111,3 +111,11 @@ MyKeys = (
 DoubleMap = {
 	* (uint => { MyKeys })
 }
+
+Floats = [
+	float_32: float32,
+	float_64: float64,
+	pi: 3.1415,
+	e: 2.71828 .size 8,
+	floats: *float,
+]

--- a/tests/decode/test5_strange/CMakeLists.txt
+++ b/tests/decode/test5_strange/CMakeLists.txt
@@ -34,6 +34,7 @@ set(py_command
     Unabstracted
     QuantityRange
     DoubleMap
+    Floats
   --decode
   --git-sha-header
   ${bit_arg}

--- a/tests/decode/test5_strange/floats.py
+++ b/tests/decode/test5_strange/floats.py
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# This file was used to generate the floating point test cases.
+# It's kept here for posterity.
+
+import struct
+import numpy
+
+def print_var(val1, val2, bytestr):
+	var_str = ""
+	for b in bytestr:
+		var_str += hex(b)  + ", "
+	print(str(val1) + ":", val2, bytestr.hex(), var_str)
+
+def print_32_64(str_val, val = None):
+	val = val or float(str_val)
+	print_var(str_val, val, struct.pack("!e", numpy.float16(val)))
+	print_var(str_val, val, struct.pack("!f", val))
+	print_var(str_val, val, struct.pack("!d", val))
+	print_var(str_val, val, struct.pack("!d", struct.unpack("!f", struct.pack("!f", val))[0]))
+	print()
+
+print_32_64("3.1415")
+print_32_64("2.71828")
+print_32_64("1234567.89")
+print_32_64("-98765.4321")
+print_32_64("123/456789", 123/456789)
+print_32_64("-2^(-42)", -1/(2**(42)))
+

--- a/tests/decode/test5_strange/src/main.c
+++ b/tests/decode/test5_strange/src/main.c
@@ -1129,6 +1129,118 @@ void test_doublemap(void)
 					&result_doublemap, &out_len), NULL);
 }
 
+
+void test_floats(void)
+{
+
+	uint8_t floats_payload1[] = {LIST(6), 0xFA, 0x49, 0x96, 0xb4, 0x3f /* 1234567.89 */,
+			0xFB, 0xc0, 0xf8, 0x1c, 0xd6, 0xe9, 0xe1, 0xb0, 0x8a /* -98765.4321 */,
+			0xFA, 0x40, 0x49, 0xe, 0x56 /* 3.1415 */,
+			0xFB, 0x40, 0x5, 0xbf, 0x9, 0x95, 0xaa, 0xf7, 0x90 /* 2.71828 */,
+			0xFA, 0x39, 0x8d, 0x2c, 0xef /* 123/456789 */,
+			0xFB, 0xbd, 0x50, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 /* -2^(-42) */,
+			END
+	};
+
+	uint8_t floats_payload2[] = {LIST(4), 0xFA, 0xc7, 0xc0, 0xe6, 0xb7 /* -98765.4321 */,
+			0xFB, 0x41, 0x32, 0xd6, 0x87, 0xe3, 0xd7, 0xa, 0x3d /* 1234567.89 */,
+			0xFB, 0x40, 0x9, 0x21, 0xca, 0xc0, 0x83, 0x12, 0x6f /* 3.1415 */,
+			0xFB, 0x40, 0x5, 0xbf, 0x9, 0x95, 0xaa, 0xf7, 0x90 /* 2.71828 */,
+			END
+	};
+
+	uint8_t floats_payload3[] = {LIST(4), 0xFA, 0x49, 0x96, 0xb4, 0x3f /* 1234567.89 */,
+			0xFB, 0xc0, 0xf8, 0x1c, 0xd6, 0xe9, 0xe1, 0xb0, 0x8a /* -98765.4321 */,
+			0xFB, 0x40, 0x9, 0x21, 0xca, 0xc0, 0x83, 0x12, 0x6f /* 3.1415 */,
+			0xFB, 0x40, 0x5, 0xbf, 0x9, 0x95, 0xaa, 0xf7, 0x90 /* 2.71828 */,
+			END
+	};
+
+	uint8_t floats_payload4[] = {LIST(5), 0xFA, 0x49, 0x96, 0xb4, 0x3f /* 1234567.89 */,
+			0xFB, 0xc0, 0xf8, 0x1c, 0xd6, 0xe9, 0xe1, 0xb0, 0x8a /* -98765.4321 */,
+			0xFB, 0x40, 0x9, 0x21, 0xca, 0xc0, 0x83, 0x12, 0x6f /* 3.1415 */,
+			0xFB, 0x40, 0x5, 0xbf, 0x9, 0x95, 0xaa, 0xf7, 0x90 /* 2.71828 */,
+			0xFB, 0x3f, 0x31, 0xa5, 0x9d, 0xe0, 0x0, 0x0, 0x0 /* 123/456789 */,
+			END
+	};
+
+	uint8_t floats_payload5_inv[] = {LIST(5), 0xFA, 0x49, 0x96, 0xb4, 0x3f /* 1234567.89 */,
+			0xFB, 0xc0, 0xf8, 0x1c, 0xd6, 0xe9, 0xe1, 0xb0, 0x8a /* -98765.4321 */,
+			0xFB, 0x40, 0x9, 0x21, 0xca, 0xc0, 0x83, 0x12, 0x6f /* 3.1415 */,
+			0xFB, 0x40, 0x5, 0xbf, 0x9, 0x95, 0xaa, 0xf7, 0x90 /* 2.71828 */,
+			0xF9, 0xc, 0x69 /* 123/456789 UNSUPPORTED SIZE */,
+			END
+	};
+
+	uint8_t floats_payload6_inv[] = {LIST(4), 0xFB, 0x41, 0x32, 0xd6, 0x87, 0xe0, 0x0, 0x0, 0x0 /* 1234567.89 WRONG SIZE */,
+			0xFB, 0xc0, 0xf8, 0x1c, 0xd6, 0xe9, 0xe1, 0xb0, 0x8a /* -98765.4321 */,
+			0xFB, 0x40, 0x9, 0x21, 0xca, 0xc0, 0x83, 0x12, 0x6f /* 3.1415 */,
+			0xFB, 0x40, 0x5, 0xbf, 0x9, 0x95, 0xaa, 0xf7, 0x90 /* 2.71828 */,
+			END
+	};
+
+	uint8_t floats_payload7_inv[] = {LIST(4), 0xFA, 0x49, 0x96, 0xb4, 0x3f /* 1234567.89 */,
+			0xFA, 0xc7, 0xc0, 0xe6, 0xb7 /* -98765.4321 WRONG SIZE */,
+			0xFA, 0x40, 0x49, 0xe, 0x56 /* 3.1415 */,
+			0xFB, 0x40, 0x5, 0xbf, 0x9, 0x95, 0xaa, 0xf7, 0x90 /* 2.71828 */,
+			END
+	};
+
+	uint8_t floats_payload8_inv[] = {LIST(4), 0xFA, 0x49, 0x96, 0xb4, 0x3f /* 1234567.89 */,
+			0xFB, 0xc0, 0xf8, 0x1c, 0xd6, 0xe9, 0xe1, 0xb0, 0x8a /* -98765.4321 */,
+			0xFA, 0x40, 0x49, 0xe, 0x56 /* 3.1415 */,
+			0x40, 0x2d, 0xf8, 0x4d /* 2.71828 WRONG SIZE */,
+			END
+	};
+
+	size_t num_decode;
+	struct Floats result;
+
+	zassert_true(cbor_decode_Floats(
+		floats_payload1, sizeof(floats_payload1), &result, &num_decode), NULL);
+	zassert_equal(sizeof(floats_payload1), num_decode, NULL);
+	zassert_equal((float)1234567.89, result._Floats_float_32, NULL);
+	zassert_equal((double)-98765.4321, result._Floats_float_64, NULL);
+	zassert_equal(2, result._Floats_floats_count, NULL);
+	zassert_equal((float)(123.0/456789.0), result._Floats_floats[0], NULL);
+	zassert_equal((double)(-1.0/(1LL << 42)), result._Floats_floats[1], NULL);
+
+	zassert_true(cbor_decode_Floats(
+		floats_payload2, sizeof(floats_payload2), &result, &num_decode), NULL);
+	zassert_equal(sizeof(floats_payload2), num_decode, NULL);
+	zassert_equal((float)-98765.4321, result._Floats_float_32, NULL);
+	zassert_equal((double)1234567.89, result._Floats_float_64, NULL);
+	zassert_equal(0, result._Floats_floats_count, NULL);
+
+	zassert_true(cbor_decode_Floats(
+		floats_payload3, sizeof(floats_payload3), &result, &num_decode), NULL);
+	zassert_equal(sizeof(floats_payload3), num_decode, NULL);
+	zassert_equal((float)1234567.89, result._Floats_float_32, NULL);
+	zassert_equal((double)-98765.4321, result._Floats_float_64, NULL);
+	zassert_equal(0, result._Floats_floats_count, NULL);
+
+	zassert_true(cbor_decode_Floats(
+		floats_payload4, sizeof(floats_payload4), &result, &num_decode), NULL);
+	zassert_equal(sizeof(floats_payload4), num_decode, NULL);
+	zassert_equal((float)1234567.89, result._Floats_float_32, NULL);
+	zassert_equal((double)-98765.4321, result._Floats_float_64, NULL);
+	zassert_equal(1, result._Floats_floats_count, NULL);
+	zassert_false((double)(123.0/456789.0) == result._Floats_floats[0], NULL);
+	zassert_equal((float)(123.0/456789.0), result._Floats_floats[0], NULL);
+
+	zassert_false(cbor_decode_Floats(
+		floats_payload5_inv, sizeof(floats_payload5_inv), &result, &num_decode), NULL);
+
+	zassert_false(cbor_decode_Floats(
+		floats_payload6_inv, sizeof(floats_payload6_inv), &result, &num_decode), NULL);
+
+	zassert_false(cbor_decode_Floats(
+		floats_payload7_inv, sizeof(floats_payload7_inv), &result, &num_decode), NULL);
+
+	zassert_false(cbor_decode_Floats(
+		floats_payload8_inv, sizeof(floats_payload8_inv), &result, &num_decode), NULL);
+}
+
 void test_main(void)
 {
 	ztest_test_suite(cbor_decode_test5,
@@ -1149,7 +1261,8 @@ void test_main(void)
 			 ztest_unit_test(test_unabstracted),
 			 ztest_unit_test(test_quantity_range),
 			 ztest_unit_test(test_unabstracted),
-			 ztest_unit_test(test_doublemap)
+			 ztest_unit_test(test_doublemap),
+			 ztest_unit_test(test_floats)
 	);
 	ztest_run_test_suite(cbor_decode_test5);
 }

--- a/tests/encode/test3_strange/CMakeLists.txt
+++ b/tests/encode/test3_strange/CMakeLists.txt
@@ -32,6 +32,7 @@ set(py_command
   Unabstracted
   QuantityRange
   DoubleMap
+  Floats
   -e
   ${bit_arg}
   )

--- a/tests/encode/test3_strange/src/main.c
+++ b/tests/encode/test3_strange/src/main.c
@@ -1043,6 +1043,65 @@ void test_doublemap(void)
 	zassert_mem_equal(exp_payload_doublemap0, output, out_len, NULL);
 }
 
+void test_floats(void)
+{
+	uint8_t exp_floats_payload2[] = {LIST(4), 0xFA, 0xc7, 0xc0, 0xe6, 0xb7 /* -98765.4321 */,
+			0xFB, 0x41, 0x32, 0xd6, 0x87, 0xe3, 0xd7, 0xa, 0x3d /* 1234567.89 */,
+			0xFB, 0x40, 0x9, 0x21, 0xca, 0xc0, 0x83, 0x12, 0x6f /* 3.1415 */,
+			0xFB, 0x40, 0x5, 0xbf, 0x9, 0x95, 0xaa, 0xf7, 0x90 /* 2.71828 */,
+			END
+	};
+
+	uint8_t exp_floats_payload3[] = {LIST(4), 0xFA, 0x49, 0x96, 0xb4, 0x3f /* 1234567.89 */,
+			0xFB, 0xc0, 0xf8, 0x1c, 0xd6, 0xe9, 0xe1, 0xb0, 0x8a /* -98765.4321 */,
+			0xFB, 0x40, 0x9, 0x21, 0xca, 0xc0, 0x83, 0x12, 0x6f /* 3.1415 */,
+			0xFB, 0x40, 0x5, 0xbf, 0x9, 0x95, 0xaa, 0xf7, 0x90 /* 2.71828 */,
+			END
+	};
+
+	uint8_t exp_floats_payload4[] = {LIST(7), 0xFA, 0x49, 0x96, 0xb4, 0x3f /* 1234567.89 */,
+			0xFB, 0xc0, 0xf8, 0x1c, 0xd6, 0xe9, 0xe1, 0xb0, 0x8a /* -98765.4321 */,
+			0xFB, 0x40, 0x9, 0x21, 0xca, 0xc0, 0x83, 0x12, 0x6f /* 3.1415 */,
+			0xFB, 0x40, 0x5, 0xbf, 0x9, 0x95, 0xaa, 0xf7, 0x90 /* 2.71828 */,
+			0xFB, 0x3f, 0x31, 0xa5, 0x9d, 0xe0, 0x0, 0x0, 0x0 /* 123/456789 */,
+			0xFB, 0x3f, 0x31, 0xa5, 0x9d, 0xd9, 0x57, 0x14, 0x64 /* 123/456789 */,
+			0xFB, 0xbd, 0x50, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 /* -2^(-42) */,
+			END
+	};
+
+	struct Floats input;
+	size_t num_encode;
+	uint8_t output[70];
+
+	input._Floats_float_32 = (float)-98765.4321;
+	input._Floats_float_64 = (double)1234567.89;
+	input._Floats_floats_count = 0;
+	zassert_true(cbor_encode_Floats(
+		output, sizeof(output), &input, &num_encode), NULL);
+	zassert_equal(sizeof(exp_floats_payload2), num_encode, NULL);
+	zassert_mem_equal(exp_floats_payload2, output, num_encode, NULL);
+
+	input._Floats_float_32 = (float)1234567.89;
+	input._Floats_float_64 = (double)-98765.4321;
+	input._Floats_floats_count = 0;
+	zassert_true(cbor_encode_Floats(
+		output, sizeof(output), &input, &num_encode), NULL);
+	zassert_equal(sizeof(exp_floats_payload3), num_encode, NULL);
+	zassert_mem_equal(exp_floats_payload3, output, num_encode, NULL);
+
+	input._Floats_float_32 = (float)1234567.89;
+	input._Floats_float_64 = (double)-98765.4321;
+	input._Floats_floats_count = 3;
+	input._Floats_floats[0] = (float)(123.0/456789.0);
+	input._Floats_floats[1] = (double)(123.0/456789.0);
+	input._Floats_floats[2] = (double)(-1.0/(1LL << 42));
+	zassert_true(cbor_encode_Floats(
+		output, sizeof(output), &input, &num_encode), NULL);
+	zassert_equal(sizeof(exp_floats_payload4), num_encode, NULL);
+	zassert_mem_equal(exp_floats_payload4, output, num_encode, NULL);
+
+}
+
 void test_main(void)
 {
 	ztest_test_suite(cbor_encode_test3,
@@ -1062,7 +1121,8 @@ void test_main(void)
 			 ztest_unit_test(test_string_overflow),
 			 ztest_unit_test(test_quantity_range),
 			 ztest_unit_test(test_unabstracted),
-			 ztest_unit_test(test_doublemap)
+			 ztest_unit_test(test_doublemap),
+			 ztest_unit_test(test_floats)
 	);
 	ztest_run_test_suite(cbor_encode_test3);
 }

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -541,7 +541,7 @@ class CddlParser:
                 self.max_value = int(value - 1)
             if self.type in ["INT", "NINT"]:
                 self.min_value = int(-1 * (value >> 1) + 1)
-        elif self.type in ["BSTR", "TSTR"]:
+        elif self.type in ["BSTR", "TSTR", "FLOAT"]:
             self.set_size_range(size, size)
         else:
             raise TypeError(".size cannot be applied to %s" % self.type)
@@ -702,13 +702,13 @@ class CddlParser:
             (r'float(?!\w)',
              lambda _: self.type_and_value("FLOAT", lambda: None)),
             (r'float16(?!\w)',
-             lambda _: self.type_value_size("FLOAT", None, 2)),
+             lambda _: self.type_value_size("FLOAT", lambda: None, 2)),
             (r'float32(?!\w)',
-             lambda _: self.type_value_size("FLOAT", None, 4)),
+             lambda _: self.type_value_size("FLOAT", lambda: None, 4)),
             (r'float64(?!\w)',
-             lambda _: self.type_value_size("FLOAT", None, 8)),
+             lambda _: self.type_value_size("FLOAT", lambda: None, 8)),
             (r'\-?\d*\.\d+',
-             lambda num: self.type_and_value("FLOAT", lambda: int(num))),
+             lambda num: self.type_and_value("FLOAT", lambda: float(num))),
             (match_uint + r'\.\.' + match_uint,
              lambda _range: self.type_and_range(
                  "UINT", *map(lambda num: int(num, 0), _range.split("..")))),
@@ -1703,6 +1703,19 @@ class CodeGenerator(CddlXcoder):
                             bit_size = 64
         return bit_size
 
+    def float_type(self):
+        if self.type != "FLOAT":
+            return None
+
+        max_size = self.max_size or 8
+
+        if max_size == 4:
+            return "float"
+        elif max_size == 8:
+            return "double"
+        else:
+            raise TypeError("Floats must have 4 or 8 bytes of precision.")
+
     # Name of the type of this element's actual value variable.
     def val_type_name(self):
         if self.multi_val_condition():
@@ -1714,7 +1727,7 @@ class CodeGenerator(CddlXcoder):
             "INT": lambda: f"int{self.bit_size()}_t",
             "UINT": lambda: f"uint{self.bit_size()}_t",
             "NINT": lambda: f"int{self.bit_size()}_t",
-            "FLOAT": lambda: "float_t",
+            "FLOAT": lambda: self.float_type(),
             "BSTR": lambda: "struct zcbor_string",
             "TSTR": lambda: "struct zcbor_string",
             "BOOL": lambda: "bool",
@@ -1892,6 +1905,22 @@ class CodeGenerator(CddlXcoder):
         tdef = self.anonymous_choice_var()
         return [(tdef, self.enum_type_name())]
 
+    def float_prefix(self):
+        if self.type != "FLOAT":
+            return ""
+
+        min_size = self.min_size or 4
+        max_size = self.max_size or 8
+
+        if max_size == 4:
+            return "float32"
+        elif min_size == 8 and max_size == 8:
+            return "float64"
+        elif min_size <= 4 and max_size == 8:
+            return "float" if self.mode == "decode" else "float64"
+        else:
+            raise TypeError("Floats must have 4 or 8 bytes of precision.")
+
     def single_func_prim_prefix(self):
         if self.type == "OTHER":
             return self.my_types[self.value].single_func_prim_prefix()
@@ -1899,7 +1928,7 @@ class CodeGenerator(CddlXcoder):
             "INT": f"zcbor_int{self.bit_size()}",
             "UINT": f"zcbor_uint{self.bit_size()}",
             "NINT": f"zcbor_int{self.bit_size()}",
-            "FLOAT": f"zcbor_float",
+            "FLOAT": f"zcbor_{self.float_prefix()}",
             "BSTR": f"zcbor_bstr",
             "TSTR": f"zcbor_tstr",
             "BOOL": f"zcbor_bool",


### PR DESCRIPTION
Add support for 32 bit and 64 bit floats.
16 bit floats are not supported in C so they are not supported here.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

Fixes #134 