### PR TITLE
zcbor.py: Fix bug where the union_int optimization decodes twice

### DIFF
--- a/include/zcbor_decode.h
+++ b/include/zcbor_decode.h
@@ -53,10 +53,12 @@ bool zcbor_uint32_expect(zcbor_state_t *state, uint32_t result);
 bool zcbor_uint64_expect(zcbor_state_t *state, uint64_t result);
 bool zcbor_size_expect(zcbor_state_t *state, size_t result);
 
-/** Consume and expect a pint with a certain value, within a union.
+/** Consume and expect a pint/nint with a certain value, within a union.
  *
- * Calls @ref zcbor_union_elem_code then @ref zcbor_uint32_expect.
+ * Calls @ref zcbor_union_elem_code then @ref zcbor_[u]int[32|64]_expect.
  */
+bool zcbor_int32_expect_union(zcbor_state_t *state, int32_t result);
+bool zcbor_int64_expect_union(zcbor_state_t *state, int64_t result);
 bool zcbor_uint32_expect_union(zcbor_state_t *state, uint32_t result);
 bool zcbor_uint64_expect_union(zcbor_state_t *state, uint64_t result);
 

--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -215,6 +215,20 @@ bool zcbor_uint32_decode(zcbor_state_t *state, uint32_t *result)
 }
 
 
+bool zcbor_int32_expect_union(zcbor_state_t *state, int32_t result)
+{
+	zcbor_union_elem_code(state);
+	return zcbor_int32_expect(state, result);
+}
+
+
+bool zcbor_int64_expect_union(zcbor_state_t *state, int64_t result)
+{
+	zcbor_union_elem_code(state);
+	return zcbor_int64_expect(state, result);
+}
+
+
 bool zcbor_uint32_expect_union(zcbor_state_t *state, uint32_t result)
 {
 	zcbor_union_elem_code(state);

--- a/tests/cases/corner_cases.cddl
+++ b/tests/cases/corner_cases.cddl
@@ -190,8 +190,20 @@ MapLength = {
 	?"e" : (end_device_array:[* uuid]),
 }
 
-UnionInt = [
+Structure_One = (
+	id: 1,
+	some_array: bstr
+)
+
+UnionInt1 = [
+	(union_uint1: 5, "This is a five") //
+	(union_uint2: 1000, bstr) //
+	(union_uint3: -100000, null, number)
+]
+
+UnionInt2 = [
 	(5, "This is a five") //
 	(1000, bstr) //
-	(-100000, null, number)
+	(-100000, null, number) //
+	Structure_One
 ]

--- a/tests/decode/test5_corner_cases/CMakeLists.txt
+++ b/tests/decode/test5_corner_cases/CMakeLists.txt
@@ -46,7 +46,8 @@ set(py_command
     Prelude
     CBORBstr
     MapLength
-    UnionInt
+    UnionInt1
+    UnionInt2
   --decode
   --git-sha-header
   --short-names

--- a/tests/encode/test3_corner_cases/CMakeLists.txt
+++ b/tests/encode/test3_corner_cases/CMakeLists.txt
@@ -43,7 +43,7 @@ set(py_command
   Floats2
   CBORBstr
   MapLength
-  UnionInt
+  UnionInt2
   -e
   ${bit_arg}
   --short-names

--- a/tests/encode/test3_corner_cases/src/main.c
+++ b/tests/encode/test3_corner_cases/src/main.c
@@ -1404,12 +1404,16 @@ void test_union_int(void)
 		0x3A, 0x00, 0x01, 0x86, 0x9F, 0xF6, 0x01,
 		END
 	};
-	struct UnionInt input;
+	uint8_t exp_union_int_payload4[] = {LIST(2),
+		0x01, 0x42, 'h', 'i',
+		END
+	};
+	struct UnionInt2 input;
 	size_t num_encode;
 	uint8_t output[60];
 
 	input.union_choice = _union__uint5;
-	zassert_equal(ZCBOR_SUCCESS, cbor_encode_UnionInt(output, sizeof(output),
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_UnionInt2(output, sizeof(output),
 			&input, &num_encode), NULL);
 	zassert_equal(sizeof(exp_union_int_payload1), num_encode, NULL);
 	zassert_mem_equal(exp_union_int_payload1, output, num_encode, NULL);
@@ -1417,7 +1421,7 @@ void test_union_int(void)
 	input.union_choice = _union__uint1000;
 	input.bstr.len = 16;
 	input.bstr.value = (uint8_t *)&"This is thousand";
-	zassert_equal(ZCBOR_SUCCESS, cbor_encode_UnionInt(output, sizeof(output),
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_UnionInt2(output, sizeof(output),
 			&input, &num_encode), NULL);
 	zassert_equal(sizeof(exp_union_int_payload2), num_encode, NULL);
 	zassert_mem_equal(exp_union_int_payload2, output, num_encode, NULL);
@@ -1425,10 +1429,18 @@ void test_union_int(void)
 	input.union_choice = _union__nint;
 	input._number.number_choice = _number_int;
 	input._number._int = 1;
-	zassert_equal(ZCBOR_SUCCESS, cbor_encode_UnionInt(output, sizeof(output),
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_UnionInt2(output, sizeof(output),
 			&input, &num_encode), NULL);
 	zassert_equal(sizeof(exp_union_int_payload3), num_encode, NULL);
 	zassert_mem_equal(exp_union_int_payload3, output, num_encode, NULL);
+
+	input.union_choice = _UnionInt2_union__Structure_One;
+	input._Structure_One.some_array.value = (uint8_t *)&"hi";
+	input._Structure_One.some_array.len = 2;
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_UnionInt2(output, sizeof(output),
+			&input, &num_encode), NULL);
+	zassert_equal(sizeof(exp_union_int_payload4), num_encode, NULL);
+	zassert_mem_equal(exp_union_int_payload4, output, num_encode, NULL);
 }
 
 

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -1170,7 +1170,8 @@ class CddlXcoder(CddlParser):
             return self.value[0].int_val()
         elif self.type == "OTHER" \
                 and not self.count_var_condition() \
-                and not self.single_func_impl_condition():
+                and not self.single_func_impl_condition() \
+                and not self.my_types[self.value].single_func_impl_condition():
             return self.my_types[self.value].int_val()
         return None
 
@@ -2225,6 +2226,7 @@ class CodeGenerator(CddlXcoder):
                     + f"sizeof({self.choice_var_access()})))",
                     "((" + f"{newl_ind}|| ".join(lines)
                          + ") || (zcbor_error(state, ZCBOR_ERR_WRONG_VALUE), false))",)
+
             child_values = ["(%s && ((%s = %s) || 1))" %
                             (child.full_xcode(
                                 union_int="EXPECT" if child.is_int_disambiguated() else None),


### PR DESCRIPTION
When a union contains another type, which is disambiguated, but which
will be decoded with its own function, the first integer would be
attempted decoded twice, once to populate the choice enum, and once
in the type's own function. This change reports such cases as
not disambiguated, so the union_int optimization won't be applied.

Later, it could be possible to make it possible to apply the union_int
optimization to these cases as well, but that would require more work,
possibly generating two variants of the function, one with and one
without decoding the first integer.

Add tests, splitting the UnionInt into two versions, one where the
optitmization is applied, and one where it's not.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

The following is needed for the changes to the tests to work:

zcbor_decode: Add zcbor_int[32|64]_expect_union

To handle negative numbers.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

Fixes #247 