### PR TITLE
include: Define variables to avoid rvalue address errors

### DIFF
--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -55,11 +55,15 @@ bool zcbor_tstr_encode(zcbor_state_t *state, const struct zcbor_string *input);
  */
 static inline bool zcbor_bstr_encode_ptr(zcbor_state_t *state, const uint8_t *ptr, size_t len)
 {
-	return zcbor_bstr_encode(state, &(const struct zcbor_string){.value = ptr, .len = len});
+	const struct zcbor_string zs = { .value = ptr, .len = len };
+
+	return zcbor_bstr_encode(state, &zs);
 }
 static inline bool zcbor_tstr_encode_ptr(zcbor_state_t *state, const uint8_t *ptr, size_t len)
 {
-	return zcbor_tstr_encode(state, &(const struct zcbor_string){.value = ptr, .len = len});
+	const struct zcbor_string zs = { .value = ptr, .len = len };
+
+	return zcbor_tstr_encode(state, &zs);
 }
 
 /** Encode a string literal as a bstr/tstr.


### PR DESCRIPTION
Change affects zcbor_bstr_encode_ptr and zcbor_tstr_encode_ptr:
the in-call definition of structure works fine, but may cause
"taking address of rvalue" errors with some compiler configurations.
This commit moves the definition out of function invocation
and defines intermediate variable to prevent possible compilation
errors (or warnings).

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

To prevent errors like this (reported by C++ compilation):
```
modules/lib/zcbor/include/zcbor_encode.h:65:62: error: taking address of rvalue [-fpermissive]
   65 |  return zcbor_tstr_encode(state, &(const struct zcbor_string){.value = ptr, .len = len});
      |	
```