### PR TITLE
include: Correct parameter name to align with other definitions

### DIFF
--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -30,7 +30,7 @@
 /** Encode a pint/nint. */
 bool zcbor_int32_put(zcbor_state_t *state, int32_t input);
 bool zcbor_int64_put(zcbor_state_t *state, int64_t input);
-bool zcbor_uint32_put(zcbor_state_t *state, uint32_t result);
+bool zcbor_uint32_put(zcbor_state_t *state, uint32_t input);
 bool zcbor_uint64_put(zcbor_state_t *state, uint64_t input);
 
 /** Encode a pint/nint from a pointer.
@@ -39,7 +39,7 @@ bool zcbor_uint64_put(zcbor_state_t *state, uint64_t input);
  */
 bool zcbor_int32_encode(zcbor_state_t *state, const int32_t *input);
 bool zcbor_int64_encode(zcbor_state_t *state, const int64_t *input);
-bool zcbor_uint32_encode(zcbor_state_t *state, const uint32_t *result);
+bool zcbor_uint32_encode(zcbor_state_t *state, const uint32_t *input);
 bool zcbor_uint64_encode(zcbor_state_t *state, const uint64_t *input);
 
 /** Encode a bstr. */


### PR DESCRIPTION
Cosmetic correction of function parameter name.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>