### PR TITLE
zcbor_common.h: Add new zcbor_assert_state() macro

### DIFF
--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -62,8 +62,16 @@ do { \
 		ZCBOR_FAIL(); \
 	} \
 } while(0)
+#define zcbor_assert_state(expr, ...) \
+do { \
+	if (!(expr)) { \
+		zcbor_print_assert(expr, __VA_ARGS__); \
+		ZCBOR_ERR(ZCBOR_ERR_ASSERTION); \
+	} \
+} while(0)
 #else
 #define zcbor_assert(expr, ...)
+#define zcbor_assert_state(expr, ...)
 #endif
 
 #ifndef MIN

--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -112,8 +112,8 @@ static bool value_extract(zcbor_state_t *state,
 		void *const result, uint_fast32_t result_len)
 {
 	zcbor_trace();
-	zcbor_assert(result_len != 0, "0-length result not supported.\r\n");
-	zcbor_assert(result != NULL, NULL);
+	zcbor_assert_state(result_len != 0, "0-length result not supported.\r\n");
+	zcbor_assert_state(result != NULL, NULL);
 
 	INITIAL_CHECKS();
 	ZCBOR_ERR_IF((state->elem_count == 0), ZCBOR_ERR_LOW_ELEM_COUNT);
@@ -765,7 +765,7 @@ bool zcbor_float_expect(zcbor_state_t *state, double result)
 
 bool zcbor_any_skip(zcbor_state_t *state, void *result)
 {
-	zcbor_assert(result == NULL,
+	zcbor_assert_state(result == NULL,
 			"'any' type cannot be returned, only skipped.\r\n");
 
 	INITIAL_CHECKS();
@@ -911,7 +911,7 @@ bool zcbor_present_decode(uint_fast32_t *present,
 	uint_fast32_t num_decode;
 	bool retval = zcbor_multi_decode(0, 1, &num_decode, decoder, state, result, 0);
 
-	zcbor_assert(retval, "zcbor_multi_decode should not fail with these parameters.\r\n");
+	zcbor_assert_state(retval, "zcbor_multi_decode should not fail with these parameters.\r\n");
 
 	*present = num_decode;
 	return retval;

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -43,7 +43,7 @@ static bool encode_header_byte(zcbor_state_t *state,
 	ZCBOR_CHECK_ERROR();
 	ZCBOR_CHECK_PAYLOAD();
 
-	zcbor_assert(additional < 32, NULL);
+	zcbor_assert_state(additional < 32, NULL);
 
 	*(state->payload_mut++) = (uint8_t)((major_type << 5) | (additional & 0x1F));
 	return true;
@@ -132,7 +132,7 @@ static uint_fast32_t get_encoded_len(const void *const result, uint_fast32_t res
 static bool value_encode(zcbor_state_t *state, zcbor_major_type_t major_type,
 		const void *const input, uint_fast32_t max_result_len)
 {
-	zcbor_assert(max_result_len != 0, "0-length result not supported.\r\n");
+	zcbor_assert_state(max_result_len != 0, "0-length result not supported.\r\n");
 
 	uint_fast32_t result_len = get_result_len(input, max_result_len);
 	const void *const result = get_result(input, max_result_len, result_len);


### PR DESCRIPTION
For situations where the 'state' variable is available, so the assertion can be reported as ZCBOR_ERR_ASSERTION.

This prevents cases where an assert hides where it came from because it did not update the error variable.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>