### PR TITLE
zcbor_common.h: Add enum with some tag values

### DIFF
--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -126,6 +126,25 @@ do {\
 #define ZCBOR_FLAG_CONSUME 2UL ///! Consume the backup. Remove the backup from the stack of backups.
 #define ZCBOR_FLAG_TRANSFER_PAYLOAD 4UL ///! Keep the pre-restore payload after restoring.
 
+/** Values defined by RFC8949 via www.iana.org/assignments/cbor-tags/cbor-tags.xhtml */
+enum zcbor_rfc8949_tag {
+	ZCBOR_TAG_TIME_TSTR =       0, ///! text string       Standard date/time string
+	ZCBOR_TAG_TIME_NUM =        1, ///! integer or float  Epoch-based date/time
+	ZCBOR_TAG_UBIGNUM_BSTR =    2, ///! byte string       Unsigned bignum
+	ZCBOR_TAG_BIGNUM_BSTR =     3, ///! byte string       Negative bignum
+	ZCBOR_TAG_DECFRAC_ARR =     4, ///! array             Decimal fraction
+	ZCBOR_TAG_BIGFLOAT_ARR =    5, ///! array             Bigfloat
+	ZCBOR_TAG_2BASE64URL =     21, ///! (any)             Expected conversion to base64url encoding
+	ZCBOR_TAG_2BASE64 =        22, ///! (any)             Expected conversion to base64 encoding
+	ZCBOR_TAG_2BASE16 =        23, ///! (any)             Expected conversion to base16 encoding
+	ZCBOR_TAG_BSTR =           24, ///! byte string       Encoded CBOR data item
+	ZCBOR_TAG_URI_TSTR =       32, ///! text string       URI
+	ZCBOR_TAG_BASE64URL_TSTR = 33, ///! text string       base64url
+	ZCBOR_TAG_BASE64_TSTR =    34, ///! text string       base64
+	ZCBOR_TAG_MIME_TSTR =      36, ///! text string       MIME message
+	ZCBOR_TAG_CBOR =        55799, ///! (any)             Self-described CBOR
+};
+
 /** Take a backup of the current state. Overwrite the current elem_count. */
 bool zcbor_new_backup(zcbor_state_t *state, uint_fast32_t new_elem_count);
 


### PR DESCRIPTION
The tag values defined by the newest CBOR spec (RFC 8949).

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>