### PR TITLE
Add support for encoding/decoding size_t

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@ Any new bugs, requests, or missing features should be reported as [Github issues
  * Make it easier to initialize zcbor_state_t objects: Allow single states as input to zcbor_new_state() and remove return value.
  * Make zcbor_list/map_end_encode() more robust to wrong max_num arguments (when ZCBOR_CANONICAL is enabled).
  * Add zcbor_peek_error() for reading the error value without clearing it.
+ * Add zcbor_size_put/encode/decode/expect functions, to allow directly encoding and decoding size_t type variables.
 
 ### Tests
  * Test on multiple Python versions

--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -74,6 +74,14 @@ do { \
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 #endif
 
+#if SIZE_MAX <= UINT64_MAX
+/** The ZCBOR_SUPPORTS_SIZE_T will be defined if processing of size_t type variables directly
+ * with zcbor_size_ functions is supported.
+**/
+#define ZCBOR_SUPPORTS_SIZE_T
+#else
+#warning "zcbor: Unsupported size_t encoding size"
+#endif
 
 struct zcbor_state_constant;
 

--- a/include/zcbor_decode.h
+++ b/include/zcbor_decode.h
@@ -34,6 +34,7 @@ bool zcbor_int32_decode(zcbor_state_t *state, int32_t *result);
 bool zcbor_int64_decode(zcbor_state_t *state, int64_t *result);
 bool zcbor_uint32_decode(zcbor_state_t *state, uint32_t *result);
 bool zcbor_uint64_decode(zcbor_state_t *state, uint64_t *result);
+bool zcbor_size_decode(zcbor_state_t *state, size_t *result);
 
 /** The following applies to all _expect() functions that don't have docs.
  *
@@ -49,6 +50,7 @@ bool zcbor_int32_expect(zcbor_state_t *state, int32_t result);
 bool zcbor_int64_expect(zcbor_state_t *state, int64_t result);
 bool zcbor_uint32_expect(zcbor_state_t *state, uint32_t result);
 bool zcbor_uint64_expect(zcbor_state_t *state, uint64_t result);
+bool zcbor_size_expect(zcbor_state_t *state, size_t result);
 
 /** Consume and expect a pint with a certain value, within a union.
  *

--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -32,6 +32,7 @@ bool zcbor_int32_put(zcbor_state_t *state, int32_t input);
 bool zcbor_int64_put(zcbor_state_t *state, int64_t input);
 bool zcbor_uint32_put(zcbor_state_t *state, uint32_t input);
 bool zcbor_uint64_put(zcbor_state_t *state, uint64_t input);
+bool zcbor_size_put(zcbor_state_t *state, size_t input);
 
 /** Encode a pint/nint from a pointer.
  *
@@ -41,6 +42,7 @@ bool zcbor_int32_encode(zcbor_state_t *state, const int32_t *input);
 bool zcbor_int64_encode(zcbor_state_t *state, const int64_t *input);
 bool zcbor_uint32_encode(zcbor_state_t *state, const uint32_t *input);
 bool zcbor_uint64_encode(zcbor_state_t *state, const uint64_t *input);
+bool zcbor_size_encode(zcbor_state_t *state, const size_t *input);
 
 /** Encode a bstr. */
 bool zcbor_bstr_encode(zcbor_state_t *state, const struct zcbor_string *input);

--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -267,6 +267,14 @@ bool zcbor_uint64_decode(zcbor_state_t *state, uint64_t *result)
 }
 
 
+#ifdef ZCBOR_SUPPORTS_SIZE_T
+bool zcbor_size_decode(zcbor_state_t *state, size_t *result)
+{
+	return value_extract(state, result, sizeof(size_t));
+}
+#endif
+
+
 bool zcbor_uint32_expect(zcbor_state_t *state, uint32_t result)
 {
 	return zcbor_uint64_expect(state, result);
@@ -286,6 +294,14 @@ bool zcbor_uint64_expect(zcbor_state_t *state, uint64_t result)
 	}
 	return true;
 }
+
+
+#ifdef ZCBOR_SUPPORTS_SIZE_T
+bool zcbor_size_expect(zcbor_state_t *state, size_t result)
+{
+	return zcbor_uint64_expect(state, result);
+}
+#endif
 
 
 static bool str_start_decode(zcbor_state_t *state,

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -233,6 +233,19 @@ bool zcbor_uint64_put(zcbor_state_t *state, uint64_t input)
 }
 
 
+#ifdef ZCBOR_SUPPORTS_SIZE_T
+bool zcbor_size_put(zcbor_state_t *state, size_t input)
+{
+	return zcbor_uint64_put(state, input);
+}
+
+
+bool zcbor_size_encode(zcbor_state_t *state, const size_t *input)
+{
+	return zcbor_size_put(state, *input);
+}
+#endif
+
 static bool str_start_encode(zcbor_state_t *state,
 		const struct zcbor_string *input, zcbor_major_type_t major_type)
 {


### PR DESCRIPTION
Add support for encoding/decoding size_t

The commit adds functions that allow to encode/decode size_t
with no need to know size_t real type.
In rare event where the size_t decoding/encoding functions can not
be generated, compilation warning will be issued and no function
definitions will be provided.
When architecture supports size_t encoding ZCBOR_SUPPORTS_SIZE_T
will be defined.


Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>