### PR TITLE
Fix the union uint optimization

### DIFF
--- a/tests/cases/manifest2.cddl
+++ b/tests/cases/manifest2.cddl
@@ -202,7 +202,7 @@ SUIT_Parameters //= (suit-parameter-image-size => uint)
 SUIT_Parameters //= (suit-parameter-uri-list => bstr .cbor SUIT_Component_URI_List)
 SUIT_Parameters //= (suit-parameter-custom => int/bool/tstr/bstr)
 
-SUIT_Component_URI = [priority: int, uri: tstr]
+SUIT_Component_URI = [priority: int, URI: tstr]
 SUIT_Component_URI_List = [ + SUIT_Component_URI ]
 SUIT_Priority_Parameter = [priority: int, parameters: { + SUIT_Parameters }]
 SUIT_Priority_Parameter_List = [ + SUIT_Priority_Parameter ]

--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -768,6 +768,11 @@ void test_map(void)
 
 	struct Map map;
 
+	zassert_equal(sizeof(map.union_choice), sizeof(int32_t),
+		"The union_int optimization relies on enums being 4 bytes.");
+	zassert_equal(_union_nintuint, -8,
+		"The union_int optimization seems to not be working.\r\n");
+
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Map(payload_map1, sizeof(payload_map1),
 			&map, NULL), NULL);
 	zassert_false(map.listkey, NULL);

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -1158,9 +1158,9 @@ class CddlXcoder(CddlParser):
 
     def all_children_uint_disambiguated(self):
         values = set(child.uint_val() for child in self.value)
-        bit_sizes = set(child.bit_size() for child in self.value)
-        return (len(values) == len(self.value)) and None not in values \
-            and (len(bit_sizes) == 1) and None not in bit_sizes
+        retval = (len(values) == len(self.value)) and None not in values \
+            and max(values) < 0x80000000 and min(values) >= -0x80000000
+        return retval
 
     # Name of the "present" variable for this element.
     def present_var_name(self):

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -879,14 +879,20 @@ class CddlParser:
         # Validation of this element.
         if self.type in ["LIST", "MAP"]:
             none_keys = [child for child in self.value if not child.elem_has_key()]
+            child_keys = [child for child in self.value if child not in none_keys]
             if self.type == "MAP" and none_keys:
                 raise TypeError(
-                    "Map entry must have key: " + str(none_keys) + " pointing to "
+                    "Map member(s) must have key: " + str(none_keys) + " pointing to "
                     + str(
                         [self.my_types[elem.value] for elem in none_keys
                             if elem.type == "OTHER"]))
-            if self.type == "LIST" and len(none_keys) != len(self.value):
-                raise TypeError("List entry cannot have keys")
+            if self.type == "LIST" and child_keys:
+                raise TypeError(
+                    str(self) + linesep
+                    + "List member(s) cannot have key: " + str(child_keys) + " pointing to "
+                    + str(
+                        [self.my_types[elem.value] for elem in child_keys
+                            if elem.type == "OTHER"]))
         if self.type == "OTHER":
             if self.value not in self.my_types.keys() or not isinstance(
                     self.my_types[self.value], type(self)):

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -34,6 +34,21 @@ PRELUDE_path = Path(P_SCRIPT, "cddl", "prelude.cddl")
 
 __version__ = VERSION_path.read_text().strip()
 
+UINT8_MAX = 0xFF
+UINT16_MAX = 0xFFFF
+UINT32_MAX = 0xFFFFFFFF
+UINT64_MAX = 0xFFFFFFFFFFFFFFFF
+
+INT8_MAX = 0x7F
+INT16_MAX = 0x7FFF
+INT32_MAX = 0x7FFFFFFF
+INT64_MAX = 0x7FFFFFFFFFFFFFFF
+
+INT8_MIN = -0x80
+INT16_MIN = -0x8000
+INT32_MIN = -0x80000000
+INT64_MIN = -0x8000000000000000
+
 
 def is_relative_to(path1, path2):
     try:
@@ -68,13 +83,13 @@ else:
 def sizeof(num):
     if num <= 23:
         return 0
-    elif num < 0x100:
+    elif num <= UINT8_MAX:
         return 1
-    elif num < 0x10000:
+    elif num <= UINT16_MAX:
         return 2
-    elif num < 0x100000000:
+    elif num <= UINT32_MAX:
         return 4
-    elif num < 0x10000000000000000:
+    elif num <= UINT64_MAX:
         return 8
     else:
         raise ValueError("Number too large (more than 64 bits).")
@@ -1159,7 +1174,7 @@ class CddlXcoder(CddlParser):
     def all_children_int_disambiguated(self):
         values = set(child.int_val() for child in self.value)
         retval = (len(values) == len(self.value)) and None not in values \
-            and max(values) < 0x80000000 and min(values) >= -0x80000000
+            and max(values) <= INT32_MAX and min(values) >= INT32_MIN
         return retval
 
     # Name of the "present" variable for this element.
@@ -1752,10 +1767,10 @@ class CodeGenerator(CddlXcoder):
 
                 for v in [self.value or 0, self.max_value or 0, self.min_value or 0]:
                     if self.type == "UINT":
-                        if (v > 0xFFFFFFFF):
+                        if (v > UINT32_MAX):
                             bit_size = 64
                     else:
-                        if (v > 0x7FFFFFFF) or (v < -0x80000000):
+                        if (v > INT32_MAX) or (v < INT32_MIN):
                             bit_size = 64
         return bit_size
 
@@ -2251,10 +2266,10 @@ class CodeGenerator(CddlXcoder):
     # Appends ULL or LL if a value exceeding 32-bits is used
     def value_suffix(self, value):
         if self.type == "INT" or self.type == "NINT":
-            if value > 2147483648 or value < -2147483647:
+            if value > INT32_MAX or value <= INT32_MIN:
                 return "LL"
         elif self.type == "UINT":
-            if value > 4294967295:
+            if value > UINT32_MAX:
                 return "ULL"
 
         return ""

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -318,7 +318,7 @@ class CddlParser:
             or (next((key for key, value in self.my_control_groups.items() if value == self), None))
             or ("_" + self.value if self.type == "OTHER" else None)
             or ("_" + self.value[0].get_base_name()
-                if self.type in ["LIST", "GROUP"] and self.value is not None else None)
+                if self.type in ["LIST", "GROUP"] and self.value else None)
             or ((self.cbor.value + "_bstr")
                 if self.cbor and self.cbor.type in ["TSTR", "OTHER"] else None)
             or ((self.key.generate_base_name() + self.type.lower()) if self.key else None)


### PR DESCRIPTION
Brings back the optimization for decoding unions where all options start with a specific uint, e.g. an id. The optimization involves decoding the integer first, directly into the enum variable, and then decoding the union. This optimization was never applied to generated after a bug was introduced. This PR fixes that bug and also expands the feature to allow negative integers as well.