### PR TITLE
zcbor.py: Fix args.error() call

### DIFF
--- a/tests/scripts/run_tests.py
+++ b/tests/scripts/run_tests.py
@@ -532,6 +532,14 @@ class TestCLI(TestCase):
         self.assertEqual(0, call1.returncode)
         self.assertEqual(dumps({"test": bytes.fromhex("1234abcd"), "test2": cbor2.CBORTag(1234, bytes.fromhex("1a2b3c4d")), ("test3",): dumps(1234)}), stdout1)
 
+    def test_decode_encode(self):
+        args = ["zcbor", "--cddl", str(p_map_bstr_cddl), "code", "-d", "-e", "-t", "map"]
+        call1 = Popen(args, stdout=PIPE, stderr=PIPE)
+
+        _, stderr1 = call1.communicate()
+        self.assertNotEqual(0, call1.returncode)
+        self.assertIn(b"error: Please specify exactly one of --decode or --encode", stderr1)
+
 
 class TestOptional(TestCase):
     def test_0(self):

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -2756,14 +2756,14 @@ If omitted, the format is inferred from the file name.
     if not args.no_prelude:
         args.cddl.append(open(PRELUDE_path, 'r'))
 
+    if hasattr(args, "decode") and (args.decode == args.encode):
+        parser.error("Please specify exactly one of --decode or --encode.")
+
     return args
 
 
 def process_code(args):
     mode = "decode" if args.decode else "encode"
-
-    if args.decode == args.encode:
-        args.error("Please specify exactly one of --decode or --encode.")
 
     print("Parsing files: " + ", ".join((c.name for c in args.cddl)))
 


### PR DESCRIPTION
Needs to be parser.error() instead
Add test for the error print.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>