### PR TITLE
Make the C library handle missing constant_state

### DIFF
--- a/include/zcbor_decode.h
+++ b/include/zcbor_decode.h
@@ -304,17 +304,13 @@ bool zcbor_present_decode(uint_fast32_t *present,
 		void *result);
 
 /** See @ref zcbor_new_state() */
-bool zcbor_new_decode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
+void zcbor_new_decode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
 		const uint8_t *payload, size_t payload_len, uint_fast32_t elem_count);
 
 /** Convenience macro for declaring and initializing a state with backups.
  *
  *  This gives you a state variable named @p name. The variable functions like
  *  a pointer.
- *
- *  The return value from @ref zcbor_new_encode_state can be safely ignored
- *  because the only error condition is n_states < 2, and this macro adds 2 to
- *  num_backups to get n_states, so it can never be < 2.
  *
  *  @param[in]  name          The name of the new state variable.
  *  @param[in]  num_backups   The number of backup slots to keep in the state.
@@ -325,7 +321,7 @@ bool zcbor_new_decode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
 #define ZCBOR_STATE_D(name, num_backups, payload, payload_size, elem_count) \
 zcbor_state_t name[((num_backups) + 2)]; \
 do { \
-	(void)zcbor_new_decode_state(name, ARRAY_SIZE(name), payload, payload_size, elem_count); \
+	zcbor_new_decode_state(name, ARRAY_SIZE(name), payload, payload_size, elem_count); \
 } while(0)
 
 #endif /* ZCBOR_DECODE_H__ */

--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -248,17 +248,13 @@ bool zcbor_present_encode(const uint_fast32_t *present,
 		const void *input);
 
 /** See @ref zcbor_new_state() */
-bool zcbor_new_encode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
+void zcbor_new_encode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
 		uint8_t *payload, size_t payload_len, uint_fast32_t elem_count);
 
 /** Convenience macro for declaring and initializing a state with backups.
  *
  *  This gives you a state variable named @p name. The variable functions like
  *  a pointer.
- *
- *  The return value from @ref zcbor_new_encode_state can be safely ignored
- *  because the only error condition is n_states < 2, and this macro adds 2 to
- *  num_backups to get n_states, so it can never be < 2.
  *
  *  @param[in]  name          The name of the new state variable.
  *  @param[in]  num_backups   The number of backup slots to keep in the state.
@@ -269,7 +265,7 @@ bool zcbor_new_encode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
 #define ZCBOR_STATE_E(name, num_backups, payload, payload_size, elem_count) \
 zcbor_state_t name[((num_backups) + 2)]; \
 do { \
-	(void)zcbor_new_encode_state(name, ARRAY_SIZE(name), payload, payload_size, elem_count); \
+	zcbor_new_encode_state(name, ARRAY_SIZE(name), payload, payload_size, elem_count); \
 } while(0)
 
 #endif /* ZCBOR_ENCODE_H__ */

--- a/src/zcbor_common.c
+++ b/src/zcbor_common.c
@@ -123,7 +123,7 @@ bool zcbor_union_end_code(zcbor_state_t *state)
 	return true;
 }
 
-bool zcbor_new_state(zcbor_state_t *state_array, uint_fast32_t n_states,
+void zcbor_new_state(zcbor_state_t *state_array, uint_fast32_t n_states,
 		const uint8_t *payload, size_t payload_len, uint_fast32_t elem_count)
 {
 	state_array[0].payload = payload;
@@ -134,7 +134,7 @@ bool zcbor_new_state(zcbor_state_t *state_array, uint_fast32_t n_states,
 	state_array[0].constant_state = NULL;
 
 	if(n_states < 2) {
-		return false;
+		return;
 	}
 
 	/* Use the last state as a struct zcbor_state_constant object. */
@@ -149,7 +149,6 @@ bool zcbor_new_state(zcbor_state_t *state_array, uint_fast32_t n_states,
 	if (n_states > 2) {
 		state_array[0].constant_state->backup_list = &state_array[1];
 	}
-	return true;
 }
 
 void zcbor_update_state(zcbor_state_t *state,

--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -907,8 +907,8 @@ bool zcbor_present_decode(uint_fast32_t *present,
 }
 
 
-bool zcbor_new_decode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
+void zcbor_new_decode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
 		const uint8_t *payload, size_t payload_len, uint_fast32_t elem_count)
 {
-	return zcbor_new_state(state_array, n_states, payload, payload_len, elem_count);
+	zcbor_new_state(state_array, n_states, payload, payload_len, elem_count);
 }

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -583,8 +583,8 @@ bool zcbor_present_encode(const uint_fast32_t *present,
 }
 
 
-bool zcbor_new_encode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
+void zcbor_new_encode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
 		uint8_t *payload, size_t payload_len, uint_fast32_t elem_count)
 {
-	return zcbor_new_state(state_array, n_states, payload, payload_len, elem_count);
+	zcbor_new_state(state_array, n_states, payload, payload_len, elem_count);
 }

--- a/tests/unit/test1_unit_tests/src/main.c
+++ b/tests/unit/test1_unit_tests/src/main.c
@@ -67,30 +67,32 @@ void test_uint64(void)
 	uint64_t uint64;
 	uint32_t uint32;
 
-	ZCBOR_STATE_E(state_e, 0, payload, sizeof(payload), 0);
-	ZCBOR_STATE_D(state_d, 0, payload, sizeof(payload), 10);
+	zcbor_state_t state_e;
+	zcbor_new_state(&state_e, 1, payload, sizeof(payload), 0);
+	zcbor_state_t state_d;
+	zcbor_new_state(&state_d, 1, payload, sizeof(payload), 10);
 
-	zassert_true(zcbor_uint64_put(state_e, 5), NULL);
-	zassert_false(zcbor_uint64_expect(state_d, 4), NULL);
-	zassert_false(zcbor_uint64_expect(state_d, 6), NULL);
-	zassert_false(zcbor_uint64_expect(state_d, -5), NULL);
-	zassert_false(zcbor_uint64_expect(state_d, -6), NULL);
-	zassert_true(zcbor_uint64_expect(state_d, 5), NULL);
+	zassert_true(zcbor_uint64_put(&state_e, 5), NULL);
+	zassert_false(zcbor_uint64_expect(&state_d, 4), NULL);
+	zassert_false(zcbor_uint64_expect(&state_d, 6), NULL);
+	zassert_false(zcbor_uint64_expect(&state_d, -5), NULL);
+	zassert_false(zcbor_uint64_expect(&state_d, -6), NULL);
+	zassert_true(zcbor_uint64_expect(&state_d, 5), NULL);
 
-	zassert_true(zcbor_uint32_put(state_e, 5), NULL);
-	zassert_true(zcbor_uint64_expect(state_d, 5), NULL);
+	zassert_true(zcbor_uint32_put(&state_e, 5), NULL);
+	zassert_true(zcbor_uint64_expect(&state_d, 5), NULL);
 
-	zassert_true(zcbor_uint64_put(state_e, 5), NULL);
-	zassert_true(zcbor_uint32_expect(state_d, 5), NULL);
+	zassert_true(zcbor_uint64_put(&state_e, 5), NULL);
+	zassert_true(zcbor_uint32_expect(&state_d, 5), NULL);
 
-	zassert_true(zcbor_uint64_put(state_e, UINT64_MAX), NULL);
-	zassert_false(zcbor_uint32_decode(state_d, &uint32), NULL);
-	zassert_true(zcbor_uint64_decode(state_d, &uint64), NULL);
+	zassert_true(zcbor_uint64_put(&state_e, UINT64_MAX), NULL);
+	zassert_false(zcbor_uint32_decode(&state_d, &uint32), NULL);
+	zassert_true(zcbor_uint64_decode(&state_d, &uint64), NULL);
 	zassert_equal(uint64, UINT64_MAX, NULL);
 
-	zassert_true(zcbor_uint64_encode(state_e, &uint64), NULL);
-	zassert_false(zcbor_uint64_expect(state_d, (UINT64_MAX - 1)), NULL);
-	zassert_true(zcbor_uint64_expect(state_d, UINT64_MAX), NULL);
+	zassert_true(zcbor_uint64_encode(&state_e, &uint64), NULL);
+	zassert_false(zcbor_uint64_expect(&state_d, (UINT64_MAX - 1)), NULL);
+	zassert_true(zcbor_uint64_expect(&state_d, UINT64_MAX), NULL);
 }
 
 


### PR DESCRIPTION
This means no error can occur during _new_state() which makes
could be scary if the error was not caught (the code would start
dereferencing NULL.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>