### PR TITLE
Switch to Python 3.10 for the helptext generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ code/convert --help to see their respective specialized arguments.
 positional arguments:
   {code,convert}
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --version             show program's version number and exit
   -c CDDL, --cddl CDDL  Path to one or more input CDDL file(s). Passing
@@ -439,7 +439,7 @@ referencing types, since the C type cannot be self referencing.
 
 This script requires 'regex' for lookaround functionality not present in 're'.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --output-c OUTPUT_C, --oc OUTPUT_C
                         Path to output C file. If both --decode and --encode
@@ -526,7 +526,7 @@ elements, e.g. {"tag": 1234, "value": ["tagged string within list"]}
 'undefined' is specified as a list with a single text entry:
 "zcbor_undefined".
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -i INPUT, --input INPUT
                         Input data file. The option --input-as specifies how

--- a/add_helptext.py
+++ b/add_helptext.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
 
     for cmd in commands:
         stdout, _ = Popen(cmd, stdout=PIPE).communicate()
-        assert b"arguments:" in stdout, f"Seems like something went wrong: {stdout.decode('utf-8')}"
+        assert b"options:" in stdout, f"Seems like something went wrong: {stdout.decode('utf-8')}"
         output += f"""
 {" ".join(cmd)}
 {"-" * len(" ".join(cmd))}

--- a/tests/scripts/run_tests.py
+++ b/tests/scripts/run_tests.py
@@ -562,7 +562,7 @@ class TestOptional(TestCase):
 
 
 class TestREADME(TestCase):
-    @skipIf(list(map(int, python_version_tuple())) >= [3, 10, 0], "Skip on Python >= 3.10 because of different wording in argparse output.")
+    @skipIf(list(map(int, python_version_tuple())) < [3, 10, 0], "Skip on Python < 3.10 because of different wording in argparse output.")
     @skipIf(platform.startswith("win"), "Skip on Windows because of path/newline issues.")
     def test_cli_doc(self):
         add_help = Popen(["python3", p_add_helptext, "--check"])


### PR DESCRIPTION
It has slightly different wording ("options" instead of "optional arguments").
Switch test to skip on versions < 3.10.
Change assert in add_helptext.py to the new wording.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>