### PR TITLE
Add zcbor_peek_error for reading error value

### DIFF
--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -296,6 +296,16 @@ static inline int zcbor_pop_error(zcbor_state_t *state)
 	return err;
 }
 
+/** Look at current error state without altering it */
+static inline int zcbor_peek_error(const zcbor_state_t *state)
+{
+	if (!state->constant_state) {
+		return ZCBOR_SUCCESS;
+	} else {
+		return state->constant_state->error;
+	}
+}
+
 /** Write the provided error to the error state. */
 static inline void zcbor_error(zcbor_state_t *state, int err)
 {

--- a/tests/unit/test1_unit_tests/src/main.c
+++ b/tests/unit/test1_unit_tests/src/main.c
@@ -225,7 +225,9 @@ void test_stop_on_error(void)
 	zassert_mem_equal(&state_backup, state_e, sizeof(state_backup), NULL);
 	zassert_mem_equal(&constant_state_backup, state_e->constant_state, sizeof(constant_state_backup), NULL);
 
+	zassert_equal(ZCBOR_ERR_NO_PAYLOAD, zcbor_peek_error(state_e), NULL);
 	zassert_equal(ZCBOR_ERR_NO_PAYLOAD, zcbor_pop_error(state_e), NULL);
+	zassert_equal(ZCBOR_SUCCESS, zcbor_peek_error(state_e), NULL);
 
 	/* All succeed since the error has been popped. */
 	zassert_true(zcbor_int32_put(state_e, 1), NULL);


### PR DESCRIPTION
Added zcbor_peek_error to allow checking error code without
directly accessing zcbor_state_t type object.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>