### PR TITLE
tests: encode: Add test4_senml to test a regression in code generation

### DIFF
--- a/tests/cases/senml.cddl
+++ b/tests/cases/senml.cddl
@@ -1,0 +1,33 @@
+lwm2m_senml = [1* record]
+
+record = {
+	? bn => tstr,        ; Base Name
+	? bt => numeric,     ; Base Time
+	? n => tstr,        ; Name
+	? t => numeric,     ; Time
+	? ( v => numeric // ; Numeric Value
+		vs => tstr //   ; String Value
+		vb => bool //   ; Boolean Value
+		vd => bstr ), ; Data Value
+	* key-value-pair
+}
+
+; now define the generic versions
+key-value-pair = ( label => value )
+
+label = non-b-label / b-label
+non-b-label = tstr / uint
+b-label = tstr / nint
+
+value = tstr / bstr / numeric / bool
+
+; numeric = number / decfrac
+numeric = int
+
+
+bver = -1  n  = 0   s  = 5
+bn  = -2   u  = 1   t  = 6
+bt  = -3   v  = 2   ut = 7
+bu  = -4   vs = 3   vd = 8
+bv  = -5   vb = 4
+bs  = -6

--- a/tests/encode/test4_senml/CMakeLists.txt
+++ b/tests/encode/test4_senml/CMakeLists.txt
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+
+include(../../cmake/test_template.cmake)
+
+set(py_command
+  zcbor
+  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/senml.cddl
+  code
+  --output-cmake ${PROJECT_BINARY_DIR}/senml.cmake
+  -t lwm2m_senml
+  -e
+  ${bit_arg}
+  )
+
+execute_process(
+  COMMAND ${py_command}
+  COMMAND_ERROR_IS_FATAL ANY
+  )
+
+include(${PROJECT_BINARY_DIR}/senml.cmake)
+
+target_link_libraries(senml PRIVATE zephyr_interface)
+target_link_libraries(app PRIVATE senml)
+

--- a/tests/encode/test4_senml/prj.conf
+++ b/tests/encode/test4_senml/prj.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_ZTEST=y

--- a/tests/encode/test4_senml/src/main.c
+++ b/tests/encode/test4_senml/src/main.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include "senml_encode.h"
+#include "zcbor_debug.h" // Enables use of print functions when debugging tests.
+
+
+
+#define CONCAT_BYTE(a,b) a ## b
+
+/* LIST() adds a start byte for a list with 'num' elements.
+ * MAP() does the same, but for a map.
+ * END adds an end byte for the list/map.
+ *
+ * With ZCBOR_CANONICAL, the start byte contains the list, so no end byte is
+ * needed. Without ZCBOR_CANONICAL, the start byte is the same no matter
+ * the number of elements, so it needs an explicit end byte.
+ */
+#ifndef ZCBOR_CANONICAL
+#define LIST(num) 0x9F
+#define MAP(num) 0xBF
+#define END 0xFF,
+#else
+#define LIST(num) CONCAT_BYTE(0x8, num)
+#define MAP(num) CONCAT_BYTE(0xA, num)
+#define END
+#endif
+
+void test_senml(void)
+{
+	struct lwm2m_senml input = {
+		._lwm2m_senml__record[0] = {
+			._record_bn = {._record_bn = {.value = "Foo", .len = 3}},
+			._record_bn_present = 1,
+			._record_bt = {._record_bt = 42},
+			._record_bt_present = 1,
+			._record_n = {._record_n = {.value = "Bar", .len = 3}},
+			._record_n_present = 1,
+			._record_t = {._record_t = 7},
+			._record_t_present = 1,
+			._record_union = {
+				._union_vb = true,
+				._record_union_choice = _union_vb,
+			},
+			._record_union_present = 1,
+			._record__key_value_pair_count = 0,
+		},
+		._lwm2m_senml__record_count = 1,
+	};
+	uint8_t payload[100];
+	size_t encode_len;
+	uint8_t exp_payload1[] = {
+		LIST(1), MAP(5), 0x21, 0x63, 'F', 'o', 'o', 0x22, 0x18, 42,
+		0x00, 0x63, 'B', 'a', 'r', 0x06, 0x07, 0x04, 0xF5, END END
+	};
+
+	zassert_true(cbor_encode_lwm2m_senml(payload, sizeof(payload), &input, &encode_len), NULL);
+	zassert_equal(sizeof(exp_payload1), encode_len, NULL);
+	zassert_mem_equal(payload, exp_payload1, encode_len, NULL);
+}
+
+void test_main(void)
+{
+	ztest_test_suite(cbor_encode_test4,
+			 ztest_unit_test(test_senml)
+	);
+	ztest_run_test_suite(cbor_encode_test4);
+}

--- a/tests/encode/test4_senml/testcase.yaml
+++ b/tests/encode/test4_senml/testcase.yaml
@@ -1,0 +1,8 @@
+tests:
+  zcbor.encode.test4_senml:
+    platform_allow: native_posix native_posix_64
+    tags: zcbor encode
+  zcbor.encode.test4_senml.canonical:
+    platform_allow: native_posix native_posix_64
+    tags: zcbor encode canonical
+    extra_args: CANONICAL=CANONICAL


### PR DESCRIPTION
zcbor\_\*\_encode() was used instead of zcbor\_\*\_put().
The bug was fixed earlier.

fixes #163 