### PR TITLE
New error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ ZCBOR_STATE_E(encode_state, n, payload, payload_len, 0);
 
 The CBOR libraries assume little-endianness by default, but you can define ZCBOR_BIG_ENDIAN to change this.
 
+Configuration
+-------------
+
+The C library has a few compile-time configuration options.
+These configuration options can be enabled by adding them as compile definitions to the build.
+
+Name                      | Description
+------------------------- | -----------
+`ZCBOR_CANONICAL`         | When encoding lists and maps, do not use indefinite length encoding. Enabling `ZCBOR_CANONICAL` increases code size and makes the encoding library more often use state backups.
+`ZCBOR_VERBOSE`           | Print messages on encoding/decoding errors (`zcbor_print()`), and also a trace message (`zcbor_trace()`) for each decoded value, and in each generated function (when using code generation). Requires `printk` as found in Zephyr.
+`ZCBOR_ASSERTS`           | Enable asserts (`zcbor_assert()`). When they fail, the assert statements instruct the current function to return a `ZCBOR_ERR_ASSERTION` error. If `ZCBOR_VERBOSE` is enabled, a message is printed.
+`ZCBOR_STOP_ON_ERROR`     | Enable the `stop_on_error` functionality. This makes all functions abort their execution if called when an error has already happened.
+`ZCBOR_BIG_ENDIAN`        | All decoded values are returned as big-endian.
+
 Schema-driven data manipulation and code generation
 ===================================================
 

--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -139,6 +139,18 @@ do {\
 #define ZCBOR_FLAG_CONSUME 2UL ///! Consume the backup. Remove the backup from the stack of backups.
 #define ZCBOR_FLAG_TRANSFER_PAYLOAD 4UL ///! Keep the pre-restore payload after restoring.
 
+
+/** The largest possible elem_count. */
+#ifdef UINT_FAST32_MAX
+#define ZCBOR_MAX_ELEM_COUNT UINT_FAST32_MAX
+#else
+#define ZCBOR_MAX_ELEM_COUNT ((uint_fast32_t)(-1L))
+#endif
+
+/** Initial value for elem_count for when it just needs to be large. */
+#define ZCBOR_LARGE_ELEM_COUNT (ZCBOR_MAX_ELEM_COUNT - 16)
+
+
 /** Values defined by RFC8949 via www.iana.org/assignments/cbor-tags/cbor-tags.xhtml */
 enum zcbor_rfc8949_tag {
 	ZCBOR_TAG_TIME_TSTR =       0, ///! text string       Standard date/time string

--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -202,12 +202,14 @@ bool zcbor_union_end_code(zcbor_state_t *state);
 /** Initialize a state with backups.
  *  One of the states in the array is used as a struct zcbor_state_constant object.
  *  This means that you get a state with (n_states - 2) backups.
- *  It also means that (n_states = 2) is an invalid input, which is handled as
- *  if (n_states = 1).
+ *  The constant state is mandatory so n_states must be at least 2.
  *  payload, payload_len, and elem_count are used to initialize the first state.
  *  in the array, which is the state that can be passed to cbor functions.
+ *
+ *  @retval false  if n_states < 2
+ *  @retval true   otherwise
  */
-void zcbor_new_state(zcbor_state_t *state_array, uint_fast32_t n_states,
+bool zcbor_new_state(zcbor_state_t *state_array, uint_fast32_t n_states,
 		const uint8_t *payload, size_t payload_len, uint_fast32_t elem_count);
 
 #endif /* ZCBOR_COMMON_H__ */

--- a/include/zcbor_decode.h
+++ b/include/zcbor_decode.h
@@ -164,11 +164,15 @@ bool zcbor_map_start_decode(zcbor_state_t *state);
  * Check that the list/map had the correct number of elements, and restore the
  * previous element count from the backup.
  *
+ * Use @ref zcbor_list_map_end_force_decode to forcibly consume the backup if
+ * something has gone wrong.
+ *
  * @retval true   Everything ok.
  * @retval false  Element count not correct.
  */
 bool zcbor_list_end_decode(zcbor_state_t *state);
 bool zcbor_map_end_decode(zcbor_state_t *state);
+bool zcbor_list_map_end_force_decode(zcbor_state_t *state);
 
 /** Decode 0 or more elements with the same type and constraints.
  *

--- a/include/zcbor_decode.h
+++ b/include/zcbor_decode.h
@@ -246,13 +246,17 @@ bool zcbor_present_decode(uint_fast32_t *present,
 		void *result);
 
 /** See @ref zcbor_new_state() */
-void zcbor_new_decode_state(zcbor_state_t *state_array, uint32_t n_states,
-		const uint8_t *payload, uint32_t payload_len, uint32_t elem_count);
+bool zcbor_new_decode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
+		const uint8_t *payload, size_t payload_len, uint_fast32_t elem_count);
 
 /** Convenience macro for declaring and initializing a state with backups.
  *
  *  This gives you a state variable named @p name. The variable functions like
  *  a pointer.
+ *
+ *  The return value from @ref zcbor_new_encode_state can be safely ignored
+ *  because the only error condition is n_states < 2, and this macro adds 2 to
+ *  num_backups to get n_states, so it can never be < 2.
  *
  *  @param[in]  name          The name of the new state variable.
  *  @param[in]  num_backups   The number of backup slots to keep in the state.
@@ -262,6 +266,8 @@ void zcbor_new_decode_state(zcbor_state_t *state_array, uint32_t n_states,
  */
 #define ZCBOR_STATE_D(name, num_backups, payload, payload_size, elem_count) \
 zcbor_state_t name[((num_backups) + 2)]; \
-zcbor_new_decode_state(name, ARRAY_SIZE(name), payload, payload_size, elem_count)
+do { \
+	(void)zcbor_new_decode_state(name, ARRAY_SIZE(name), payload, payload_size, elem_count); \
+} while(0)
 
 #endif /* ZCBOR_DECODE_H__ */

--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -235,13 +235,17 @@ bool zcbor_present_encode(const uint_fast32_t *present,
 		const void *input);
 
 /** See @ref zcbor_new_state() */
-void zcbor_new_encode_state(zcbor_state_t *state_array, uint32_t n_states,
-		uint8_t *payload, uint32_t payload_len, uint32_t elem_count);
+bool zcbor_new_encode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
+		uint8_t *payload, size_t payload_len, uint_fast32_t elem_count);
 
 /** Convenience macro for declaring and initializing a state with backups.
  *
  *  This gives you a state variable named @p name. The variable functions like
  *  a pointer.
+ *
+ *  The return value from @ref zcbor_new_encode_state can be safely ignored
+ *  because the only error condition is n_states < 2, and this macro adds 2 to
+ *  num_backups to get n_states, so it can never be < 2.
  *
  *  @param[in]  name          The name of the new state variable.
  *  @param[in]  num_backups   The number of backup slots to keep in the state.
@@ -251,6 +255,8 @@ void zcbor_new_encode_state(zcbor_state_t *state_array, uint32_t n_states,
  */
 #define ZCBOR_STATE_E(name, num_backups, payload, payload_size, elem_count) \
 zcbor_state_t name[((num_backups) + 2)]; \
-zcbor_new_encode_state(name, ARRAY_SIZE(name), payload, payload_size, elem_count)
+do { \
+	(void)zcbor_new_encode_state(name, ARRAY_SIZE(name), payload, payload_size, elem_count); \
+} while(0)
 
 #endif /* ZCBOR_ENCODE_H__ */

--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -150,6 +150,9 @@ bool zcbor_map_start_encode(zcbor_state_t *state, uint_fast32_t max_num);
  *    the list/map header. If the header ends up a different size than expected,
  *    the list/map contents are moved using memmove().
  *
+ * Use @ref zcbor_list_map_end_force_encode to forcibly consume the backup if
+ * something has gone wrong.
+ *
  * @param[inout] state    The current state of the encoding.
  * @param[in]    max_num  The maximum number of members in the list/map. Must be
  *                        equal to the max_num provided to the corresponding
@@ -158,6 +161,7 @@ bool zcbor_map_start_encode(zcbor_state_t *state, uint_fast32_t max_num);
  */
 bool zcbor_list_end_encode(zcbor_state_t *state, uint_fast32_t max_num);
 bool zcbor_map_end_encode(zcbor_state_t *state, uint_fast32_t max_num);
+bool zcbor_list_map_end_force_encode(zcbor_state_t *state);
 
 /** Encode 0 or more elements with the same type and constraints.
  *

--- a/src/zcbor_common.c
+++ b/src/zcbor_common.c
@@ -18,6 +18,8 @@ _Static_assert((sizeof(zcbor_state_t) >= sizeof(struct zcbor_state_constant)),
 
 bool zcbor_new_backup(zcbor_state_t *state, uint_fast32_t new_elem_count)
 {
+	ZCBOR_CHECK_ERROR();
+
 	if ((state->constant_state->current_backup)
 		>= state->constant_state->num_backups) {
 		ZCBOR_ERR(ZCBOR_ERR_NO_BACKUP_MEM);
@@ -43,6 +45,8 @@ bool zcbor_process_backup(zcbor_state_t *state, uint32_t flags,
 {
 	const uint8_t *payload = state->payload;
 	const uint_fast32_t elem_count = state->elem_count;
+
+	ZCBOR_CHECK_ERROR();
 
 	if (state->constant_state->current_backup == 0) {
 		ZCBOR_ERR(ZCBOR_ERR_NO_BACKUP_ACTIVE);
@@ -118,6 +122,9 @@ bool zcbor_new_state(zcbor_state_t *state_array, uint_fast32_t n_states,
 	state_array[0].constant_state->num_backups = n_states - 2;
 	state_array[0].constant_state->current_backup = 0;
 	state_array[0].constant_state->error = ZCBOR_SUCCESS;
+#ifdef ZCBOR_STOP_ON_ERROR
+	state_array[0].constant_state->stop_on_error = false;
+#endif
 	if (n_states > 2) {
 		state_array[0].constant_state->backup_list = &state_array[1];
 	}

--- a/src/zcbor_common.c
+++ b/src/zcbor_common.c
@@ -18,9 +18,9 @@ _Static_assert((sizeof(zcbor_state_t) >= sizeof(struct zcbor_state_constant)),
 
 bool zcbor_new_backup(zcbor_state_t *state, uint_fast32_t new_elem_count)
 {
-	if (!state->constant_state || ((state->constant_state->current_backup)
-		>= state->constant_state->num_backups)) {
-		ZCBOR_FAIL();
+	if ((state->constant_state->current_backup)
+		>= state->constant_state->num_backups) {
+		ZCBOR_ERR(ZCBOR_ERR_NO_BACKUP_MEM);
 	}
 
 	(state->constant_state->current_backup)++;
@@ -44,8 +44,8 @@ bool zcbor_process_backup(zcbor_state_t *state, uint32_t flags,
 	const uint8_t *payload = state->payload;
 	const uint_fast32_t elem_count = state->elem_count;
 
-	if (!state->constant_state || (state->constant_state->current_backup == 0)) {
-		ZCBOR_FAIL();
+	if (state->constant_state->current_backup == 0) {
+		ZCBOR_ERR(ZCBOR_ERR_NO_BACKUP_ACTIVE);
 	}
 
 	if (flags & ZCBOR_FLAG_RESTORE) {
@@ -64,7 +64,7 @@ bool zcbor_process_backup(zcbor_state_t *state, uint32_t flags,
 	if (elem_count > max_elem_count) {
 		zcbor_print("elem_count: %" PRIuFAST32 " (expected max %" PRIuFAST32 ")\r\n",
 			elem_count, max_elem_count);
-		ZCBOR_FAIL();
+		ZCBOR_ERR(ZCBOR_ERR_HIGH_ELEM_COUNT);
 	}
 
 	if (flags & ZCBOR_FLAG_TRANSFER_PAYLOAD) {
@@ -117,6 +117,7 @@ bool zcbor_new_state(zcbor_state_t *state_array, uint_fast32_t n_states,
 	state_array[0].constant_state->backup_list = NULL;
 	state_array[0].constant_state->num_backups = n_states - 2;
 	state_array[0].constant_state->current_backup = 0;
+	state_array[0].constant_state->error = ZCBOR_SUCCESS;
 	if (n_states > 2) {
 		state_array[0].constant_state->backup_list = &state_array[1];
 	}

--- a/src/zcbor_common.c
+++ b/src/zcbor_common.c
@@ -100,19 +100,25 @@ bool zcbor_union_end_code(zcbor_state_t *state)
 	return true;
 }
 
-void zcbor_new_state(zcbor_state_t *state_array, uint_fast32_t n_states,
+bool zcbor_new_state(zcbor_state_t *state_array, uint_fast32_t n_states,
 		const uint8_t *payload, size_t payload_len, uint_fast32_t elem_count)
 {
 	state_array[0].payload = payload;
 	state_array[0].payload_end = payload + payload_len;
 	state_array[0].elem_count = elem_count;
 	state_array[0].indefinite_length_array = false;
-	state_array[0].constant_state = NULL;
-	if (n_states > 2) {
-		/* Use the last state as a struct zcbor_state_constant object. */
-		state_array[0].constant_state = (struct zcbor_state_constant *)&state_array[n_states - 1];
-		state_array[0].constant_state->backup_list = &state_array[1];
-		state_array[0].constant_state->num_backups = n_states - 2;
-		state_array[0].constant_state->current_backup = 0;
+
+	if(n_states < 2) {
+		return false;
 	}
+
+	/* Use the last state as a struct zcbor_state_constant object. */
+	state_array[0].constant_state = (struct zcbor_state_constant *)&state_array[n_states - 1];
+	state_array[0].constant_state->backup_list = NULL;
+	state_array[0].constant_state->num_backups = n_states - 2;
+	state_array[0].constant_state->current_backup = 0;
+	if (n_states > 2) {
+		state_array[0].constant_state->backup_list = &state_array[1];
+	}
+	return true;
 }

--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -476,6 +476,18 @@ bool zcbor_map_end_decode(zcbor_state_t *state)
 }
 
 
+bool zcbor_list_map_end_force_decode(zcbor_state_t *state)
+{
+	if (!zcbor_process_backup(state,
+			ZCBOR_FLAG_RESTORE | ZCBOR_FLAG_CONSUME | ZCBOR_FLAG_TRANSFER_PAYLOAD,
+			ZCBOR_MAX_ELEM_COUNT)) {
+		ZCBOR_FAIL();
+	}
+
+	return true;
+}
+
+
 static bool primx_expect(zcbor_state_t *state, uint8_t result)
 {
 	FAIL_IF(state->payload >= state->payload_end);

--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -88,6 +88,7 @@ static bool value_extract(zcbor_state_t *state,
 	zcbor_assert(result_len != 0, "0-length result not supported.\r\n");
 	zcbor_assert(result != NULL, NULL);
 
+	ZCBOR_CHECK_ERROR();
 	ZCBOR_ERR_IF((state->elem_count == 0), ZCBOR_ERR_LOW_ELEM_COUNT);
 	ZCBOR_ERR_IF(state->payload >= state->payload_end, ZCBOR_ERR_NO_PAYLOAD);
 
@@ -379,6 +380,7 @@ static bool list_map_start_decode(zcbor_state_t *state,
 	uint_fast32_t new_elem_count;
 	bool indefinite_length_array = false;
 
+	ZCBOR_CHECK_ERROR();
 	ZCBOR_CHECK_PAYLOAD();
 	CHECK_MAJOR_TYPE(exp_major_type);
 
@@ -439,6 +441,8 @@ static bool array_end_expect(zcbor_state_t *state)
 static bool list_map_end_decode(zcbor_state_t *state)
 {
 	uint_fast32_t max_elem_count = 0;
+
+	ZCBOR_CHECK_ERROR();
 	if (state->indefinite_length_array) {
 		if (!array_end_expect(state)) {
 			ZCBOR_FAIL();
@@ -627,6 +631,7 @@ bool zcbor_any_skip(zcbor_state_t *state, void *result)
 	zcbor_assert(result == NULL,
 			"'any' type cannot be returned, only skipped.\r\n");
 
+	ZCBOR_CHECK_ERROR();
 	ZCBOR_CHECK_PAYLOAD();
 	uint8_t major_type = MAJOR_TYPE(*state->payload);
 	uint8_t additional = ADDITIONAL(*state->payload);
@@ -742,6 +747,7 @@ bool zcbor_multi_decode(uint_fast32_t min_decode,
 		void *result,
 		uint_fast32_t result_len)
 {
+	ZCBOR_CHECK_ERROR();
 	for (uint_fast32_t i = 0; i < max_decode; i++) {
 		uint8_t const *payload_bak = state->payload;
 		uint_fast32_t elem_count_bak = state->elem_count;

--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -808,8 +808,8 @@ bool zcbor_present_decode(uint_fast32_t *present,
 }
 
 
-void zcbor_new_decode_state(zcbor_state_t *state_array, uint32_t n_states,
-		const uint8_t *payload, uint32_t payload_len, uint32_t elem_count)
+bool zcbor_new_decode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
+		const uint8_t *payload, size_t payload_len, uint_fast32_t elem_count)
 {
-	zcbor_new_state(state_array, n_states, payload, payload_len, elem_count);
+	return zcbor_new_state(state_array, n_states, payload, payload_len, elem_count);
 }

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -437,6 +437,18 @@ bool zcbor_map_end_encode(zcbor_state_t *state, uint_fast32_t max_num)
 }
 
 
+bool zcbor_list_map_end_force_encode(zcbor_state_t *state)
+{
+#ifdef ZCBOR_CANONICAL
+	if (!zcbor_process_backup(state, ZCBOR_FLAG_RESTORE | ZCBOR_FLAG_CONSUME,
+			ZCBOR_MAX_ELEM_COUNT)) {
+		ZCBOR_FAIL();
+	}
+#endif
+	return true;
+}
+
+
 bool zcbor_nil_put(zcbor_state_t *state, const void *unused)
 {
 	(void)unused;

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -567,8 +567,8 @@ bool zcbor_present_encode(const uint_fast32_t *present,
 }
 
 
-void zcbor_new_encode_state(zcbor_state_t *state_array, uint32_t n_states,
-		uint8_t *payload, uint32_t payload_len, uint32_t elem_count)
+bool zcbor_new_encode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
+		uint8_t *payload, size_t payload_len, uint_fast32_t elem_count)
 {
-	zcbor_new_state(state_array, n_states, payload, payload_len, elem_count);
+	return zcbor_new_state(state_array, n_states, payload, payload_len, elem_count);
 }

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -40,6 +40,7 @@ static uint8_t get_additional(uint_fast32_t len, uint8_t value0)
 static bool encode_header_byte(zcbor_state_t *state,
 	zcbor_major_type_t major_type, uint8_t additional)
 {
+	ZCBOR_CHECK_ERROR();
 	ZCBOR_CHECK_PAYLOAD();
 
 	zcbor_assert(additional < 32, NULL);
@@ -547,6 +548,7 @@ bool zcbor_multi_encode(uint_fast32_t num_encode,
 		const void *input,
 		uint_fast32_t result_len)
 {
+	ZCBOR_CHECK_ERROR();
 	for (uint_fast32_t i = 0; i < num_encode; i++) {
 		if (!encoder(state, (const uint8_t *)input + i*result_len)) {
 			ZCBOR_FAIL();

--- a/tests/decode/test1_suit_old_formats/src/main.c
+++ b/tests/decode/test1_suit_old_formats/src/main.c
@@ -109,7 +109,7 @@ void test_1(void)
 		0x0b, 0x5e, 0x6a, 0x1d, 0x2c, 0xa3, 0x9f, 0x74,
 		0x98, 0xb6, 0xa6, 0xa7, 0xbe, 0x8d, 0x8d, 0x67,
 	};
-	zassert_true(cbor_decode_OuterWrapper(test_vector2,
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_OuterWrapper(test_vector2,
 				sizeof(test_vector2),
 				&outerwrapper, &decode_len),
 			"test_vector2 failed");
@@ -157,7 +157,7 @@ void test_2(void)
 		"sed tincidunt ante, a sodales ligula. Phasellus ullamcorper "
 		"odio commodo ipsum egestas, vitae lacinia leo ornare. "
 		"Suspendisse posuere sed.";
-	zassert_true(cbor_decode_OuterWrapper(test_vector3,
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_OuterWrapper(test_vector3,
 				sizeof(test_vector3),
 				&outerwrapper, &decode_len),
 			"test_vector3 failed");
@@ -203,7 +203,7 @@ void test_3(void)
 	size_t decode_len;
 	char expected_uri[] = "http://example.com/file.bin";
 	memset(&outerwrapper4, 0, sizeof(struct SUIT_Outer_Wrapper));
-	zassert_true(cbor_decode_SUIT_Outer_Wrapper(test_vector4,
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Outer_Wrapper(test_vector4,
 		sizeof(test_vector4), &outerwrapper4, &decode_len), "test_vector failed");
 	zassert_equal(sizeof(test_vector4), decode_len, NULL);
 	zassert_equal(2,

--- a/tests/decode/test1_suit_old_formats/testcase.yaml
+++ b/tests/decode/test1_suit_old_formats/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   zcbor.decode.test1_suit_old_formats:
     platform_allow: native_posix native_posix_64
-    tags: zcbor decode
+    tags: zcbor decode test1

--- a/tests/decode/test2_suit/src/main.c
+++ b/tests/decode/test2_suit/src/main.c
@@ -43,7 +43,7 @@ void test_5(void)
 	struct SUIT_Component_Identifier *component;
 	uint8_t expected_component0[] = {0x46, 0x6c, 0x61, 0x73, 0x68};
 	uint8_t expected_component1[] = {0x00, 0x34, 0x01};
-	bool res;
+	uint_fast8_t res;
 
 	zcbor_print("test_vector at: 0x%zu\r\n", (size_t)test_vector1);
 	zcbor_print("test_vector end at: 0x%zu\r\n",
@@ -51,7 +51,7 @@ void test_5(void)
 	memset(&outerwrapper1, 0, sizeof(outerwrapper1));
 	res = cbor_decode_SUIT_Outer_Wrapper(test_vector1, sizeof(test_vector1),
 						&outerwrapper1, &decode_len);
-	zassert_true(res, "top-level decoding failed.");
+	zassert_equal(ZCBOR_SUCCESS, res, "top-level decoding failed.");
 	zassert_equal(sizeof(test_vector1), decode_len, NULL);
 	zassert_equal(_SUIT_Manifest_Wrapped_suit_manifest, outerwrapper1
 			._SUIT_Outer_Wrapper__SUIT_Manifest_Wrapped
@@ -146,7 +146,7 @@ void test_5(void)
 			._SUIT_Common_suit_common_sequence
 			.len,
 			&sequence, &decode_len);
-	zassert_true(res, "Parsing common sequence failed.");
+	zassert_equal(ZCBOR_SUCCESS, res, "Parsing common sequence failed.");
 	zassert_equal(manifest
 			->_SUIT_Manifest_suit_common
 			._SUIT_Manifest_suit_common_cbor
@@ -179,7 +179,7 @@ void test_5(void)
 			._SUIT_Manifest_suit_run
 			.len,
 			&sequence, &decode_len);
-	zassert_true(res, "Parsing run command sequence failed.");
+	zassert_equal(ZCBOR_SUCCESS, res, "Parsing run command sequence failed.");
 	zassert_equal(manifest
 			->_SUIT_Manifest_suit_run
 			._SUIT_Manifest_suit_run

--- a/tests/decode/test2_suit/testcase.yaml
+++ b/tests/decode/test2_suit/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   zcbor.decode.test2_suit:
     platform_allow: native_posix native_posix_64
-    tags: zcbor decode
+    tags: zcbor decode test2

--- a/tests/decode/test3_simple/src/main.c
+++ b/tests/decode/test3_simple/src/main.c
@@ -437,7 +437,7 @@ void test_pet(void)
 		0x83, 0x82, 0x63, 0x66, 0x6f, 0x6f, 0x63, 0x62, 0x61, 0x72,
 		0x48, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 		0x02};
-	zassert_true(cbor_decode_Pet(input, sizeof(input), &pet, &decode_len), "");
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Pet(input, sizeof(input), &pet, &decode_len), "");
 	zassert_equal(sizeof(input), decode_len, NULL);
 
 	uint8_t exp_birthday[] = {1,2,3,4,5,6,7,8};
@@ -485,7 +485,7 @@ void test_serial1(void)
 	size_t decode_len;
 	bool ret = cbor_decode_Upload(serial_rec_input1,
 			sizeof(serial_rec_input1), &upload, &decode_len);
-	zassert_true(ret, "decoding failed.");
+	zassert_equal(ZCBOR_SUCCESS, ret, "decoding failed.");
 	zassert_equal(sizeof(serial_rec_input1), decode_len, NULL);
 
 	zassert_equal(5, upload._Upload_members_count,
@@ -509,7 +509,7 @@ void test_serial2(void)
 	size_t decode_len;
 	bool ret = cbor_decode_Upload(serial_rec_input2,
 			sizeof(serial_rec_input2), &upload, &decode_len);
-	zassert_true(ret, "decoding failed.");
+	zassert_equal(ZCBOR_SUCCESS, ret, "decoding failed.");
 	zassert_equal(sizeof(serial_rec_input2), decode_len, NULL);
 
 	zassert_equal(5, upload._Upload_members_count,

--- a/tests/decode/test3_simple/testcase.yaml
+++ b/tests/decode/test3_simple/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   zcbor.decode.test3_simple:
     platform_allow: native_posix native_posix_64
-    tags: zcbor decode
+    tags: zcbor decode test3

--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -635,9 +635,8 @@ void test_empty_map(void)
 	const uint8_t payload3_inv[] = {MAP(1), 0, END};
 	const uint8_t payload4[] = {MAP(0), END MAP(0), END MAP(0), END};
 	uint_fast32_t num_decode;
-	zcbor_state_t state;
 
-	zcbor_new_state(&state, 1, payload4, sizeof(payload4), 3);
+	ZCBOR_STATE_D(state, 0, payload4, sizeof(payload4), 3);
 
 	zassert_true(cbor_decode_EmptyMap(payload1, sizeof(payload1), NULL, NULL), NULL);
 #ifdef TEST_INDEFINITE_LENGTH_ARRAYS

--- a/tests/decode/test5_corner_cases/testcase.yaml
+++ b/tests/decode/test5_corner_cases/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   zcbor.decode.test5_corner_cases:
     platform_allow: native_posix native_posix_64
-    tags: zcbor decode
+    tags: zcbor decode test5
   zcbor.decode.test5_corner_cases.indefinite_length_arrays:
     platform_allow: native_posix native_posix_64
-    tags: zcbor decode
+    tags: zcbor decode test5 indefinite
     extra_args: TEST_INDEFINITE_LENGTH_ARRAYS=1

--- a/tests/decode/test7_suit9_simple/src/main.c
+++ b/tests/decode/test7_suit9_simple/src/main.c
@@ -94,7 +94,7 @@ static struct SUIT_Manifest manifest;
 
 void test_suit9_simple2(void)
 {
-	bool res;
+	uint_fast8_t res;
 
 	zcbor_print("test_vector at: 0x%zx\r\n", (size_t)test_vector2);
 	zcbor_print("test_vector end at: 0x%zx\r\n",
@@ -102,19 +102,19 @@ void test_suit9_simple2(void)
 	memset(&envelope1, 0, sizeof(envelope1));
 	res = cbor_decode_SUIT_Envelope(test_vector2,
 					sizeof(test_vector2), &envelope1, NULL);
-	zassert_true(res, "top-level decoding failed.");
+	zassert_equal(ZCBOR_SUCCESS, res, "top-level decoding failed.");
 
 	res = cbor_decode_SUIT_Manifest(
 		envelope1._SUIT_Envelope_suit_manifest.value,
 		envelope1._SUIT_Envelope_suit_manifest.len, &manifest, NULL);
 
-	zassert_true(res, "manifest decoding failed.");
+	zassert_equal(ZCBOR_SUCCESS, res, "manifest decoding failed.");
 }
 
 
 void test_suit9_simple5(void)
 {
-	bool res;
+	uint_fast8_t res;
 
 	zcbor_print("test_vector at: 0x%zx\r\n", (size_t)test_vector5);
 	zcbor_print("test_vector end at: 0x%zx\r\n",
@@ -122,13 +122,13 @@ void test_suit9_simple5(void)
 	memset(&envelope1, 0, sizeof(envelope1));
 	res = cbor_decode_SUIT_Envelope(test_vector5,
 					sizeof(test_vector5), &envelope1, NULL);
-	zassert_true(res, "top-level decoding failed.");
+	zassert_equal(ZCBOR_SUCCESS, res, "top-level decoding failed.");
 
 	res = cbor_decode_SUIT_Manifest(
 		envelope1._SUIT_Envelope_suit_manifest.value,
 		envelope1._SUIT_Envelope_suit_manifest.len, &manifest, NULL);
 
-	zassert_true(res, "manifest decoding failed.");
+	zassert_equal(ZCBOR_SUCCESS, res, "manifest decoding failed.");
 }
 
 void test_main(void)

--- a/tests/decode/test7_suit9_simple/testcase.yaml
+++ b/tests/decode/test7_suit9_simple/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   zcbor.decode.test7_suit9_simple:
     platform_allow: native_posix native_posix_64
-    tags: zcbor decode
+    tags: zcbor decode test7

--- a/tests/decode/test8_suit12/testcase.yaml
+++ b/tests/decode/test8_suit12/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   zcbor.decode.test8_suit12:
     platform_allow: native_posix native_posix_64
-    tags: zcbor decode
+    tags: zcbor decode test8

--- a/tests/decode/test9_manifest14/src/main.c
+++ b/tests/decode/test9_manifest14/src/main.c
@@ -61,7 +61,7 @@ void test_suit14_ex0_auth(void)
 		0x7d, 0x05, 0x2b, 0x42, 0xdb, 0x6b, 0x72, 0x87,
 	};
 
-	zassert_true(cbor_decode_SUIT_Envelope_Tagged(example0, sizeof(example0), &envelope, &out_len), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Envelope_Tagged(example0, sizeof(example0), &envelope, &out_len), NULL);
 	zassert_equal(sizeof(example0), out_len, NULL);
 
 	digest = &envelope._SUIT_Envelope_suit_authentication_wrapper_cbor._SUIT_Authentication_SUIT_Digest_bstr_cbor;
@@ -126,18 +126,18 @@ void test_suit14_ex0_common_sequence(void)
 		| (1 << _suit_reporting_bits_suit_send_sysinfo_success)
 		| (1 << _suit_reporting_bits_suit_send_sysinfo_failure));
 
-	zassert_true(cbor_decode_SUIT_Envelope_Tagged(example0, sizeof(example0), &envelope, &out_len), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Envelope_Tagged(example0, sizeof(example0), &envelope, &out_len), NULL);
 	zassert_equal(sizeof(example0), out_len, NULL);
-	zassert_true(cbor_decode_SUIT_Manifest(envelope._SUIT_Envelope_suit_manifest.value,
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Manifest(envelope._SUIT_Envelope_suit_manifest.value,
 		envelope._SUIT_Envelope_suit_manifest.len, &manifest, &out_len), NULL);
 	zassert_equal(envelope._SUIT_Envelope_suit_manifest.len, out_len, NULL);
 	zassert_true(manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_components_present, NULL);
 	zassert_true(manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence_present, NULL);
-	zassert_true(cbor_decode_SUIT_Common_Sequence(
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Common_Sequence(
 		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.value,
 		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.len,
 		&common_sequence, &out_len), NULL);
-	zassert_true(cbor_decode_SUIT_Command_Sequence(
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Command_Sequence(
 		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.value,
 		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.len,
 		&command_sequence, &out_len), NULL);
@@ -242,21 +242,21 @@ void test_suit14_ex0_common_sequence_as_command_sequence(void)
 		| (1 << _suit_reporting_bits_suit_send_sysinfo_success)
 		| (1 << _suit_reporting_bits_suit_send_sysinfo_failure));
 
-	zassert_true(cbor_decode_SUIT_Envelope_Tagged(example0, sizeof(example0), &envelope, &out_len), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Envelope_Tagged(example0, sizeof(example0), &envelope, &out_len), NULL);
 	zassert_equal(sizeof(example0), out_len, NULL);
-	zassert_true(cbor_decode_SUIT_Manifest(envelope._SUIT_Envelope_suit_manifest.value,
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Manifest(envelope._SUIT_Envelope_suit_manifest.value,
 		envelope._SUIT_Envelope_suit_manifest.len, &manifest, &out_len), NULL);
 	zassert_equal(envelope._SUIT_Envelope_suit_manifest.len, out_len, NULL);
 	zassert_true(manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_components_present, NULL);
 	zassert_true(manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence_present, NULL);
-	zassert_true(cbor_decode_SUIT_Common_Sequence(
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Common_Sequence(
 		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.value,
 		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.len,
 		&common_sequence, &out_len), NULL);
 	zassert_equal(
 		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.len,
 		out_len, NULL);
-	zassert_true(cbor_decode_SUIT_Command_Sequence(
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Command_Sequence(
 		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.value,
 		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.len,
 		&command_sequence, &out_len), NULL);
@@ -344,16 +344,16 @@ void test_suit14_ex0_validate_run(void)
 		| (1 << _suit_reporting_bits_suit_send_sysinfo_failure));
 	uint32_t exp_rep_policy2 = (1 << _suit_reporting_bits_suit_send_record_failure);
 
-	zassert_true(cbor_decode_SUIT_Envelope_Tagged(example0, sizeof(example0), &envelope, &out_len), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Envelope_Tagged(example0, sizeof(example0), &envelope, &out_len), NULL);
 	zassert_equal(sizeof(example0), out_len, NULL);
-	zassert_true(cbor_decode_SUIT_Manifest(envelope._SUIT_Envelope_suit_manifest.value,
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Manifest(envelope._SUIT_Envelope_suit_manifest.value,
 		envelope._SUIT_Envelope_suit_manifest.len, &manifest, &out_len), NULL);
 	zassert_equal(envelope._SUIT_Envelope_suit_manifest.len, out_len, NULL);
 	zassert_true(manifest._SUIT_Manifest__SUIT_Unseverable_Members._SUIT_Unseverable_Members_suit_validate_present, NULL);
 	zassert_false(manifest._SUIT_Manifest__SUIT_Unseverable_Members._SUIT_Unseverable_Members_suit_load_present, NULL);
 	zassert_true(manifest._SUIT_Manifest__SUIT_Unseverable_Members._SUIT_Unseverable_Members_suit_run_present, NULL);
 
-	zassert_true(cbor_decode_SUIT_Command_Sequence(
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Command_Sequence(
 		manifest._SUIT_Manifest__SUIT_Unseverable_Members._SUIT_Unseverable_Members_suit_validate._SUIT_Unseverable_Members_suit_validate.value,
 		manifest._SUIT_Manifest__SUIT_Unseverable_Members._SUIT_Unseverable_Members_suit_validate._SUIT_Unseverable_Members_suit_validate.len,
 		&command_sequence, &out_len), NULL);
@@ -368,7 +368,7 @@ void test_suit14_ex0_validate_run(void)
 	zassert_equal(exp_rep_policy1,
 		condition->_SUIT_Condition___suit_condition_image_match__SUIT_Rep_Policy, NULL);
 
-	zassert_true(cbor_decode_SUIT_Command_Sequence(
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Command_Sequence(
 		manifest._SUIT_Manifest__SUIT_Unseverable_Members._SUIT_Unseverable_Members_suit_run._SUIT_Unseverable_Members_suit_run.value,
 		manifest._SUIT_Manifest__SUIT_Unseverable_Members._SUIT_Unseverable_Members_suit_run._SUIT_Unseverable_Members_suit_run.len,
 		&command_sequence, &out_len), NULL);

--- a/tests/decode/test9_manifest14/testcase.yaml
+++ b/tests/decode/test9_manifest14/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   zcbor.decode.test9_manifest14:
     platform_allow: native_posix native_posix_64
-    tags: zcbor decode manifest14
+    tags: zcbor decode manifest14 test9
   zcbor.cbor_decode.test9_manifest16:
     platform_allow: native_posix native_posix_64
-    tags: zcbor decode manifest16
+    tags: zcbor decode manifest16 test9
     extra_args: MANIFEST=manifest16

--- a/tests/encode/test1_suit/src/main.c
+++ b/tests/encode/test1_suit/src/main.c
@@ -247,16 +247,16 @@ void test_command_sequence(struct zcbor_string *sequence_str,
 	zcbor_print("\r\ntest %s\r\n", name);
 
 	memset(&sequence1, 0, sizeof(sequence1));
-	bool res = cbor_decode_SUIT_Command_Sequence(sequence_str->value,
+	uint_fast8_t res = cbor_decode_SUIT_Command_Sequence(sequence_str->value,
 		sequence_str->len,
 		&sequence1, NULL);
-	zassert_true(res, NULL);
+	zassert_equal(ZCBOR_SUCCESS, res, NULL);
 
 
 	res = cbor_encode_SUIT_Command_Sequence(output,
 		sizeof(output),
 		&sequence1, &out_len);
-	zassert_true(res, NULL);
+	zassert_equal(ZCBOR_SUCCESS, res, NULL);
 	zassert_equal(sequence_str->len, out_len, "%d != %d\r\n", sequence_str->len, out_len);
 	zassert_mem_equal(sequence_str->value,
 		output,
@@ -335,14 +335,14 @@ void test_manifest(const uint8_t *input, uint32_t len)
 	bool load_present;
 	struct zcbor_string *run;
 	bool run_present;
-	bool res;
+	uint_fast8_t res;
 	size_t out_len;
 
 	zcbor_print("test_vector at: 0x%zx\r\n", (size_t)input);
 	zcbor_print("test_vector end at: 0x%zx\r\n",
 				((size_t)input) + len);
 	res = cbor_decode_SUIT_Outer_Wrapper(input, len, &outerwrapper1, NULL);
-	zassert_true(res, "top-level decoding failed.");
+	zassert_equal(ZCBOR_SUCCESS, res, "top-level decoding failed.");
 
 	dependency1 = &outerwrapper1
 		._SUIT_Outer_Wrapper_suit_dependency_resolution
@@ -438,7 +438,7 @@ void test_manifest(const uint8_t *input, uint32_t len)
 
 	res = cbor_encode_SUIT_Outer_Wrapper(output,
 					sizeof(output), &outerwrapper1, &out_len);
-	zassert_true(res, "top-level encoding failed.");
+	zassert_equal(ZCBOR_SUCCESS, res, "top-level encoding failed.");
 	zassert_equal(len, out_len, NULL);
 	zassert_mem_equal(input, output, len, NULL);
 }

--- a/tests/encode/test1_suit/testcase.yaml
+++ b/tests/encode/test1_suit/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
   zcbor.encode.test1_suit.canonical:
     platform_allow: native_posix native_posix_64
-    tags: zcbor encode canonical
+    tags: zcbor encode canonical test1
     extra_args: CANONICAL=CANONICAL

--- a/tests/encode/test2_simple/src/main.c
+++ b/tests/encode/test2_simple/src/main.c
@@ -170,7 +170,7 @@ void test_pet(void)
 	size_t out_len;
 
 	/* Check that encoding succeeded. */
-	zassert_true(cbor_encode_Pet(output, sizeof(output), &pet, &out_len), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Pet(output, sizeof(output), &pet, &out_len), NULL);
 
 	/* Check that the resulting length is correct. */
 	zassert_equal(sizeof(exp_output), out_len, NULL);

--- a/tests/encode/test2_simple/testcase.yaml
+++ b/tests/encode/test2_simple/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   zcbor.encode.test2_simple:
     platform_allow: native_posix native_posix_64
-    tags: zcbor encode
+    tags: zcbor encode test
   zcbor.encode.test2_simple.canonical:
     platform_allow: native_posix native_posix_64
-    tags: zcbor encode canonical
+    tags: zcbor encode canonical test
     extra_args: CANONICAL=CANONICAL

--- a/tests/encode/test3_corner_cases/src/main.c
+++ b/tests/encode/test3_corner_cases/src/main.c
@@ -50,37 +50,37 @@ void test_numbers(void)
 	numbers._Numbers_posint = 0;
 	numbers._Numbers_tagged_int = 1;
 
-	zassert_false(cbor_encode_Numbers(output,
+	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_Numbers(output,
 		sizeof(output), &numbers, &out_len), NULL);
 
 	numbers._Numbers_fourtoten = 11; // Invalid
-	zassert_false(cbor_encode_Numbers(output,
+	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_Numbers(output,
 		sizeof(output), &numbers, &out_len), NULL);
 
 	numbers._Numbers_fourtoten = 5; // Valid
-	zassert_true(cbor_encode_Numbers(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Numbers(output,
 		sizeof(output), &numbers, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_numbers1), out_len, "%d != %d\r\n", sizeof(exp_payload_numbers1), out_len);
 	zassert_mem_equal(exp_payload_numbers1, output, sizeof(exp_payload_numbers1), NULL);
 
 	numbers._Numbers_negint = 1; // Invalid
-	zassert_false(cbor_encode_Numbers(output,
+	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_Numbers(output,
 		sizeof(output), &numbers, &out_len), NULL);
 
 	numbers._Numbers_negint = -1; // Valid
-	zassert_true(cbor_encode_Numbers(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Numbers(output,
 		sizeof(output), &numbers, &out_len), NULL);
 
 	numbers._Numbers_minusfivektoplustwohundred = -5001; // Invalid
-	zassert_false(cbor_encode_Numbers(output,
+	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_Numbers(output,
 		sizeof(output), &numbers, &out_len), NULL);
 
 	numbers._Numbers_minusfivektoplustwohundred = 201; // Invalid
-	zassert_false(cbor_encode_Numbers(output,
+	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_Numbers(output,
 		sizeof(output), &numbers, &out_len), NULL);
 
 	numbers._Numbers_minusfivektoplustwohundred = 200; // Valid
-	zassert_true(cbor_encode_Numbers(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Numbers(output,
 		sizeof(output), &numbers, &out_len), NULL);
 }
 
@@ -103,7 +103,7 @@ void test_numbers2(void)
 	uint8_t output[100];
 	size_t out_len;
 
-	zassert_true(cbor_encode_Numbers2(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Numbers2(output,
 		sizeof(output), &numbers2, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_numbers2), out_len, "%d != %d\r\n",
 		sizeof(exp_payload_numbers2), out_len);
@@ -272,21 +272,21 @@ void test_strings(void)
 	strings2._Strings_cborseqPrimitives_cbor_count = 1;
 	strings2._Strings_cborseqPrimitives_cbor[0]._Primitives_boolval = false;
 
-	zassert_true(cbor_encode_Numbers(output2, sizeof(output2), &numbers1, &out_len), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Numbers(output2, sizeof(output2), &numbers1, &out_len), NULL);
 	strings1._Strings_cborNumbers.value = output2;
 	strings1._Strings_cborNumbers.len = out_len;
 	numbers1._Numbers_tagged_int = -10;
-	zassert_true(cbor_encode_Numbers(output1, sizeof(output1), &numbers1, &out_len), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Numbers(output1, sizeof(output1), &numbers1, &out_len), NULL);
 	strings2._Strings_cborNumbers.value = output1;
 	strings2._Strings_cborNumbers.len = out_len;
-	zassert_false(cbor_encode_Strings(output3, sizeof(output3), &strings2, &out_len), NULL);
+	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_Strings(output3, sizeof(output3), &strings2, &out_len), NULL);
 	strings2._Strings_tentothirtybytetstr.len = 31; // Invalid
-	zassert_false(cbor_encode_Strings(output3, sizeof(output3), &strings2, &out_len), NULL);
+	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_Strings(output3, sizeof(output3), &strings2, &out_len), NULL);
 	strings2._Strings_tentothirtybytetstr.len = 10; // Valid
-	zassert_true(cbor_encode_Strings(output3, sizeof(output3), &strings2, &out_len), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Strings(output3, sizeof(output3), &strings2, &out_len), NULL);
 	strings1._Strings_optCborStrings.value = output3;
 	strings1._Strings_optCborStrings.len = out_len;
-	zassert_true(cbor_encode_Strings(output4, sizeof(output4), &strings1, &out_len), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Strings(output4, sizeof(output4), &strings1, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_strings1), out_len, "expected: %d, actual: %d\r\n", sizeof(exp_payload_strings1), out_len);
 
 	zassert_mem_equal(exp_payload_strings1, output4, sizeof(exp_payload_strings1), NULL);
@@ -302,12 +302,12 @@ void test_primitives(void)
 	uint8_t output[10];
 
 	input._Primitives_boolval = false;
-	zassert_true(cbor_encode_Prim2(output, sizeof(output), &input, &len_encode), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Prim2(output, sizeof(output), &input, &len_encode), NULL);
 	zassert_equal(len_encode, sizeof(exp_payload_prim1), NULL);
 	zassert_mem_equal(exp_payload_prim1, output, sizeof(exp_payload_prim1), NULL);
 
 	input._Primitives_boolval = true;
-	zassert_true(cbor_encode_Prim2(output, sizeof(output), &input, &len_encode), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Prim2(output, sizeof(output), &input, &len_encode), NULL);
 	zassert_equal(len_encode, sizeof(exp_payload_prim2), NULL);
 	zassert_mem_equal(exp_payload_prim2, output, sizeof(exp_payload_prim2), NULL);
 }
@@ -352,37 +352,37 @@ void test_optional(void)
 	uint8_t output[10];
 	size_t out_len;
 
-	zassert_true(cbor_encode_Optional(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Optional(output,
 			sizeof(output), &optional1, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_optional1), out_len, NULL);
 	zassert_mem_equal(exp_payload_optional1, output, sizeof(exp_payload_optional1), NULL);
 
-	zassert_true(cbor_encode_Optional(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Optional(output,
 			sizeof(output), &optional2, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_optional2), out_len, NULL);
 	zassert_mem_equal(exp_payload_optional2, output, sizeof(exp_payload_optional2), NULL);
 
-	zassert_true(cbor_encode_Optional(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Optional(output,
 			sizeof(output), &optional3, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_optional3), out_len, NULL);
 	zassert_mem_equal(exp_payload_optional3, output, sizeof(exp_payload_optional3), NULL);
 
-	zassert_true(cbor_encode_Optional(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Optional(output,
 			sizeof(output), &optional4, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_optional4), out_len, NULL);
 	zassert_mem_equal(exp_payload_optional4, output, sizeof(exp_payload_optional4), NULL);
 
-	zassert_true(cbor_encode_Optional(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Optional(output,
 			sizeof(output), &optional5, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_optional5), out_len, NULL);
 	zassert_mem_equal(exp_payload_optional5, output, sizeof(exp_payload_optional5), NULL);
 
-	zassert_true(cbor_encode_Optional(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Optional(output,
 			sizeof(output), &optional6, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_optional6), out_len, NULL);
 	zassert_mem_equal(exp_payload_optional6, output, sizeof(exp_payload_optional6), NULL);
 
-	zassert_true(cbor_encode_Optional(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Optional(output,
 			sizeof(output), &optional7, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_optional7), out_len, NULL);
 	zassert_mem_equal(exp_payload_optional7, output, sizeof(exp_payload_optional7), NULL);
@@ -411,32 +411,32 @@ void test_union(void)
 	uint8_t output[15];
 	size_t out_len;
 
-	zassert_true(cbor_encode_Union(output, sizeof(output),
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Union(output, sizeof(output),
 				&_union1, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_union1), out_len, NULL);
 	zassert_mem_equal(exp_payload_union1, output, sizeof(exp_payload_union1), NULL);
 
-	zassert_true(cbor_encode_Union(output, sizeof(output),
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Union(output, sizeof(output),
 				&_union2, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_union2), out_len, NULL);
 	zassert_mem_equal(exp_payload_union2, output, sizeof(exp_payload_union2), NULL);
 
-	zassert_true(cbor_encode_Union(output, sizeof(output),
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Union(output, sizeof(output),
 				&_union3, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_union3), out_len, NULL);
 	zassert_mem_equal(exp_payload_union3, output, sizeof(exp_payload_union3), NULL);
 
-	zassert_true(cbor_encode_Union(output, sizeof(output),
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Union(output, sizeof(output),
 				&_union4, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_union4), out_len, NULL);
 	zassert_mem_equal(exp_payload_union4, output, sizeof(exp_payload_union4), NULL);
 
-	zassert_true(cbor_encode_Union(output, sizeof(output),
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Union(output, sizeof(output),
 				&_union5, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_union5), out_len, NULL);
 	zassert_mem_equal(exp_payload_union5, output, sizeof(exp_payload_union5), NULL);
 
-	zassert_false(cbor_encode_Union(output, sizeof(output),
+	zassert_equal(ZCBOR_ERR_ITERATIONS, cbor_encode_Union(output, sizeof(output),
 				&_union6_inv, &out_len), NULL);
 }
 
@@ -466,9 +466,9 @@ void test_levels(void)
 	}};
 	_Static_assert(sizeof(exp_payload_levels1) <= sizeof(output),
 		"Payload is larger than output");
-	zassert_false(cbor_encode_Level1(output,
+	zassert_equal(ZCBOR_ERR_NO_PAYLOAD, cbor_encode_Level1(output,
 		sizeof(exp_payload_levels1)-1, &level1, &out_len), NULL);
-	zassert_true(cbor_encode_Level1(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Level1(output,
 		sizeof(output), &level1, &out_len), NULL);
 
 	zassert_equal(sizeof(exp_payload_levels1), out_len, "%d != %d", sizeof(exp_payload_levels1), out_len);
@@ -534,17 +534,17 @@ void test_map(void)
 	uint8_t output[25];
 	size_t out_len;
 
-	zassert_true(cbor_encode_Map(output, sizeof(output),
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Map(output, sizeof(output),
 			&map1, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_map1), out_len, NULL);
 	zassert_mem_equal(exp_payload_map1, output, sizeof(exp_payload_map1), NULL);
 
-	zassert_true(cbor_encode_Map(output, sizeof(output),
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Map(output, sizeof(output),
 			&map2, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_map2), out_len, NULL);
 	zassert_mem_equal(exp_payload_map2, output, sizeof(exp_payload_map2), NULL);
 
-	zassert_true(cbor_encode_Map(output, sizeof(output),
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Map(output, sizeof(output),
 			&map3, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_map3), out_len, NULL);
 	zassert_mem_equal(exp_payload_map3, output, sizeof(exp_payload_map3), NULL);
@@ -590,31 +590,31 @@ void test_nested_list_map(void)
 	uint8_t output[40];
 	size_t out_len;
 
-	zassert_true(cbor_encode_NestedListMap(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_NestedListMap(output,
 			sizeof(output), &listmap1, &out_len), NULL);
 
 	zassert_equal(sizeof(exp_payload_nested_lm1), out_len, NULL);
 	zassert_mem_equal(exp_payload_nested_lm1, output, sizeof(exp_payload_nested_lm1), NULL);
 
-	zassert_true(cbor_encode_NestedListMap(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_NestedListMap(output,
 			sizeof(output), &listmap2, &out_len), NULL);
 
 	zassert_equal(sizeof(exp_payload_nested_lm2), out_len, NULL);
 	zassert_mem_equal(exp_payload_nested_lm2, output, sizeof(exp_payload_nested_lm2), NULL);
 
-	zassert_true(cbor_encode_NestedListMap(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_NestedListMap(output,
 			sizeof(output), &listmap3, &out_len), NULL);
 
 	zassert_equal(sizeof(exp_payload_nested_lm3), out_len, NULL);
 	zassert_mem_equal(exp_payload_nested_lm3, output, sizeof(exp_payload_nested_lm3), NULL);
 
-	zassert_true(cbor_encode_NestedListMap(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_NestedListMap(output,
 			sizeof(output), &listmap4, &out_len), NULL);
 
 	zassert_equal(sizeof(exp_payload_nested_lm4), out_len, NULL);
 	zassert_mem_equal(exp_payload_nested_lm4, output, sizeof(exp_payload_nested_lm4), NULL);
 
-	zassert_true(cbor_encode_NestedListMap(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_NestedListMap(output,
 			sizeof(output), &listmap5, &out_len), NULL);
 
 	zassert_equal(sizeof(exp_payload_nested_lm5), out_len, "%d != %d", sizeof(exp_payload_nested_lm5), out_len);
@@ -662,31 +662,31 @@ void test_nested_map_list_map(void)
 	uint8_t output[30];
 	size_t out_len;
 
-	zassert_true(cbor_encode_NestedMapListMap(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_NestedMapListMap(output,
 			sizeof(output), &maplistmap1, &out_len), NULL);
 
 	zassert_equal(sizeof(exp_payload_nested_mlm1), out_len, NULL);
 	zassert_mem_equal(exp_payload_nested_mlm1, output, sizeof(exp_payload_nested_mlm1), NULL);
 
-	zassert_true(cbor_encode_NestedMapListMap(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_NestedMapListMap(output,
 			sizeof(output), &maplistmap2, &out_len), NULL);
 
 	zassert_equal(sizeof(exp_payload_nested_mlm2), out_len, "%d != %d", sizeof(exp_payload_nested_mlm2), out_len);
 	zassert_mem_equal(exp_payload_nested_mlm2, output, sizeof(exp_payload_nested_mlm2), NULL);
 
-	zassert_true(cbor_encode_NestedMapListMap(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_NestedMapListMap(output,
 			sizeof(output), &maplistmap3, &out_len), NULL);
 
 	zassert_equal(sizeof(exp_payload_nested_mlm3), out_len, "%d != %d", sizeof(exp_payload_nested_mlm3), out_len);
 	zassert_mem_equal(exp_payload_nested_mlm3, output, sizeof(exp_payload_nested_mlm3), NULL);
 
-	zassert_true(cbor_encode_NestedMapListMap(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_NestedMapListMap(output,
 			sizeof(output), &maplistmap4, &out_len), NULL);
 
 	zassert_equal(sizeof(exp_payload_nested_mlm4), out_len, NULL);
 	zassert_mem_equal(exp_payload_nested_mlm4, output, sizeof(exp_payload_nested_mlm4), NULL);
 
-	zassert_true(cbor_encode_NestedMapListMap(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_NestedMapListMap(output,
 			sizeof(output), &maplistmap5, &out_len), NULL);
 
 	zassert_equal(sizeof(exp_payload_nested_mlm5), out_len, "%d != %d", sizeof(exp_payload_nested_mlm5), out_len);
@@ -783,27 +783,27 @@ void test_range(void)
 	uint8_t output[25];
 	size_t out_len;
 
-	zassert_true(cbor_encode_Range(output, sizeof(output), &input1,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Range(output, sizeof(output), &input1,
 				&out_len), NULL);
 	zassert_equal(sizeof(exp_payload_range1), out_len, NULL);
 	zassert_mem_equal(exp_payload_range1, output, sizeof(exp_payload_range1), NULL);
 
-	zassert_true(cbor_encode_Range(output, sizeof(output), &input2,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Range(output, sizeof(output), &input2,
 				&out_len), NULL);
 	zassert_equal(sizeof(exp_payload_range2), out_len, NULL);
 	zassert_mem_equal(exp_payload_range2, output, sizeof(exp_payload_range2), NULL);
 
-	zassert_true(cbor_encode_Range(output, sizeof(output), &input3,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Range(output, sizeof(output), &input3,
 				&out_len), NULL);
 	zassert_equal(sizeof(exp_payload_range3), out_len, NULL);
 	zassert_mem_equal(exp_payload_range3, output, sizeof(exp_payload_range3), NULL);
 
-	zassert_true(cbor_encode_Range(output, sizeof(output), &input4,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Range(output, sizeof(output), &input4,
 				&out_len), NULL);
 	zassert_equal(sizeof(exp_payload_range4), out_len, NULL);
 	zassert_mem_equal(exp_payload_range4, output, sizeof(exp_payload_range4), NULL);
 
-	zassert_false(cbor_encode_Range(output, sizeof(output), &input5_inv,
+	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_Range(output, sizeof(output), &input5_inv,
 				&out_len), NULL);
 }
 
@@ -893,31 +893,31 @@ void test_value_range(void)
 	uint8_t output[25];
 	size_t out_len;
 
-	zassert_true(cbor_encode_ValueRange(output, sizeof(output), &input1,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_ValueRange(output, sizeof(output), &input1,
 				&out_len), NULL);
 	zassert_equal(sizeof(exp_payload_value_range1), out_len, NULL);
 	zassert_mem_equal(exp_payload_value_range1, output, sizeof(exp_payload_value_range1), NULL);
 
-	zassert_true(cbor_encode_ValueRange(output, sizeof(output), &input2,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_ValueRange(output, sizeof(output), &input2,
 				&out_len), NULL);
 	zassert_equal(sizeof(exp_payload_value_range2), out_len, NULL);
 	zassert_mem_equal(exp_payload_value_range2, output, sizeof(exp_payload_value_range2), NULL);
 
-	zassert_false(cbor_encode_ValueRange(output, sizeof(output), &input3_inval,
+	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_ValueRange(output, sizeof(output), &input3_inval,
 				&out_len), NULL);
-	zassert_false(cbor_encode_ValueRange(output, sizeof(output), &input4_inval,
+	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_ValueRange(output, sizeof(output), &input4_inval,
 				&out_len), NULL);
-	zassert_false(cbor_encode_ValueRange(output, sizeof(output), &input5_inval,
+	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_ValueRange(output, sizeof(output), &input5_inval,
 				&out_len), NULL);
-	zassert_false(cbor_encode_ValueRange(output, sizeof(output), &input6_inval,
+	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_ValueRange(output, sizeof(output), &input6_inval,
 				&out_len), NULL);
-	zassert_false(cbor_encode_ValueRange(output, sizeof(output), &input7_inval,
+	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_ValueRange(output, sizeof(output), &input7_inval,
 				&out_len), NULL);
-	zassert_false(cbor_encode_ValueRange(output, sizeof(output), &input8_inval,
+	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_ValueRange(output, sizeof(output), &input8_inval,
 				&out_len), NULL);
-	zassert_false(cbor_encode_ValueRange(output, sizeof(output), &input9_inval,
+	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_ValueRange(output, sizeof(output), &input9_inval,
 				&out_len), NULL);
-	zassert_false(cbor_encode_ValueRange(output, sizeof(output), &input10_inval,
+	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_ValueRange(output, sizeof(output), &input10_inval,
 				&out_len), NULL);
 }
 
@@ -937,23 +937,23 @@ void test_single(void)
 	uint_fast32_t input_single3 = 9;
 	uint_fast32_t input_single4_inv = 10;
 
-	zassert_true(cbor_encode_SingleBstr(output, sizeof(output), &input_single0, &out_len), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_SingleBstr(output, sizeof(output), &input_single0, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_single0), out_len, NULL);
 	zassert_mem_equal(exp_payload_single0, output, sizeof(exp_payload_single0), NULL);
-	zassert_false(cbor_encode_SingleBstr(output, 5, &input_single0, &out_len), NULL);
+	zassert_equal(ZCBOR_ERR_NO_PAYLOAD, cbor_encode_SingleBstr(output, 5, &input_single0, &out_len), NULL);
 
-	zassert_true(cbor_encode_SingleInt(output, sizeof(output), &input_single1, &out_len), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_SingleInt(output, sizeof(output), &input_single1, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_single1), out_len, NULL);
 	zassert_mem_equal(exp_payload_single1, output, sizeof(exp_payload_single1), NULL);
-	zassert_false(cbor_encode_SingleInt(output, 1, &input_single1, &out_len), NULL);
-	zassert_true(cbor_encode_SingleInt(output, sizeof(output), &input_single2_ign, &out_len), NULL);
+	zassert_equal(ZCBOR_ERR_NO_PAYLOAD, cbor_encode_SingleInt(output, 1, &input_single1, &out_len), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_SingleInt(output, sizeof(output), &input_single2_ign, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_single1), out_len, NULL);
 	zassert_mem_equal(exp_payload_single1, output, sizeof(exp_payload_single1), NULL);
 
-	zassert_true(cbor_encode_SingleInt2(output, sizeof(output), &input_single3, &out_len), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_SingleInt2(output, sizeof(output), &input_single3, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_single2), out_len, NULL);
 	zassert_mem_equal(exp_payload_single2, output, sizeof(exp_payload_single2), NULL);
-	zassert_false(cbor_encode_SingleInt2(output, sizeof(output), &input_single4_inv, &out_len), NULL);
+	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_SingleInt2(output, sizeof(output), &input_single4_inv, &out_len), NULL);
 }
 
 void test_unabstracted(void)
@@ -971,12 +971,12 @@ void test_unabstracted(void)
 	uint8_t output[4];
 	size_t out_len;
 
-	zassert_true(cbor_encode_Unabstracted(output, sizeof(output),
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Unabstracted(output, sizeof(output),
 					&result_unabstracted0, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_unabstracted0), out_len, "was %d\n", out_len);
 	zassert_mem_equal(exp_payload_unabstracted0, output, sizeof(exp_payload_unabstracted0), NULL);
 
-	zassert_true(cbor_encode_Unabstracted(output, sizeof(output),
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Unabstracted(output, sizeof(output),
 					&result_unabstracted1, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_unabstracted1), out_len, NULL);
 	zassert_mem_equal(exp_payload_unabstracted1, output, sizeof(exp_payload_unabstracted1), NULL);
@@ -991,7 +991,7 @@ void test_string_overflow(void)
 	uint8_t output[10];
 	size_t out_len;
 
-	zassert_false(cbor_encode_SingleBstr(output, sizeof(output), &input_overflow0, &out_len), NULL);
+	zassert_equal(ZCBOR_ERR_NO_PAYLOAD, cbor_encode_SingleBstr(output, sizeof(output), &input_overflow0, &out_len), NULL);
 }
 
 void test_quantity_range(void)
@@ -1017,20 +1017,20 @@ void test_quantity_range(void)
 	uint8_t output[12];
 	size_t out_len;
 
-	zassert_true(cbor_encode_QuantityRange(output, sizeof(output),
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_QuantityRange(output, sizeof(output),
 			&result_qty_range1, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_qty_range1), out_len, "was %d\n", out_len);
 	zassert_mem_equal(exp_payload_qty_range1, output, sizeof(exp_payload_qty_range1), NULL);
 
-	zassert_true(cbor_encode_QuantityRange(output, sizeof(output),
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_QuantityRange(output, sizeof(output),
 			&result_qty_range2, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_qty_range2), out_len, "was %d\n", out_len);
 	zassert_mem_equal(exp_payload_qty_range2, output, sizeof(exp_payload_qty_range2), NULL);
 
-	zassert_false(cbor_encode_QuantityRange(output, sizeof(output),
+	zassert_equal(ZCBOR_ERR_ITERATIONS, cbor_encode_QuantityRange(output, sizeof(output),
 			&result_qty_range3_inv, &out_len), NULL);
 
-	zassert_false(cbor_encode_QuantityRange(output, sizeof(output),
+	zassert_equal(ZCBOR_ERR_ITERATIONS, cbor_encode_QuantityRange(output, sizeof(output),
 			&result_qty_range4_inv, &out_len), NULL);
 }
 
@@ -1059,7 +1059,7 @@ void test_doublemap(void)
 	uint8_t output[20];
 	size_t out_len;
 
-	zassert_true(cbor_encode_DoubleMap(output,
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_DoubleMap(output,
 					sizeof(output),
 					&result_doublemap, &out_len), NULL);
 	zassert_equal(out_len, sizeof(exp_payload_doublemap0), "%d != %d\n",
@@ -1100,7 +1100,7 @@ void test_floats(void)
 	input._Floats_float_32 = (float)-98765.4321;
 	input._Floats_float_64 = (double)1234567.89;
 	input._Floats_floats_count = 0;
-	zassert_true(cbor_encode_Floats(
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Floats(
 		output, sizeof(output), &input, &num_encode), NULL);
 	zassert_equal(sizeof(exp_floats_payload2), num_encode, NULL);
 	zassert_mem_equal(exp_floats_payload2, output, num_encode, NULL);
@@ -1108,7 +1108,7 @@ void test_floats(void)
 	input._Floats_float_32 = (float)1234567.89;
 	input._Floats_float_64 = (double)-98765.4321;
 	input._Floats_floats_count = 0;
-	zassert_true(cbor_encode_Floats(
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Floats(
 		output, sizeof(output), &input, &num_encode), NULL);
 	zassert_equal(sizeof(exp_floats_payload3), num_encode, NULL);
 	zassert_mem_equal(exp_floats_payload3, output, num_encode, NULL);
@@ -1119,7 +1119,7 @@ void test_floats(void)
 	input._Floats_floats[0] = (float)(123.0/456789.0);
 	input._Floats_floats[1] = (double)(123.0/456789.0);
 	input._Floats_floats[2] = (double)(-1.0/(1LL << 42));
-	zassert_true(cbor_encode_Floats(
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Floats(
 		output, sizeof(output), &input, &num_encode), NULL);
 	zassert_equal(sizeof(exp_floats_payload4), num_encode, NULL);
 	zassert_mem_equal(exp_floats_payload4, output, num_encode, NULL);

--- a/tests/encode/test3_corner_cases/testcase.yaml
+++ b/tests/encode/test3_corner_cases/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   zcbor.encode.test3_corner_cases:
     platform_allow: native_posix native_posix_64
-    tags: zcbor encode
+    tags: zcbor encode test3
   zcbor.encode.test3_corner_cases.canonical:
     platform_allow: native_posix native_posix_64
-    tags: zcbor encode
+    tags: zcbor encode canonical test3
     extra_args: CANONICAL=CANONICAL

--- a/tests/encode/test4_senml/src/main.c
+++ b/tests/encode/test4_senml/src/main.c
@@ -58,7 +58,7 @@ void test_senml(void)
 		0x00, 0x63, 'B', 'a', 'r', 0x06, 0x07, 0x04, 0xF5, END END
 	};
 
-	zassert_true(cbor_encode_lwm2m_senml(payload, sizeof(payload), &input, &encode_len), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_lwm2m_senml(payload, sizeof(payload), &input, &encode_len), NULL);
 	zassert_equal(sizeof(exp_payload1), encode_len, NULL);
 	zassert_mem_equal(payload, exp_payload1, encode_len, NULL);
 }

--- a/tests/encode/test4_senml/testcase.yaml
+++ b/tests/encode/test4_senml/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   zcbor.encode.test4_senml:
     platform_allow: native_posix native_posix_64
-    tags: zcbor encode
+    tags: zcbor encode test4
   zcbor.encode.test4_senml.canonical:
     platform_allow: native_posix native_posix_64
-    tags: zcbor encode canonical
+    tags: zcbor encode canonical test4
     extra_args: CANONICAL=CANONICAL

--- a/tests/unit/test1_unit_tests/CMakeLists.txt
+++ b/tests/unit/test1_unit_tests/CMakeLists.txt
@@ -15,3 +15,4 @@ target_sources(app PRIVATE
 
 target_include_directories(app PRIVATE ../../../include)
 
+zephyr_compile_definitions(ZCBOR_STOP_ON_ERROR)

--- a/tests/unit/test1_unit_tests/src/main.c
+++ b/tests/unit/test1_unit_tests/src/main.c
@@ -14,51 +14,49 @@ void test_int64(void)
 	uint8_t payload[100] = {0};
 	int64_t int64;
 	int32_t int32;
-	zcbor_state_t state_d;
-	zcbor_state_t state_e;
 
-	zcbor_new_state(&state_e, 1, payload, sizeof(payload), 0);
-	zcbor_new_state(&state_d, 1, payload, sizeof(payload), 10);
+	ZCBOR_STATE_E(state_e, 0, payload, sizeof(payload), 0);
+	ZCBOR_STATE_D(state_d, 0, payload, sizeof(payload), 10);
 
-	zassert_true(zcbor_int64_put(&state_e, 5), NULL);
-	zassert_false(zcbor_int64_expect(&state_d, 4), NULL);
-	zassert_false(zcbor_int64_expect(&state_d, 6), NULL);
-	zassert_false(zcbor_int64_expect(&state_d, -5), NULL);
-	zassert_false(zcbor_int64_expect(&state_d, -6), NULL);
-	zassert_true(zcbor_int64_expect(&state_d, 5), NULL);
+	zassert_true(zcbor_int64_put(state_e, 5), NULL);
+	zassert_false(zcbor_int64_expect(state_d, 4), NULL);
+	zassert_false(zcbor_int64_expect(state_d, 6), NULL);
+	zassert_false(zcbor_int64_expect(state_d, -5), NULL);
+	zassert_false(zcbor_int64_expect(state_d, -6), NULL);
+	zassert_true(zcbor_int64_expect(state_d, 5), NULL);
 
-	zassert_true(zcbor_int32_put(&state_e, 5), NULL);
-	zassert_true(zcbor_int64_expect(&state_d, 5), NULL);
+	zassert_true(zcbor_int32_put(state_e, 5), NULL);
+	zassert_true(zcbor_int64_expect(state_d, 5), NULL);
 
-	zassert_true(zcbor_int64_put(&state_e, 5), NULL);
-	zassert_true(zcbor_int32_expect(&state_d, 5), NULL);
+	zassert_true(zcbor_int64_put(state_e, 5), NULL);
+	zassert_true(zcbor_int32_expect(state_d, 5), NULL);
 
-	zassert_true(zcbor_int64_put(&state_e, 5000000000), NULL);
-	zassert_false(zcbor_int32_decode(&state_d, &int32), NULL);
-	zassert_true(zcbor_int64_decode(&state_d, &int64), NULL);
+	zassert_true(zcbor_int64_put(state_e, 5000000000), NULL);
+	zassert_false(zcbor_int32_decode(state_d, &int32), NULL);
+	zassert_true(zcbor_int64_decode(state_d, &int64), NULL);
 	zassert_equal(int64, 5000000000, NULL);
 
-	zassert_true(zcbor_int64_encode(&state_e, &int64), NULL);
-	zassert_false(zcbor_int64_expect(&state_d, 5000000001), NULL);
-	zassert_true(zcbor_int64_expect(&state_d, 5000000000), NULL);
+	zassert_true(zcbor_int64_encode(state_e, &int64), NULL);
+	zassert_false(zcbor_int64_expect(state_d, 5000000001), NULL);
+	zassert_true(zcbor_int64_expect(state_d, 5000000000), NULL);
 
-	zassert_true(zcbor_int64_put(&state_e, 0x80000000), NULL);
-	zassert_false(zcbor_int32_decode(&state_d, &int32), NULL);
-	zassert_true(zcbor_uint32_expect(&state_d, 0x80000000), NULL);
+	zassert_true(zcbor_int64_put(state_e, 0x80000000), NULL);
+	zassert_false(zcbor_int32_decode(state_d, &int32), NULL);
+	zassert_true(zcbor_uint32_expect(state_d, 0x80000000), NULL);
 
-	zassert_true(zcbor_int32_put(&state_e, -505), NULL);
-	zassert_true(zcbor_int64_expect(&state_d, -505), NULL);
+	zassert_true(zcbor_int32_put(state_e, -505), NULL);
+	zassert_true(zcbor_int64_expect(state_d, -505), NULL);
 
-	zassert_true(zcbor_int64_put(&state_e, -5000000000000), NULL);
-	zassert_false(zcbor_int64_expect(&state_d, -5000000000001), NULL);
-	zassert_false(zcbor_int64_expect(&state_d, -4999999999999), NULL);
-	zassert_false(zcbor_int64_expect(&state_d, 5000000000000), NULL);
-	zassert_false(zcbor_int64_expect(&state_d, 4999999999999), NULL);
-	zassert_true(zcbor_int64_expect(&state_d, -5000000000000), NULL);
+	zassert_true(zcbor_int64_put(state_e, -5000000000000), NULL);
+	zassert_false(zcbor_int64_expect(state_d, -5000000000001), NULL);
+	zassert_false(zcbor_int64_expect(state_d, -4999999999999), NULL);
+	zassert_false(zcbor_int64_expect(state_d, 5000000000000), NULL);
+	zassert_false(zcbor_int64_expect(state_d, 4999999999999), NULL);
+	zassert_true(zcbor_int64_expect(state_d, -5000000000000), NULL);
 
-	zassert_true(zcbor_uint64_put(&state_e, ((uint64_t)INT64_MAX + 1)), NULL);
-	zassert_false(zcbor_int64_decode(&state_d, &int64), NULL);
-	zassert_true(zcbor_uint64_expect(&state_d, ((uint64_t)INT64_MAX + 1)), NULL);
+	zassert_true(zcbor_uint64_put(state_e, ((uint64_t)INT64_MAX + 1)), NULL);
+	zassert_false(zcbor_int64_decode(state_d, &int64), NULL);
+	zassert_true(zcbor_uint64_expect(state_d, ((uint64_t)INT64_MAX + 1)), NULL);
 
 }
 
@@ -68,33 +66,31 @@ void test_uint64(void)
 	uint8_t payload[100] = {0};
 	uint64_t uint64;
 	uint32_t uint32;
-	zcbor_state_t state_d;
-	zcbor_state_t state_e;
 
-	zcbor_new_state(&state_e, 1, payload, sizeof(payload), 0);
-	zcbor_new_state(&state_d, 1, payload, sizeof(payload), 10);
+	ZCBOR_STATE_E(state_e, 0, payload, sizeof(payload), 0);
+	ZCBOR_STATE_D(state_d, 0, payload, sizeof(payload), 10);
 
-	zassert_true(zcbor_uint64_put(&state_e, 5), NULL);
-	zassert_false(zcbor_uint64_expect(&state_d, 4), NULL);
-	zassert_false(zcbor_uint64_expect(&state_d, 6), NULL);
-	zassert_false(zcbor_uint64_expect(&state_d, -5), NULL);
-	zassert_false(zcbor_uint64_expect(&state_d, -6), NULL);
-	zassert_true(zcbor_uint64_expect(&state_d, 5), NULL);
+	zassert_true(zcbor_uint64_put(state_e, 5), NULL);
+	zassert_false(zcbor_uint64_expect(state_d, 4), NULL);
+	zassert_false(zcbor_uint64_expect(state_d, 6), NULL);
+	zassert_false(zcbor_uint64_expect(state_d, -5), NULL);
+	zassert_false(zcbor_uint64_expect(state_d, -6), NULL);
+	zassert_true(zcbor_uint64_expect(state_d, 5), NULL);
 
-	zassert_true(zcbor_uint32_put(&state_e, 5), NULL);
-	zassert_true(zcbor_uint64_expect(&state_d, 5), NULL);
+	zassert_true(zcbor_uint32_put(state_e, 5), NULL);
+	zassert_true(zcbor_uint64_expect(state_d, 5), NULL);
 
-	zassert_true(zcbor_uint64_put(&state_e, 5), NULL);
-	zassert_true(zcbor_uint32_expect(&state_d, 5), NULL);
+	zassert_true(zcbor_uint64_put(state_e, 5), NULL);
+	zassert_true(zcbor_uint32_expect(state_d, 5), NULL);
 
-	zassert_true(zcbor_uint64_put(&state_e, UINT64_MAX), NULL);
-	zassert_false(zcbor_uint32_decode(&state_d, &uint32), NULL);
-	zassert_true(zcbor_uint64_decode(&state_d, &uint64), NULL);
+	zassert_true(zcbor_uint64_put(state_e, UINT64_MAX), NULL);
+	zassert_false(zcbor_uint32_decode(state_d, &uint32), NULL);
+	zassert_true(zcbor_uint64_decode(state_d, &uint64), NULL);
 	zassert_equal(uint64, UINT64_MAX, NULL);
 
-	zassert_true(zcbor_uint64_encode(&state_e, &uint64), NULL);
-	zassert_false(zcbor_uint64_expect(&state_d, (UINT64_MAX - 1)), NULL);
-	zassert_true(zcbor_uint64_expect(&state_d, UINT64_MAX), NULL);
+	zassert_true(zcbor_uint64_encode(state_e, &uint64), NULL);
+	zassert_false(zcbor_uint64_expect(state_d, (UINT64_MAX - 1)), NULL);
+	zassert_true(zcbor_uint64_expect(state_d, UINT64_MAX), NULL);
 }
 
 
@@ -111,8 +107,6 @@ void test_size64(void)
 	uint8_t *large_string = malloc(STR_SIZE);
 	struct zcbor_string tstr = {.value = large_string, .len = STR_SIZE};
 	struct zcbor_string tstr_res;
-	zcbor_state_t state_d;
-	zcbor_state_t state_e;
 
 	for (int i = 0; i < 1000; i++) {
 		large_string[i] = i % 256;
@@ -123,12 +117,12 @@ void test_size64(void)
 		large_payload[i + 9] = 0;
 	}
 
-	zcbor_new_state(&state_e, 1, large_payload, PAYL_SIZE, 0);
-	zcbor_new_state(&state_d, 1, large_payload, PAYL_SIZE, 10);
+	ZCBOR_STATE_E(state_e, 0, large_payload, PAYL_SIZE, 0);
+	ZCBOR_STATE_D(state_d, 0, large_payload, PAYL_SIZE, 10);
 
-	zassert_true(zcbor_tstr_encode(&state_e, &tstr), NULL);
-	zassert_false(zcbor_bstr_decode(&state_d, &tstr_res), NULL);
-	zassert_true(zcbor_tstr_decode(&state_d, &tstr_res), NULL);
+	zassert_true(zcbor_tstr_encode(state_e, &tstr), NULL);
+	zassert_false(zcbor_bstr_decode(state_d, &tstr_res), NULL);
+	zassert_true(zcbor_tstr_decode(state_d, &tstr_res), NULL);
 	zassert_equal(tstr_res.len, tstr.len, NULL);
 	zassert_equal_ptr(tstr_res.value, &large_payload[9], NULL);
 	zassert_mem_equal(tstr_res.value, large_string, tstr.len, NULL);

--- a/tests/unit/test1_unit_tests/src/main.c
+++ b/tests/unit/test1_unit_tests/src/main.c
@@ -173,13 +173,177 @@ void test_string_macros(void)
 }
 
 
+void test_stop_on_error(void)
+{
+	uint8_t payload[100];
+	ZCBOR_STATE_E(state_e, 3, payload, sizeof(payload), 0);
+	struct zcbor_string failing_string = {.value = NULL, .len = 1000};
+	struct zcbor_string dummy_string;
+	zcbor_state_t state_backup;
+	struct zcbor_state_constant constant_state_backup;
+
+	state_e->constant_state->stop_on_error = true;
+
+	zassert_false(zcbor_tstr_encode(state_e, &failing_string), NULL);
+	zassert_equal(ZCBOR_ERR_NO_PAYLOAD, state_e->constant_state->error, "%d\r\n", state_e->constant_state->error);
+	memcpy(&state_backup, state_e, sizeof(state_backup));
+	memcpy(&constant_state_backup, state_e->constant_state, sizeof(constant_state_backup));
+
+	/* All fail because of ZCBOR_ERR_NO_PAYLOAD */
+	zassert_false(zcbor_int32_put(state_e, 1), NULL);
+	zassert_false(zcbor_int64_put(state_e, 2), NULL);
+	zassert_false(zcbor_uint32_put(state_e, 3), NULL);
+	zassert_false(zcbor_uint64_put(state_e, 4), NULL);
+	zassert_false(zcbor_int32_encode(state_e, &(int32_t){5}), NULL);
+	zassert_false(zcbor_int64_encode(state_e, &(int64_t){6}), NULL);
+	zassert_false(zcbor_uint32_encode(state_e, &(uint32_t){7}), NULL);
+	zassert_false(zcbor_uint64_encode(state_e, &(uint64_t){8}), NULL);
+	zassert_false(zcbor_bstr_put_lit(state_e, "Hello"), NULL);
+	zassert_false(zcbor_tstr_put_lit(state_e, "World"), NULL);
+	zassert_false(zcbor_tag_encode(state_e, 9), NULL);
+	zassert_false(zcbor_bool_put(state_e, true), NULL);
+	zassert_false(zcbor_bool_encode(state_e, &(bool){false}), NULL);
+	zassert_false(zcbor_float32_put(state_e, 10.5), NULL);
+	zassert_false(zcbor_float32_encode(state_e, &(float){11.6}), NULL);
+	zassert_false(zcbor_float64_put(state_e, 12.7), NULL);
+	zassert_false(zcbor_float64_encode(state_e, &(double){13.8}), NULL);
+	zassert_false(zcbor_nil_put(state_e, NULL), NULL);
+	zassert_false(zcbor_undefined_put(state_e, NULL), NULL);
+	zassert_false(zcbor_bstr_start_encode(state_e), NULL);
+	zassert_false(zcbor_bstr_end_encode(state_e), NULL);
+	zassert_false(zcbor_list_start_encode(state_e, 1), NULL);
+	zassert_false(zcbor_map_start_encode(state_e, 0), NULL);
+	zassert_false(zcbor_map_end_encode(state_e, 0), NULL);
+	zassert_false(zcbor_list_end_encode(state_e, 1), NULL);
+	zassert_false(zcbor_multi_encode(1, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)14, 0), NULL);
+	zassert_false(zcbor_multi_encode_minmax(1, 1, &(uint_fast32_t){1}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)15, 0), NULL);
+	zassert_false(zcbor_present_encode(&(uint_fast32_t){1}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)16), NULL);
+
+
+	zassert_mem_equal(&state_backup, state_e, sizeof(state_backup), NULL);
+	zassert_mem_equal(&constant_state_backup, state_e->constant_state, sizeof(constant_state_backup), NULL);
+
+	zassert_equal(ZCBOR_ERR_NO_PAYLOAD, zcbor_pop_error(state_e), NULL);
+
+	/* All succeed since the error has been popped. */
+	zassert_true(zcbor_int32_put(state_e, 1), NULL);
+	zassert_true(zcbor_int64_put(state_e, 2), NULL);
+	zassert_true(zcbor_uint32_put(state_e, 3), NULL);
+	zassert_true(zcbor_uint64_put(state_e, 4), NULL);
+	zassert_true(zcbor_int32_encode(state_e, &(int32_t){5}), NULL);
+	zassert_true(zcbor_int64_encode(state_e, &(int64_t){6}), NULL);
+	zassert_true(zcbor_uint32_encode(state_e, &(uint32_t){7}), NULL);
+	zassert_true(zcbor_uint64_encode(state_e, &(uint64_t){8}), NULL);
+	zassert_true(zcbor_bstr_put_lit(state_e, "Hello"), NULL);
+	zassert_true(zcbor_tstr_put_lit(state_e, "World"), NULL);
+	zassert_true(zcbor_tag_encode(state_e, 9), NULL);
+	zassert_true(zcbor_tag_encode(state_e, 10), NULL);
+	zassert_true(zcbor_bool_put(state_e, true), NULL);
+	zassert_true(zcbor_bool_encode(state_e, &(bool){false}), NULL);
+	zassert_true(zcbor_float32_put(state_e, 10.5), NULL);
+	zassert_true(zcbor_float32_encode(state_e, &(float){11.6}), NULL);
+	zassert_true(zcbor_float64_put(state_e, 12.7), NULL);
+	zassert_true(zcbor_float64_encode(state_e, &(double){13.8}), NULL);
+	zassert_true(zcbor_nil_put(state_e, NULL), NULL);
+	zassert_true(zcbor_undefined_put(state_e, NULL), NULL);
+	zassert_true(zcbor_bstr_start_encode(state_e), NULL);
+	zassert_true(zcbor_bstr_end_encode(state_e), NULL);
+	zassert_true(zcbor_list_start_encode(state_e, 1), NULL);
+	zassert_true(zcbor_map_start_encode(state_e, 0), NULL);
+	zassert_true(zcbor_map_end_encode(state_e, 0), NULL);
+	zassert_true(zcbor_list_end_encode(state_e, 1), NULL);
+	zassert_true(zcbor_multi_encode(1, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)14, 0), NULL);
+	zassert_true(zcbor_multi_encode_minmax(1, 1, &(uint_fast32_t){1}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)15, 0), NULL);
+	zassert_true(zcbor_present_encode(&(uint_fast32_t){1}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)16), NULL);
+
+	ZCBOR_STATE_D(state_d, 3, payload, sizeof(payload), 30);
+	state_d->constant_state->stop_on_error = true;
+
+	zassert_false(zcbor_int32_expect(state_d, 2), NULL);
+	zassert_equal(ZCBOR_ERR_WRONG_VALUE, state_d->constant_state->error, "%d\r\n", state_d->constant_state->error);
+	memcpy(&state_backup, state_d, sizeof(state_backup));
+	memcpy(&constant_state_backup, state_d->constant_state, sizeof(constant_state_backup));
+
+	/* All fail because of ZCBOR_ERR_WRONG_VALUE */
+	zassert_false(zcbor_int32_expect(state_d, 1), NULL);
+	zassert_false(zcbor_int64_expect(state_d, 2), NULL);
+	zassert_false(zcbor_uint32_expect(state_d, 3), NULL);
+	zassert_false(zcbor_uint64_expect(state_d, 4), NULL);
+	zassert_false(zcbor_int32_decode(state_d, &(int32_t){5}), NULL);
+	zassert_false(zcbor_int64_decode(state_d, &(int64_t){6}), NULL);
+	zassert_false(zcbor_uint32_decode(state_d, &(uint32_t){7}), NULL);
+	zassert_false(zcbor_uint64_decode(state_d, &(uint64_t){8}), NULL);
+	zassert_false(zcbor_bstr_expect_lit(state_d, "Hello"), NULL);
+	zassert_false(zcbor_tstr_expect_lit(state_d, "World"), NULL);
+	zassert_false(zcbor_tag_decode(state_d, &(uint32_t){9}), NULL);
+	zassert_false(zcbor_tag_expect(state_d, 10), NULL);
+	zassert_false(zcbor_bool_expect(state_d, true), NULL);
+	zassert_false(zcbor_bool_decode(state_d, &(bool){false}), NULL);
+	zassert_false(zcbor_float32_expect(state_d, 10.5), NULL);
+	zassert_false(zcbor_float32_decode(state_d, &(float){11.6}), NULL);
+	zassert_false(zcbor_float64_expect(state_d, 12.7), NULL);
+	zassert_false(zcbor_float64_decode(state_d, &(double){13.8}), NULL);
+	zassert_false(zcbor_nil_expect(state_d, NULL), NULL);
+	zassert_false(zcbor_undefined_expect(state_d, NULL), NULL);
+	zassert_false(zcbor_bstr_start_decode(state_d, &dummy_string), NULL);
+	zassert_false(zcbor_bstr_end_decode(state_d), NULL);
+	zassert_false(zcbor_list_start_decode(state_d), NULL);
+	zassert_false(zcbor_map_start_decode(state_d), NULL);
+	zassert_false(zcbor_map_end_decode(state_d), NULL);
+	zassert_false(zcbor_list_end_decode(state_d), NULL);
+	zassert_false(zcbor_multi_decode(1, 1, &(uint_fast32_t){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)14, 0), NULL);
+	zassert_false(zcbor_int32_expect(state_d, 15), NULL);
+	zassert_false(zcbor_present_decode(&(uint_fast32_t){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)16), NULL);
+
+	zassert_mem_equal(&state_backup, state_d, sizeof(state_backup), NULL);
+	zassert_mem_equal(&constant_state_backup, state_d->constant_state, sizeof(constant_state_backup), NULL);
+
+	zassert_equal(ZCBOR_ERR_WRONG_VALUE, zcbor_pop_error(state_d), NULL);
+
+	/* All succeed since the error has been popped. */
+	zassert_true(zcbor_int32_expect(state_d, 1), NULL);
+	zassert_true(zcbor_int64_expect(state_d, 2), NULL);
+	zassert_true(zcbor_uint32_expect(state_d, 3), NULL);
+	zassert_true(zcbor_uint64_expect(state_d, 4), NULL);
+	zassert_true(zcbor_int32_decode(state_d, &(int32_t){5}), NULL);
+	zassert_true(zcbor_int64_decode(state_d, &(int64_t){6}), NULL);
+	zassert_true(zcbor_uint32_decode(state_d, &(uint32_t){7}), NULL);
+	zassert_true(zcbor_uint64_decode(state_d, &(uint64_t){8}), NULL);
+	zassert_true(zcbor_bstr_expect_lit(state_d, "Hello"), NULL);
+	zassert_true(zcbor_tstr_expect_lit(state_d, "World"), NULL);
+	zassert_true(zcbor_tag_decode(state_d, &(uint32_t){9}), NULL);
+	zassert_true(zcbor_tag_expect(state_d, 10), NULL);
+	zassert_true(zcbor_bool_expect(state_d, true), NULL);
+	zassert_true(zcbor_bool_decode(state_d, &(bool){false}), NULL);
+	zassert_true(zcbor_float32_expect(state_d, 10.5), NULL);
+	zassert_true(zcbor_float32_decode(state_d, &(float){11.6}), NULL);
+	zassert_true(zcbor_float64_expect(state_d, 12.7), NULL);
+	zassert_true(zcbor_float64_decode(state_d, &(double){13.8}), NULL);
+	zassert_true(zcbor_nil_expect(state_d, NULL), NULL);
+	zassert_true(zcbor_undefined_expect(state_d, NULL), NULL);
+	zassert_true(zcbor_bstr_start_decode(state_d, &dummy_string), NULL);
+	zassert_true(zcbor_bstr_end_decode(state_d), NULL);
+	zassert_true(zcbor_list_start_decode(state_d), NULL);
+	zassert_true(zcbor_map_start_decode(state_d), NULL);
+	zassert_true(zcbor_map_end_decode(state_d), NULL);
+	zassert_true(zcbor_list_end_decode(state_d), NULL);
+	zassert_true(zcbor_multi_decode(1, 1, &(uint_fast32_t){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)14, 0), NULL);
+	zassert_true(zcbor_int32_expect(state_d, 15), NULL);
+	zassert_true(zcbor_present_decode(&(uint_fast32_t){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)16), NULL);
+
+	/* Everything has been decoded. */
+	zassert_equal(state_e->payload, state_d->payload, NULL);
+}
+
+
 void test_main(void)
 {
 	ztest_test_suite(zcbor_unit_tests,
 			 ztest_unit_test(test_int64),
 			 ztest_unit_test(test_uint64),
 			 ztest_unit_test(test_size64),
-			 ztest_unit_test(test_string_macros)
+			 ztest_unit_test(test_string_macros),
+			 ztest_unit_test(test_stop_on_error)
 	);
 	ztest_run_test_suite(zcbor_unit_tests);
 }

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -2345,18 +2345,11 @@ class CodeGenerator(CddlXcoder):
     def public_xcode_func_sig(self):
         type_name = self.type_name()
         return f"""
-bool cbor_{self.xcode_func_name()}(
+uint_fast8_t cbor_{self.xcode_func_name()}(
 		{"const " if self.mode == "decode" else ""}uint8_t *payload, size_t payload_len,
 		{"" if self.mode == "decode" else "const "}{type_name if type_name else "void"} *{
             struct_ptr_name(self.mode)},
 		{"size_t *payload_len_out"})"""
-
-    def type_test_xcode_func_sig(self):
-        type_name = self.type_name()
-        return f"""
-__attribute__((unused)) static bool type_test_{self.xcode_func_name()}(
-		{"" if self.mode == "decode" else "const "}{type_name if type_name else "void"} *{
-            struct_ptr_name(self.mode)})"""
 
 
 class CodeRenderer():
@@ -2491,7 +2484,11 @@ static bool {xcoder.func_name}(
 				(size_t)states[0].payload - (size_t)payload);
 	}}
 
-	return ret;
+	if (!ret) {{
+		uint_fast8_t ret = zcbor_pop_error(states);
+		return (ret == ZCBOR_SUCCESS) ? ZCBOR_ERR_UNKNOWN : ret;
+	}}
+	return ZCBOR_SUCCESS;
 }}"""
 
     # Render the entire generated C file contents.


### PR DESCRIPTION
Add an error member to the state variable, which is populated whenever a function returns `false`.

Add a `stop_on_error` feature which, when enabled, allows calling several functions in a row without checking the return value, since if an error has occurred, all subsequent functions are aborted before they have side effects.

The PR is quite large, but reviewing commit by commit should work well here.