### PR TITLE
decoder: define local variables to avoid rvalue address errors

### DIFF
--- a/include/zcbor_decode.h
+++ b/include/zcbor_decode.h
@@ -75,14 +75,14 @@ bool zcbor_tstr_expect(zcbor_state_t *state, struct zcbor_string *result);
 static inline bool zcbor_bstr_expect_ptr(zcbor_state_t *state, uint8_t *ptr, size_t len)
 {
     struct zcbor_string zs = { .value = ptr, .len = len };
-
-	return zcbor_bstr_expect(state, &zs);
+    
+    return zcbor_bstr_expect(state, &zs);
 }
 static inline bool zcbor_tstr_expect_ptr(zcbor_state_t *state, uint8_t *ptr, size_t len)
 {
-	struct zcbor_string zs = { .value = ptr, .len = len };
-
-	return zcbor_tstr_expect(state, &zs);
+    struct zcbor_string zs = { .value = ptr, .len = len };
+	
+    return zcbor_tstr_expect(state, &zs);
 }
 
 

--- a/include/zcbor_decode.h
+++ b/include/zcbor_decode.h
@@ -74,11 +74,15 @@ bool zcbor_tstr_expect(zcbor_state_t *state, struct zcbor_string *result);
  */
 static inline bool zcbor_bstr_expect_ptr(zcbor_state_t *state, uint8_t *ptr, size_t len)
 {
-	return zcbor_bstr_expect(state, &(struct zcbor_string){.value = ptr, .len = len});
+    struct zcbor_string zs = { .value = ptr, .len = len };
+
+	return zcbor_bstr_expect(state, &zs);
 }
 static inline bool zcbor_tstr_expect_ptr(zcbor_state_t *state, uint8_t *ptr, size_t len)
 {
-	return zcbor_tstr_expect(state, &(struct zcbor_string){.value = ptr, .len = len});
+	struct zcbor_string zs = { .value = ptr, .len = len };
+
+	return zcbor_tstr_expect(state, &zs);
 }
 
 


### PR DESCRIPTION
This is similiar fix as it was done for encoder part in #218 

