### PR TITLE
tests: Fix an error in manifest3.cddl (collision with 'uri')

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@ Any new bugs, requests, or missing features should be reported as [Github issues
 ## Improvements:
 
 ## Bugfixes:
+ * tests: Fix an error in manifest3.cddl (encode/test1) (naming collision with 'uri')
 
 ## Unsupported CDDL features
 Not all features outlined in the [CDDL spec](https://datatracker.ietf.org/doc/html/rfc8610) are supported by zcbor.

--- a/tests/cases/manifest3.cddl
+++ b/tests/cases/manifest3.cddl
@@ -226,7 +226,7 @@ SUIT_Parameters //= (suit-parameter-uri-list
     => bstr .cbor SUIT_Component_URI_List)
 SUIT_Parameters //= (suit-parameter-custom => int/bool/tstr/bstr)
 
-SUIT_Component_URI_List = [ + [priority: int, uri: tstr] ]
+SUIT_Component_URI_List = [ + [priority: int, URI: tstr] ]
 
 SUIT_Encryption_Info = COSE_Encrypt_Tagged/COSE_Encrypt0_Tagged
 SUIT_Compression_Info = {


### PR DESCRIPTION
Related to 695af474f1818cdecae40692b1401b83b1599cde
This was missed in CI because of change to twister in Zephyr.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>