### PR TITLE
.github: Refactor Github action to use more of strategy: matrix

### DIFF
--- a/.github/actions/install_zcbor/action.yaml
+++ b/.github/actions/install_zcbor/action.yaml
@@ -1,0 +1,30 @@
+inputs:
+  zcbor_package:
+    description: 'How to install zcbor'
+    required: false
+    default: 'bdist_wheel'
+runs:
+  using: 'composite'
+  steps:
+
+    - name: Install west and dependencies
+      shell: sh
+      run: |
+        pip3 install -U pip
+        pip3 install -U setuptools
+        pip3 install -U -r scripts/requirements.txt
+
+    - name: Install zcbor package
+      if: ${{ inputs.zcbor_package == 'bdist_wheel' }}
+      shell: sh
+      run: |
+        python3 setup.py sdist bdist_wheel
+        pip3 install dist/zcbor-*.tar.gz
+        pip3 uninstall -y zcbor
+        pip3 install dist/zcbor-*.whl
+
+    - name: Install zcbor package
+      if: ${{ inputs.zcbor_package == 'setup_install' }}
+      shell: sh
+      run: |
+        python3 setup.py install

--- a/.github/actions/prepare_and_run_tests/action.yaml
+++ b/.github/actions/prepare_and_run_tests/action.yaml
@@ -1,41 +1,15 @@
 inputs:
-  tags:
-    description: 'Tags to be passed to twister when running tests.'
+  twister_arguments:
+    description: 'Twister arguments.'
     required: false
     default: ''
-  asserts:
-    description: 'asserts'
+  zephyr_toolchain:
+    description: 'Which zephyr toolchain to use.'
     required: false
-    default: 'none'
-  zcbor_package:
-    description: 'How to install zcbor'
-    required: false
-    default: 'bdist_wheel'
+    default: 'host'
 runs:
   using: 'composite'
   steps:
-
-    - name: Install west and dependencies
-      shell: sh
-      run: |
-        pip3 install -U pip
-        pip3 install -U setuptools
-        pip3 install -U -r scripts/requirements.txt
-
-    - name: Install zcbor package
-      if: ${{ inputs.zcbor_package == 'bdist_wheel' }}
-      shell: sh
-      run: |
-        python3 setup.py sdist bdist_wheel
-        pip3 install dist/zcbor-*.tar.gz
-        pip3 uninstall -y zcbor
-        pip3 install dist/zcbor-*.whl
-
-    - name: Install zcbor package
-      if: ${{ inputs.zcbor_package == 'setup_install' }}
-      shell: sh
-      run: |
-        python3 setup.py install
 
     - name: Install packages
       shell: sh
@@ -44,13 +18,11 @@ runs:
         sudo apt install -y gcc-multilib ninja-build
 
     - name: Clone zephyr
-      if: ${{ inputs.asserts != 'none' }}
       shell: sh
       run: |
         git clone --depth 1 https://github.com/zephyrproject-rtos/zephyr zephyr-clone
 
     - name: West init
-      if: ${{ inputs.asserts != 'none' }}
       shell: sh
       run: |
         export ZEPHYR_BASE=$(pwd)/zephyr-clone
@@ -59,7 +31,6 @@ runs:
         west init -l $ZEPHYR_BASE
 
     - name: Install twister dependencies
-      if: ${{ inputs.asserts != 'none' }}
       working-directory: tests
       shell: sh
       run: |
@@ -67,20 +38,27 @@ runs:
         pip3 install -U -r $ZEPHYR_BASE/scripts/requirements-build-test.txt
         pip3 install -U -r $ZEPHYR_BASE/scripts/requirements-run-test.txt
 
-    - name: Run tests
-      if: ${{ inputs.asserts == 'without' || inputs.asserts == 'both' }}
-      working-directory: tests
+    - name: Install Zephyr SDK (ARM)
+      if: ${{ inputs.zephyr_toolchain == 'zephyr' }}
       shell: sh
       run: |
-        export ZEPHYR_BASE=$(pwd)/../zephyr-clone
-        export ZEPHYR_TOOLCHAIN_VARIANT=host
-        $ZEPHYR_BASE/scripts/twister -i -T . -W --platform native_posix --platform native_posix_64 ${{ inputs.tags }}
+        sudo apt install qemu qemu-system-arm
+        ZEPHYR_SDK_VERSION=0.14.2
+        wget -nv https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION/zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-x86_64_minimal.tar.gz
+        wget -nv https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION/toolchain_linux-x86_64_arm-zephyr-eabi.tar.gz
+        wget -nv -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION/sha256.sum | shasum --check --ignore-missing
+        tar -xf zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-x86_64_minimal.tar.gz
+        mv zephyr-sdk-$ZEPHYR_SDK_VERSION zephyr-sdk
+        tar -xf toolchain_linux-x86_64_arm-zephyr-eabi.tar.gz -C zephyr-sdk
+        west update cmsis
 
-    - name: Run tests with asserts
-      if: ${{ inputs.asserts == 'with' || inputs.asserts == 'both' }}
+    - name: Run tests
       working-directory: tests
       shell: sh
       run: |
         export ZEPHYR_BASE=$(pwd)/../zephyr-clone
-        export ZEPHYR_TOOLCHAIN_VARIANT=host
-        $ZEPHYR_BASE/scripts/twister -i -T . -W --platform native_posix --platform native_posix_64 ${{ inputs.tags }} -x VERBOSE=ON -x ASSERTS=ON
+        export ZEPHYR_TOOLCHAIN_VARIANT=${{ inputs.zephyr_toolchain }}
+        ${{ inputs.zephyr_toolchain == 'zephyr' && 'export ZEPHYR_SDK_INSTALL_DIR=$(pwd)/../zephyr-sdk' || '' }}
+        ZCBOR_TEST_COMMAND="$ZEPHYR_BASE/scripts/twister -i -v -T . -W ${{ inputs.twister_arguments }}"
+        echo $ZCBOR_TEST_COMMAND
+        $ZCBOR_TEST_COMMAND

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: ["native_posix", "native_posix_64"]
+        platform: ["native_posix", "native_posix_64", "mps2_an521"]
         asserts: ["", "-x VERBOSE=ON -x ASSERTS=ON"]
     name: Merge tests 1 (${{ matrix.platform }}${{ matrix.asserts != '' && ' with asserts' || '' }})
     steps:
@@ -147,4 +147,5 @@ jobs:
     - name: Prepare and run tests
       uses: ./.github/actions/prepare_and_run_tests
       with:
-        twister_arguments: "--platform native_posix --platform native_posix_64 ${{ matrix.asserts }}"
+        twister_arguments: "--platform native_posix --platform native_posix_64 --platform mps2_an521 ${{ matrix.asserts }}"
+        zephyr_toolchain: zephyr

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -32,79 +32,30 @@ jobs:
 
   merge-test-1:
     runs-on: ubuntu-latest
-    name: Merge tests 1
+    strategy:
+      matrix:
+        platform: ["native_posix", "native_posix_64"]
+        asserts: ["", "-x VERBOSE=ON -x ASSERTS=ON"]
+    name: Merge tests 1 (${{ matrix.platform }}${{ matrix.asserts != '' && ' with asserts' || '' }})
     steps:
     - name: Checkout the code
       uses: actions/checkout@v2
 
+    - name: Install zcbor
+      uses: ./.github/actions/install_zcbor
+
     - name: Prepare and run tests
       uses: ./.github/actions/prepare_and_run_tests
       with:
-        tags: -t unit
-        asserts: both
-
-    - name: Run pycodestyle
-      run: |
-        pycodestyle zcbor/zcbor.py --max-line-length=100 --ignore=W191,E101,W503
-        pycodestyle tests/scripts/run_tests.py --max-line-length=100 --ignore=W503,E501,E402
-        pycodestyle tests/scripts/release_test.py --max-line-length=100
-        pycodestyle zcbor/__init__.py --max-line-length=100
-        pycodestyle setup.py --max-line-length=100
+        twister_arguments: "--platform ${{ matrix.platform }} ${{ matrix.asserts }}"
+        zephyr_toolchain: ${{ matrix.platform == 'mps2_an521' && 'zephyr' || 'host'}}
 
   merge-test-2:
-    runs-on: ubuntu-latest
-    name: Merge tests 2
-    steps:
-    - name: Checkout the code
-      uses: actions/checkout@v2
-    - name: Prepare and run tests
-      uses: ./.github/actions/prepare_and_run_tests
-      with:
-        tags: -t decode
-        asserts: without
-
-  merge-test-3:
-    runs-on: ubuntu-latest
-    name: Merge tests 3
-    steps:
-    - name: Checkout the code
-      uses: actions/checkout@v2
-    - name: Prepare and run tests
-      uses: ./.github/actions/prepare_and_run_tests
-      with:
-        tags: -t decode
-        asserts: with
-
-  merge-test-4:
-    runs-on: ubuntu-latest
-    name: Merge tests 4
-    steps:
-    - name: Checkout the code
-      uses: actions/checkout@v2
-    - name: Prepare and run tests
-      uses: ./.github/actions/prepare_and_run_tests
-      with:
-        tags: -t encode
-        asserts: without
-
-  merge-test-5:
-    runs-on: ubuntu-latest
-    name: Merge tests 5
-    steps:
-    - name: Checkout the code
-      uses: actions/checkout@v2
-    - name: Prepare and run tests
-      uses: ./.github/actions/prepare_and_run_tests
-      with:
-        tags: -t encode
-        asserts: with
-
-  merge-test-6:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-    name: Merge tests 6 (Python ${{ matrix.python-version }})
+    name: Merge tests 2 (Python ${{ matrix.python-version }})
     steps:
     - name: Checkout the code
       uses: actions/checkout@v2
@@ -114,17 +65,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      shell: sh
-      run: |
-        pip3 install -U pip
-        pip3 install -U setuptools
-        pip3 install -U -r scripts/requirements.txt
-
-    - name: Install zcbor package
-      shell: sh
-      run: |
-        python3 setup.py install
+    - name: Install zcbor
+      uses: ./.github/actions/install_zcbor
+      with:
+        zcbor_package: 'setup_install'
 
     - name: Run python tests
       working-directory: tests/scripts
@@ -138,17 +82,13 @@ jobs:
     - merge-test-win
     - merge-test-1
     - merge-test-2
-    - merge-test-3
-    - merge-test-4
-    - merge-test-5
-    - merge-test-6
     if: "startswith(github.head_ref, 'release/')"
     steps:
     - name: Checkout the code
       uses: actions/checkout@v2
 
-    - name: Prepare zcbor
-      uses: ./.github/actions/prepare_and_run_tests
+    - name: Install zcbor
+      uses: ./.github/actions/install_zcbor
 
     - name: Run python release tests
       working-directory: tests/scripts
@@ -183,15 +123,12 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-    name: Release tests 2 (Python ${{ matrix.python-version }})
+        asserts: ["", "-x VERBOSE=ON -x ASSERTS=ON"]
+    name: Release tests 2 (Python ${{ matrix.python-version }}${{ matrix.asserts != '' && ' with asserts' || '' }})
     needs:
     - merge-test-win
     - merge-test-1
     - merge-test-2
-    - merge-test-3
-    - merge-test-4
-    - merge-test-5
-    - merge-test-6
     if: "startswith(github.head_ref, 'release/')"
     steps:
     - name: Checkout the code
@@ -202,9 +139,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install zcbor
+      uses: ./.github/actions/install_zcbor
+      with:
+        zcbor_package: 'setup_install'
+
     - name: Prepare and run tests
       uses: ./.github/actions/prepare_and_run_tests
       with:
-        tags: ''
-        asserts: 'both'
-        zcbor_package: 'setup_install'
+        twister_arguments: "--platform native_posix --platform native_posix_64 ${{ matrix.asserts }}"

--- a/tests/scripts/run_tests.py
+++ b/tests/scripts/run_tests.py
@@ -16,6 +16,7 @@ import cbor2
 from platform import python_version_tuple
 from sys import platform, exit
 from yaml import safe_load
+from pycodestyle import StyleGuide
 
 
 try:
@@ -46,6 +47,25 @@ p_map_bstr_yaml = Path(p_tests, 'cases', 'map_bstr.yaml')
 p_README = Path(p_root, 'README.md')
 p_add_helptext = Path(p_root, 'add_helptext.py')
 p_prelude = Path(p_root, 'zcbor', 'cddl', 'prelude.cddl')
+p_init_py = Path(p_root, 'zcbor', '__init__.py')
+p_zcbor_py = Path(p_root, 'zcbor', 'zcbor.py')
+p_setup_py = Path(p_root, 'setup.py')
+p_run_tests_py = Path(p_tests, 'scripts', 'run_tests.py')
+p_release_test_py = Path(p_tests, 'scripts', 'release_test.py')
+
+
+class Test00_Codestyle(TestCase):
+    def do_codestyle(self, files, **kwargs):
+        style = StyleGuide(max_line_length=100, **kwargs)
+        result = style.check_files([str(f) for f in files])
+        result.print_statistics()
+        self.assertEqual(result.total_errors, 0,
+            f"Found {result.total_errors} style errors")
+
+    def test_codestyle(self):
+        self.do_codestyle([p_init_py, p_setup_py, p_release_test_py])
+        self.do_codestyle([p_zcbor_py], ignore=['W191', 'E101', 'W503'])
+        self.do_codestyle([p_release_test_py], ignore=['E402', 'E501', 'W503'])
 
 
 class Testn(TestCase):

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -5,17 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-pycodestyle ../zcbor/zcbor.py --max-line-length=100 --ignore=W191,E101,W503
-[[ $? -ne 0 ]] && exit 1
-pycodestyle ../zcbor/__init__.py --max-line-length=100
-[[ $? -ne 0 ]] && exit 1
-pycodestyle ../setup.py --max-line-length=100
-[[ $? -ne 0 ]] && exit 1
-pycodestyle scripts/run_tests.py --max-line-length=100 --ignore=W503,E501,E402
-[[ $? -ne 0 ]] && exit 1
-pycodestyle scripts/release_test.py --max-line-length=100
-[[ $? -ne 0 ]] && exit 1
-
 pushd "scripts"
 python3 -m unittest run_tests
 [[ $? -ne 0 ]] && popd && exit 1


### PR DESCRIPTION
Instead of manually dividing the twister tests via tags and asserts,
divide by platform.

Asserts are still handled manually instead of adding an "asserts" variant
to all testcase.yaml files.

Create a new action "install_zcbor", to support the use case of installing
without running tests.

Add support for the zephyr toolchain to run tests on qemu

Print twister command before executing it

Do codestyle testing as part of Python unittesting

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>