### PR TITLE
include: Add const to *ptr argument of cbor_tstr_encode_ptr

### DIFF
--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -53,13 +53,13 @@ bool zcbor_tstr_encode(zcbor_state_t *state, const struct zcbor_string *input);
  * @param[in]    string  The value to encode. A pointer to the string
  * @param[in]    len     The length of the string pointed to by @p string.
  */
-static inline bool zcbor_bstr_encode_ptr(zcbor_state_t *state, uint8_t *ptr, size_t len)
+static inline bool zcbor_bstr_encode_ptr(zcbor_state_t *state, const uint8_t *ptr, size_t len)
 {
-	return zcbor_bstr_encode(state, &(struct zcbor_string){.value = ptr, .len = len});
+	return zcbor_bstr_encode(state, &(const struct zcbor_string){.value = ptr, .len = len});
 }
-static inline bool zcbor_tstr_encode_ptr(zcbor_state_t *state, uint8_t *ptr, size_t len)
+static inline bool zcbor_tstr_encode_ptr(zcbor_state_t *state, const uint8_t *ptr, size_t len)
 {
-	return zcbor_tstr_encode(state, &(struct zcbor_string){.value = ptr, .len = len});
+	return zcbor_tstr_encode(state, &(const struct zcbor_string){.value = ptr, .len = len});
 }
 
 /** Encode a string literal as a bstr/tstr.


### PR DESCRIPTION
The function is often, indirectly, used to encode constant strings
and without the change compiler issues warnings on discarded
const qualifiers.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>