### PR TITLE
Indefinite length arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,13 +227,13 @@ Major types `pint`, `nint`, `tag`, and `prim` elements have no payload, only _Va
     * 25: Interpret the _Value_ as an IEEE 754 float16.
     * 26: Interpret the _Value_ as an IEEE 754 float32.
     * 27: Interpret the _Value_ as an IEEE 754 float64.
-    * 31: End of an indeterminate-length `list` or `map`.
+    * 31: End of an indefinite-length `list` or `map`.
 
 For `bstr`, `tstr`, `list`, and `map`, the _Value_ describes the length of the _Payload_.
 For `bstr` and `tstr`, the length is in bytes, for `list`, the length is in number of elements, and for `map`, the length is in number of key/value element pairs.
 
 For `list` and `map`, sub elements are regular CBOR elements with their own _Header_, _Value_ and _Payload_. `list`s and `map`s can be recursively encoded.
-If a `list` or `map` has _Additional info_ 31, it is "indeterminate-length", which means it has an "unknown" number of elements.
+If a `list` or `map` has _Additional info_ 31, it is "indefinite-length", which means it has an "unknown" number of elements.
 Instead, its end is marked by a `prim` with _Additional info_ 31 (byte value 0xFF).
 
 Usage Example

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -95,7 +95,7 @@ Any new bugs, requests, or missing features should be reported as [Github issues
 
 ### C Libraries
  * Refactor cbor_common.c
- * Add support for indeterminate length arrays in cbor_decode.c.
+ * Add support for indefinite length arrays in cbor_decode.c.
 
 ### Tests
  * Move all cddl files into tests/cases

--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -69,6 +69,9 @@ union {
 	uint8_t const *payload_end; /**< The end of the payload. This will be
 	                                 checked against payload before
 	                                 processing each element. */
+	bool indefinite_length_array; /**< Is set to true if the decoder is currently
+	                                   decoding the contents of an indefinite-
+	                                   length array. */
 	struct zcbor_state_constant *constant_state; /**< The part of the state that is
 	                                                  not backed up and duplicated. */
 } zcbor_state_t;

--- a/src/zcbor_common.c
+++ b/src/zcbor_common.c
@@ -106,6 +106,7 @@ void zcbor_new_state(zcbor_state_t *state_array, uint_fast32_t n_states,
 	state_array[0].payload = payload;
 	state_array[0].payload_end = payload + payload_len;
 	state_array[0].elem_count = elem_count;
+	state_array[0].indefinite_length_array = false;
 	state_array[0].constant_state = NULL;
 	if (n_states > 2) {
 		/* Use the last state as a struct zcbor_state_constant object. */

--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -34,17 +34,17 @@ static uint_fast32_t additional_len(uint8_t additional)
 #define ADDITIONAL(header_byte) ((header_byte) & 0x1F)
 
 /** The value where the INDET_LEN bit (bit 31) is set, and elem_count is 0.
- *  This represents the minimum value elem_count can have for indeterminate
+ *  This represents the minimum value elem_count can have for indefinite
  *  length arrays. It also functions as a mask for the INDET_LEN bit.
  */
 #define MIN_INDET_LEN_ELEM_COUNT 0x80000000
 
-/** Check the most significant bit to see if we are processing an indeterminate
+/** Check the most significant bit to see if we are processing an indefinite
  *  length array.
  */
 #define INDET_LEN(elem_count) (elem_count >= MIN_INDET_LEN_ELEM_COUNT)
 
-/** Initial value for elem_count for indeterminate length arrays. */
+/** Initial value for elem_count for indefinite length arrays. */
 #define INDET_LEN_ELEM_COUNT 0xFFFFFFF0
 
 
@@ -405,7 +405,7 @@ static bool list_map_start_decode(zcbor_state_t *state,
 	}
 
 	if (ADDITIONAL(*state->payload) == 0x1F) {
-		/* Indeterminate length array. */
+		/* Indefinite length array. */
 		new_elem_count = INDET_LEN_ELEM_COUNT;
 		FAIL_IF(state->elem_count == 0);
 		state->payload++;

--- a/tests/decode/test5_corner_cases/CMakeLists.txt
+++ b/tests/decode/test5_corner_cases/CMakeLists.txt
@@ -58,8 +58,8 @@ target_include_directories(strange PUBLIC ${PROJECT_BINARY_DIR}/include)
 target_link_libraries(strange PRIVATE zephyr_interface)
 target_link_libraries(app PRIVATE strange)
 
-if (TEST_INDETERMINATE_LENGTH_ARRAYS)
-  target_compile_definitions(app PUBLIC TEST_INDETERMINATE_LENGTH_ARRAYS)
+if (TEST_INDEFINITE_LENGTH_ARRAYS)
+  target_compile_definitions(app PUBLIC TEST_INDEFINITE_LENGTH_ARRAYS)
 endif()
 
 if (NOT VERBOSE)

--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -10,7 +10,7 @@
 
 #define CONCAT_BYTE(a,b) a ## b
 
-#ifdef TEST_INDETERMINATE_LENGTH_ARRAYS
+#ifdef TEST_INDEFINITE_LENGTH_ARRAYS
 #define LIST(num) 0x9F /* Use short count 31 (indefinite-length). Note that the 'num' argument is ignored */
 #define LIST2(num) 0x9F /* Use short count 31 (indefinite-length). Note that the 'num' argument is ignored */
 #define LIST3(num) 0x9F /* Use short count 31 (indefinite-length). Note that the 'num' argument is ignored */
@@ -553,7 +553,7 @@ void test_map(void)
 		END
 	};
 
-	/* Wrong list length. Will not fail for indeterminate length arrays. */
+	/* Wrong list length. Will not fail for indefinite length arrays. */
 	const uint8_t payload_map4_inv[] = {
 		MAP(6), LIST(2), 0x05, 0x06, END 0xF4, // [5,6] => false
 		0x07, 0x01, // 7 => 1
@@ -598,7 +598,7 @@ void test_map(void)
 	zassert_equal(0, map._Map_twotothree[1]._Map_twotothree.len, NULL);
 	zassert_equal(0, map._Map_twotothree[2]._Map_twotothree.len, NULL);
 
-#ifdef TEST_INDETERMINATE_LENGTH_ARRAYS
+#ifdef TEST_INDEFINITE_LENGTH_ARRAYS
 	zassert_true(
 #else
 	zassert_false(
@@ -640,7 +640,7 @@ void test_empty_map(void)
 	zcbor_new_state(&state, 1, payload4, sizeof(payload4), 3);
 
 	zassert_true(cbor_decode_EmptyMap(payload1, sizeof(payload1), NULL, NULL), NULL);
-#ifdef TEST_INDETERMINATE_LENGTH_ARRAYS
+#ifdef TEST_INDEFINITE_LENGTH_ARRAYS
 	zassert_true(cbor_decode_EmptyMap(payload2_inv, sizeof(payload2_inv), NULL, NULL), NULL);
 #else
 	zassert_false(cbor_decode_EmptyMap(payload2_inv, sizeof(payload2_inv), NULL, NULL), NULL);

--- a/tests/decode/test5_corner_cases/testcase.yaml
+++ b/tests/decode/test5_corner_cases/testcase.yaml
@@ -2,7 +2,7 @@ tests:
   zcbor.decode.test5_corner_cases:
     platform_allow: native_posix native_posix_64
     tags: zcbor decode
-  zcbor.decode.test5_corner_cases.indeterminate_length_arrays:
+  zcbor.decode.test5_corner_cases.indefinite_length_arrays:
     platform_allow: native_posix native_posix_64
     tags: zcbor decode
-    extra_args: TEST_INDETERMINATE_LENGTH_ARRAYS=1
+    extra_args: TEST_INDEFINITE_LENGTH_ARRAYS=1


### PR DESCRIPTION
Rename "Indeterminate length"  to "indefinite length" to match wording in the CBOR RFC.

Also refactor how the indefinite length state is kept.