### PR TITLE
CLI refactor

### DIFF
--- a/.github/actions/prepare_and_run_tests/action.yaml
+++ b/.github/actions/prepare_and_run_tests/action.yaml
@@ -43,7 +43,7 @@ runs:
       shell: sh
       run: |
         sudo apt install qemu qemu-system-arm
-        ZEPHYR_SDK_VERSION=0.14.2
+        ZEPHYR_SDK_VERSION=0.15.0
         wget -nv https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION/zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-x86_64_minimal.tar.gz
         wget -nv https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION/toolchain_linux-x86_64_arm-zephyr-eabi.tar.gz
         wget -nv -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION/sha256.sum | shasum --check --ignore-missing

--- a/README.md
+++ b/README.md
@@ -4,18 +4,34 @@ zcbor
 zcbor is a low footprint [CBOR](https://en.wikipedia.org/wiki/CBOR) library in the C language that comes with a schema-driven script tool that can validate your data, or even generate code for you.
 Aside from the script, the CBOR library is a standalone library which is tailored for use in microcontrollers.
 
-The validation part of the script can also work with YAML and JSON data.
+The validation/conversion part of the script works with YAML and JSON data, in addition to CBOR.
 It can for example validate a YAML file against a schema and convert it into CBOR.
 
 The schema language used by zcbor is CDDL (Consise Data Definition Language) which is a powerful human-readable data description language defined in [IETF RFC 8610](https://datatracker.ietf.org/doc/rfc8610/).
 
 zcbor was previously called "cddl-gen".
 
+
+Features
+========
+
+Here are some possible ways zcbor can be used:
+
+ - Python script and module:
+   - Validate a YAML/JSON file and translate it into CBOR e.g. for transmission.
+   - Validate a YAML/JSON/CBOR file before processing it with some other tool
+   - Decode and validate incoming CBOR data into human-readable YAML/JSON.
+   - As part of a python script that processes YAML/JSON/CBOR files. zcbor is compatible with PyYAML and can additionally provide validation and/or easier inspection via named tuples.
+ - C code:
+   - Generate C code for validating and decoding or encoding CBOR, for use in optimized or constrained environments, such as microcontrollers.
+   - Provide a low-footprint CBOR decoding/encoding library similar to TinyCBOR/QCBOR/NanoCBOR.
+
+
 CBOR decoding/encoding library
 ==============================
 
 The CBOR library found at [headers](include) and [source](src) is used by the generated code, but can also be used directly.
-If so, you must instantiate a `zcbor_state_t` object, which is most easily done using the `zcbor_new_*_state()` functions or the `ZCBOR_STATE_*()` macros.
+To use it, instantiate a `zcbor_state_t` object, which is most easily done using the `zcbor_new_*_state()` functions or the `ZCBOR_STATE_*()` macros.
 
 The `elem_count` member refers to the number of encoded objects in the current list or map.
 `elem_count` starts again when entering a nested list or map, and is restored when exiting.
@@ -64,30 +80,9 @@ Name                      | Description
 `ZCBOR_STOP_ON_ERROR`     | Enable the `stop_on_error` functionality. This makes all functions abort their execution if called when an error has already happened.
 `ZCBOR_BIG_ENDIAN`        | All decoded values are returned as big-endian.
 
-Schema-driven data manipulation and code generation
-===================================================
 
-By invoking `zcbor` (when installed via Pip or setup.py), or the Python script [zcbor.py](zcbor/zcbor.py) directly, you can generate C code that validates/encodes/decodes CBOR data conforming to a CDDL schema.
-zcbor can also validate and convert CBOR data to and from JSON/YAML, either from the command line, or imported as a module.
-Finally, the package contains a light-weight CBOR encoding/decoding library in C.
-This library is used by the generated code, and can also be used directly in your own code.
-
-Features
-========
-
-Here are some possible ways zcbor can be used:
-
- - Python scripting:
-   - Validate a YAML file and translate it into CBOR e.g. for transmission.
-   - Validate a YAML/JSON/CBOR file before processing it with some other tool
-   - Decode and validate incoming CBOR data into human-readable YAML/JSON.
-   - As part of a python script that processes YAML/JSON/CBOR files. zcbor is compatible with PyYAML and can additionally provide validation and/or easier inspection via named tuples.
- - C code:
-   - Generate C code for validating and decoding or encoding CBOR, for use in optimized or constrained environments, such as microcontrollers.
-   - Provide a low-footprint CBOR decoding/encoding library similar to TinyCBOR/QCBOR/NanoCBOR.
-
-Python scripting
-================
+Python script and module
+========================
 
 Invoking zcbor.py from the command line
 ---------------------------------------
@@ -96,18 +91,20 @@ The zcbor.py script can directly read CBOR, YAML, or JSON data and validate it a
 It can also freely convert the data between CBOR/YAML/JSON.
 It can also output the data to a C file formatted as a byte array.
 
-The following is a generalized example for converting (and validating) data from the command line.
+Following are some generalized examples for validating, and for converting (which also validates) data from the command line.
 The script infers the data format from the file extension, but the format can also be specified explicitly.
-See `zcbor convert --help` for more information.
+See `zcbor validate --help` and `zcbor convert --help` for more information.
 
 ```sh
-python3 <zcbor base>/zcbor/zcbor.py -c <CDDL description file> convert -t <which CDDL type to expect> -i <input data file> -o <output data file>
+python3 <zcbor base>/zcbor/zcbor.py validate -c <CDDL description file> -t <which CDDL type to expect> -i <input data file>
+python3 <zcbor base>/zcbor/zcbor.py convert -c <CDDL description file> -t <which CDDL type to expect> -i <input data file> -o <output data file>
 ```
 
 Or invoke its command line executable (if installed via `pip`):
 
 ```sh
-zcbor -c <CDDL description file> convert -t <which CDDL type to expect> -i <input data file> -o <output data file>
+zcbor validate -c <CDDL description file> -t <which CDDL type to expect> -i <input data file>
+zcbor convert -c <CDDL description file> -t <which CDDL type to expect> -i <input data file> -o <output data file>
 ```
 
 Note that since CBOR supports more data types than YAML and JSON, zcbor uses an idiomatic format when converting to/from YAML/JSON.
@@ -131,6 +128,7 @@ When accessing the data, you can choose between two internal formats:
     When returning this format, DataTranslator hides the idiomatic representations for bytestrings, tags, and non-text keys described above.
  2. A custom format which allows accessing the data via the names from the CDDL description file.
     This format is implemented using named tuples, and is immutable, meaning that it can be used for inspecting data, but not for changing or creating data.
+
 
 Code generation
 ===============
@@ -210,6 +208,7 @@ E.g. `Foo = [name: tstr, age: uint]` is equivalent to `Foo = [tstr, uint]`.
 
 See [test3_simple](tests/decode/test3_simple/) for CDDL example code.
 
+
 Introduction to CBOR
 ====================
 
@@ -275,9 +274,9 @@ Pet = [
 Call the Python script:
 
 ```sh
-python3 <zcbor base>/zcbor/zcbor.py -c pet.cddl code -d -t Pet --oc pet_decode.c --oh pet_decode.h
+python3 <zcbor base>/zcbor/zcbor.py code -c pet.cddl -d -t Pet --oc pet_decode.c --oh pet_decode.h
 # or
-zcbor -c pet.cddl code -d -t Pet --oc pet_decode.c --oh pet_decode.h
+zcbor code -c pet.cddl -d -t Pet --oc pet_decode.c --oh pet_decode.h
 ```
 
 And use the generated code with
@@ -348,9 +347,9 @@ Converting
 Here is an example call for converting from YAML to CBOR:
 
 ```sh
-python3 <zcbor base>/zcbor/zcbor.py -c pet.cddl convert -t Pet -i mypet.yaml -o mypet.cbor
+python3 <zcbor base>/zcbor/zcbor.py convert -c pet.cddl -t Pet -i mypet.yaml -o mypet.cbor
 # or
-zcbor -c pet.cddl convert -t Pet -i mypet.yaml -o mypet.cbor
+zcbor convert -c pet.cddl -t Pet -i mypet.yaml -o mypet.cbor
 ```
 
 Which takes a yaml structure from mypet.yaml, validates it against the Pet type in the CDDL description in pet.cddl, and writes binary CBOR data to mypet.cbor.
@@ -371,6 +370,7 @@ Run these scripts with no arguments.
 
 To set up the environment to run the ztest tests, follow [Zephyr's Getting Started Guide](https://docs.zephyrproject.org/latest/getting_started/index.html), or see the workflow in the [`.github`](.github) directory.
 
+
 Command line documentation
 ==========================
 
@@ -380,41 +380,16 @@ zcbor --help
 ------------
 
 ```
-usage: zcbor [-h] [--version] -c CDDL [--default-max-qty DEFAULT_MAX_QTY]
-             [--no-prelude] [-v]
-             {code,convert} ...
+usage: zcbor [-h] {code,validate,convert} ...
 
 Parse a CDDL file and validate/convert between YAML, JSON, and CBOR. Can also
-generate C code for validation/encoding/decoding of CBOR. Note that the other
-top-level arguments (e.g. -c) must appear before {code/convert}. See zcbor
-code/convert --help to see their respective specialized arguments.
+generate C code for validation/encoding/decoding of CBOR.
 
 positional arguments:
-  {code,convert}
+  {code,validate,convert}
 
 options:
   -h, --help            show this help message and exit
-  --version             show program's version number and exit
-  -c CDDL, --cddl CDDL  Path to one or more input CDDL file(s). Passing
-                        multiple files is equivalent to concatenating them.
-  --default-max-qty DEFAULT_MAX_QTY, --dq DEFAULT_MAX_QTY
-                        Default maximum number of repetitions when no maximum
-                        is specified. This is needed to construct complete C
-                        types. This is relevant for the generated code. It is
-                        not relevant for converting, except when handling data
-                        that will be decoded by generated code. The default
-                        value of this option is 3. Set it to a large number
-                        when not relevant. When generating code, the
-                        default_max_qty can usually be set to a text symbol,
-                        to allow it to be configurable when building the code.
-                        This is not always possible, as sometimes the value is
-                        needed for internal computations. If so, the script
-                        will raise an exception.
-  --no-prelude          Exclude the standard CDDL prelude from the build. The
-                        prelude can be viewed at zcbor/cddl/prelude.cddl in
-                        the repo, or together with the script.
-  -v, --verbose         Print more information while parsing CDDL and
-                        generating code.
 
 ```
 
@@ -422,10 +397,11 @@ zcbor code --help
 -----------------
 
 ```
-usage: zcbor code [-h] [--output-c OUTPUT_C] [--output-h OUTPUT_H]
-                  [--output-h-types OUTPUT_H_TYPES] [--copy-sources]
-                  [--output-cmake OUTPUT_CMAKE] -t ENTRY_TYPES
-                  [ENTRY_TYPES ...] [-d] [-e] [--time-header]
+usage: zcbor code [-h] [--version] -c CDDL [--no-prelude] [-v]
+                  [--default-max-qty DEFAULT_MAX_QTY] [--output-c OUTPUT_C]
+                  [--output-h OUTPUT_H] [--output-h-types OUTPUT_H_TYPES]
+                  [--copy-sources] [--output-cmake OUTPUT_CMAKE] -t
+                  ENTRY_TYPES [ENTRY_TYPES ...] [-d] [-e] [--time-header]
                   [--git-sha-header] [-b {32,64}]
                   [--include-prefix INCLUDE_PREFIX] [-s]
 
@@ -446,6 +422,23 @@ This script requires 'regex' for lookaround functionality not present in 're'.
 
 options:
   -h, --help            show this help message and exit
+  --version             show program's version number and exit
+  -c CDDL, --cddl CDDL  Path to one or more input CDDL file(s). Passing
+                        multiple files is equivalent to concatenating them.
+  --no-prelude          Exclude the standard CDDL prelude from the build. The
+                        prelude can be viewed at zcbor/cddl/prelude.cddl in
+                        the repo, or together with the script.
+  -v, --verbose         Print more information while parsing CDDL and
+                        generating code.
+  --default-max-qty DEFAULT_MAX_QTY, --dq DEFAULT_MAX_QTY
+                        Default maximum number of repetitions when no maximum
+                        is specified. This is needed to construct complete C
+                        types. The default_max_qty can usually be set to a
+                        text symbol if desired, to allow it to be configurable
+                        when building the code. This is not always possible,
+                        as sometimes the value is needed for internal
+                        computations. If so, the script will raise an
+                        exception.
   --output-c OUTPUT_C, --oc OUTPUT_C
                         Path to output C file. If both --decode and --encode
                         are specified, _decode and _encode will be appended to
@@ -510,35 +503,32 @@ options:
 
 ```
 
-zcbor convert --help
---------------------
+zcbor validate --help
+---------------------
 
 ```
-usage: zcbor convert [-h] -i INPUT [--input-as {yaml,json,cbor,cborhex}]
-                     [-o OUTPUT] [--output-as {yaml,json,cbor,cborhex,c_code}]
-                     [--c-code-var-name C_CODE_VAR_NAME] -t ENTRY_TYPE
+usage: zcbor validate [-h] [--version] -c CDDL [--no-prelude] [-v]
+                      [--default-max-qty DEFAULT_MAX_QTY] -i INPUT
+                      [--input-as {yaml,json,cbor,cborhex}] -t ENTRY_TYPE
 
-Parse a CDDL file and verify/convert between CBOR and YAML/JSON. The script
-decodes the CBOR/YAML/JSON data from a file or stdin and verifies that it
-conforms to the CDDL description. The script fails if the data does not
-conform. The script can also be used to just verify. JSON and YAML do not
-support all data types that CBOR/CDDL supports. bytestrings (BSTR), tags, and
-maps with non-text keys need special handling: All strings in JSON/YAML are
-text strings. If a BSTR is needed, use a dict with a single entry, with "bstr"
-as the key, and the byte string (as a hex string) as the value, e.g. {"bstr":
-"0123456789abcdef"}. The value can also be another type, e.g. which will be
-interpreted as a BSTR with the given value as contents (in cddl: 'bstr .cbor
-SomeType'). E.g. {"bstr": ["first element", 2, [3]]} Dicts in JSON/YAML only
-support text strings for keys, so if a dict needs other types of keys,
-encapsulate the key and value into a dict (n is an arbitrary integer): e.g.
-{"name": "foo", "keyvaln": {"key": 123, "val": "bar"}} which will conform to
-the CDDL {tstr => tstr, int => tstr}. Tags are specified by a dict with two
-elements, e.g. {"tag": 1234, "value": ["tagged string within list"]}
-'undefined' is specified as a list with a single text entry:
-"zcbor_undefined".
+Read CBOR, YAML, or JSON data from file or stdin and validate it against a
+CDDL schema file.
 
 options:
   -h, --help            show this help message and exit
+  --version             show program's version number and exit
+  -c CDDL, --cddl CDDL  Path to one or more input CDDL file(s). Passing
+                        multiple files is equivalent to concatenating them.
+  --no-prelude          Exclude the standard CDDL prelude from the build. The
+                        prelude can be viewed at zcbor/cddl/prelude.cddl in
+                        the repo, or together with the script.
+  -v, --verbose         Print more information while parsing CDDL and
+                        generating code.
+  --default-max-qty DEFAULT_MAX_QTY, --dq DEFAULT_MAX_QTY
+                        Default maximum number of repetitions when no maximum
+                        is specified. It is only relevant when handling data
+                        that will be decoded by generated code. If omitted, a
+                        large number will be used.
   -i INPUT, --input INPUT
                         Input data file. The option --input-as specifies how
                         to interpret the contents. Use "-" to indicate stdin.
@@ -547,11 +537,70 @@ options:
                         omitted, the format is inferred from the file name.
                         .yaml, .yml => YAML, .json => JSON, .cborhex => CBOR
                         as hex string, everything else => CBOR
+  -t ENTRY_TYPE, --entry-type ENTRY_TYPE
+                        Name of the type (from the CDDL) to interpret the data
+                        as.
+
+```
+
+zcbor convert --help
+--------------------
+
+```
+usage: zcbor convert [-h] [--version] -c CDDL [--no-prelude] [-v]
+                     [--default-max-qty DEFAULT_MAX_QTY] -i INPUT
+                     [--input-as {yaml,json,cbor,cborhex}] -t ENTRY_TYPE -o
+                     OUTPUT [--output-as {yaml,json,cbor,cborhex,c_code}]
+                     [--c-code-var-name C_CODE_VAR_NAME]
+
+Parse a CDDL file and validate/convert between CBOR and YAML/JSON. The script
+decodes the CBOR/YAML/JSON data from a file or stdin and verifies that it
+conforms to the CDDL description. The script fails if the data does not
+conform. 'zcbor validate' can be used if only validate is needed. JSON and
+YAML do not support all data types that CBOR/CDDL supports. bytestrings
+(BSTR), tags, and maps with non-text keys need special handling: All strings
+in JSON/YAML are text strings. If a BSTR is needed, use a dict with a single
+entry, with "bstr" as the key, and the byte string (as a hex string) as the
+value, e.g. {"bstr": "0123456789abcdef"}. The value can also be another type,
+e.g. which will be interpreted as a BSTR with the given value as contents (in
+cddl: 'bstr .cbor SomeType'). E.g. {"bstr": ["first element", 2, [3]]} Dicts
+in JSON/YAML only support text strings for keys, so if a dict needs other
+types of keys, encapsulate the key and value into a dict (n is an arbitrary
+integer): e.g. {"name": "foo", "keyvaln": {"key": 123, "val": "bar"}} which
+will conform to the CDDL {tstr => tstr, int => tstr}. Tags are specified by a
+dict with two elements, e.g. {"tag": 1234, "value": ["tagged string within
+list"]} 'undefined' is specified as a list with a single text entry:
+"zcbor_undefined".
+
+options:
+  -h, --help            show this help message and exit
+  --version             show program's version number and exit
+  -c CDDL, --cddl CDDL  Path to one or more input CDDL file(s). Passing
+                        multiple files is equivalent to concatenating them.
+  --no-prelude          Exclude the standard CDDL prelude from the build. The
+                        prelude can be viewed at zcbor/cddl/prelude.cddl in
+                        the repo, or together with the script.
+  -v, --verbose         Print more information while parsing CDDL and
+                        generating code.
+  --default-max-qty DEFAULT_MAX_QTY, --dq DEFAULT_MAX_QTY
+                        Default maximum number of repetitions when no maximum
+                        is specified. It is only relevant when handling data
+                        that will be decoded by generated code. If omitted, a
+                        large number will be used.
+  -i INPUT, --input INPUT
+                        Input data file. The option --input-as specifies how
+                        to interpret the contents. Use "-" to indicate stdin.
+  --input-as {yaml,json,cbor,cborhex}
+                        Which format to interpret the input file as. If
+                        omitted, the format is inferred from the file name.
+                        .yaml, .yml => YAML, .json => JSON, .cborhex => CBOR
+                        as hex string, everything else => CBOR
+  -t ENTRY_TYPE, --entry-type ENTRY_TYPE
+                        Name of the type (from the CDDL) to interpret the data
+                        as.
   -o OUTPUT, --output OUTPUT
                         Output data file. The option --output-as specifies how
-                        to interpret the contents. If --output is omitted, no
-                        conversion is done, only verification of the input.
-                        Use "-" to indicate stdout.
+                        to interpret the contents. Use "-" to indicate stdout.
   --output-as {yaml,json,cbor,cborhex,c_code}
                         Which format to interpret the output file as. If
                         omitted, the format is inferred from the file name.
@@ -561,8 +610,5 @@ options:
   --c-code-var-name C_CODE_VAR_NAME
                         Only relevant together with '--output-as c_code' or .c
                         files.
-  -t ENTRY_TYPE, --entry-type ENTRY_TYPE
-                        Name of the type (from the CDDL) to interpret the data
-                        as.
 
 ```

--- a/add_helptext.py
+++ b/add_helptext.py
@@ -24,6 +24,7 @@ if __name__ == "__main__":
     commands = [
         ["zcbor", "--help"],
         ["zcbor", "code", "--help"],
+        ["zcbor", "validate", "--help"],
         ["zcbor", "convert", "--help"],
     ]
 

--- a/tests/decode/test1_suit_old_formats/CMakeLists.txt
+++ b/tests/decode/test1_suit_old_formats/CMakeLists.txt
@@ -12,10 +12,10 @@ include(../../cmake/test_template.cmake)
 
 set(py_command3
   zcbor
+  code
   -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/manifest-moran3.cddl
   --no-prelude # manifest-moran3.cddl contains types that collide with types in prelude.cddl.
   --default-max-qty MY_DEFAULT_MAX_QTY
-  code
   --output-cmake ${PROJECT_BINARY_DIR}/manifest-moran3.cmake
   -t OuterWrapper
   --decode
@@ -24,10 +24,10 @@ set(py_command3
 
 set(py_command4
   zcbor
+  code
   -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/manifest-moran4.cddl
   --no-prelude
   --default-max-qty MY_DEFAULT_MAX_QTY
-  code
   --output-cmake ${PROJECT_BINARY_DIR}/manifest-moran4.cmake
   -t SUIT_Outer_Wrapper
   --decode

--- a/tests/decode/test2_suit/CMakeLists.txt
+++ b/tests/decode/test2_suit/CMakeLists.txt
@@ -14,8 +14,8 @@ include(../../cmake/test_template.cmake)
 
 set(py_command
   zcbor
-  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/manifest2.cddl
   code
+  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/manifest2.cddl
   --output-cmake ${PROJECT_BINARY_DIR}/manifest2.cmake
   -t
   SUIT_Outer_Wrapper

--- a/tests/decode/test2_suit/CMakeLists.txt
+++ b/tests/decode/test2_suit/CMakeLists.txt
@@ -6,6 +6,8 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
+set_property(GLOBAL PROPERTY CSTD c11) # To avoid issues with c99 and -Wpedantic
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(test2_suit)
 include(../../cmake/test_template.cmake)
@@ -34,11 +36,7 @@ include(${PROJECT_BINARY_DIR}/manifest2.cmake)
 target_link_libraries(manifest2 PRIVATE zephyr_interface)
 target_link_libraries(app PRIVATE manifest2)
 
-
-
-if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 11)
-  if (NOT VERBOSE)
-    # VERBOSE means including printk which doesn't build with these options.
-    target_compile_options(manifest2 PRIVATE -Wpedantic -Wconversion)
-  endif()
+if (NOT VERBOSE)
+  # VERBOSE means including printk which doesn't build with these options.
+  target_compile_options(manifest2 PRIVATE -Wpedantic -Wconversion)
 endif()

--- a/tests/decode/test3_simple/CMakeLists.txt
+++ b/tests/decode/test3_simple/CMakeLists.txt
@@ -15,8 +15,8 @@ target_sources(app PRIVATE
 
 set(py_command_pet
   zcbor
-  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/pet.cddl
   code
+  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/pet.cddl
   --output-cmake ${PROJECT_BINARY_DIR}/pet.cmake
   -t Pet
   -d
@@ -25,8 +25,8 @@ set(py_command_pet
   )
 set(py_command_serial_recovery
   zcbor
-  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/serial_recovery.cddl
   code
+  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/serial_recovery.cddl
   --oh ${PROJECT_BINARY_DIR}/include/serial/serial_recovery_decode.h
   --oht ${PROJECT_BINARY_DIR}/include/serial/serial_recovery_decode_types.h
   --oc ${PROJECT_BINARY_DIR}/src/serial/serial_recovery_decode.c

--- a/tests/decode/test5_corner_cases/CMakeLists.txt
+++ b/tests/decode/test5_corner_cases/CMakeLists.txt
@@ -6,6 +6,8 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
+set_property(GLOBAL PROPERTY CSTD c11) # To avoid issues with c99 and -Wpedantic
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(test5_corner_cases)
 include(../../cmake/test_template.cmake)
@@ -70,9 +72,7 @@ if (TEST_INDEFINITE_LENGTH_ARRAYS)
   target_compile_definitions(app PUBLIC TEST_INDEFINITE_LENGTH_ARRAYS)
 endif()
 
-if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 11)
-  if (NOT VERBOSE)
-    # VERBOSE means including printk which doesn't build with these options.
-    target_compile_options(corner_cases PRIVATE -Wpedantic -Wconversion)
-  endif()
+if (NOT VERBOSE)
+  # VERBOSE means including printk which doesn't build with these options.
+  target_compile_options(corner_cases PRIVATE -Wpedantic -Wconversion)
 endif()

--- a/tests/decode/test5_corner_cases/CMakeLists.txt
+++ b/tests/decode/test5_corner_cases/CMakeLists.txt
@@ -15,9 +15,9 @@ include(../../cmake/test_template.cmake)
 set(py_command
   ${PYTHON_EXECUTABLE}
   ${CMAKE_CURRENT_LIST_DIR}/../../../zcbor/zcbor.py
+  code
   -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/corner_cases.cddl
   --default-max-qty 6
-  code
   --output-c ${PROJECT_BINARY_DIR}/src/corner_cases.c
   --output-h ${PROJECT_BINARY_DIR}/include/corner_cases.h
   --copy-sources

--- a/tests/decode/test7_suit9_simple/CMakeLists.txt
+++ b/tests/decode/test7_suit9_simple/CMakeLists.txt
@@ -13,8 +13,8 @@ include(../../cmake/test_template.cmake)
 set(py_command
   ${PYTHON_EXECUTABLE}
   ${CMAKE_CURRENT_LIST_DIR}/../../../zcbor/zcbor.py
-  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/manifest9_simple.cddl
   code
+  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/manifest9_simple.cddl
   --output-cmake ${PROJECT_BINARY_DIR}/manifest9_simple.cmake
   -t
   SUIT_Envelope

--- a/tests/decode/test8_suit12/CMakeLists.txt
+++ b/tests/decode/test8_suit12/CMakeLists.txt
@@ -12,8 +12,8 @@ include(../../cmake/test_template.cmake)
 
 set(py_command
   zcbor
-  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/manifest12.cddl
   code
+  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/manifest12.cddl
   --output-cmake ${PROJECT_BINARY_DIR}/manifest12.cmake
   -t
   SUIT_Envelope_Tagged

--- a/tests/decode/test9_manifest14/CMakeLists.txt
+++ b/tests/decode/test9_manifest14/CMakeLists.txt
@@ -17,10 +17,10 @@ endif()
 set(py_command
   ${PYTHON_EXECUTABLE}
   ${CMAKE_CURRENT_LIST_DIR}/../../../zcbor/zcbor.py
+  code
   -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/${MANIFEST}.cddl
   -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/cose.cddl
   --default-max-qty 4
-  code
   --output-cmake ${PROJECT_BINARY_DIR}/${MANIFEST}.cmake
   -t
   SUIT_Envelope_Tagged

--- a/tests/encode/test1_suit/CMakeLists.txt
+++ b/tests/encode/test1_suit/CMakeLists.txt
@@ -12,8 +12,8 @@ include(../../cmake/test_template.cmake)
 
 set(py_command
   zcbor
-  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/manifest3.cddl
   code
+  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/manifest3.cddl
   --output-cmake ${PROJECT_BINARY_DIR}/manifest3.cmake
   -t
   SUIT_Outer_Wrapper

--- a/tests/encode/test2_simple/CMakeLists.txt
+++ b/tests/encode/test2_simple/CMakeLists.txt
@@ -12,8 +12,8 @@ include(../../cmake/test_template.cmake)
 
 set(py_command
   zcbor
-  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/pet.cddl
   code
+  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/pet.cddl
   --output-cmake ${PROJECT_BINARY_DIR}/pet.cmake
   -t Pet
   -e

--- a/tests/encode/test3_corner_cases/CMakeLists.txt
+++ b/tests/encode/test3_corner_cases/CMakeLists.txt
@@ -6,6 +6,8 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
+set_property(GLOBAL PROPERTY CSTD c11) # To avoid issues with c99 and -Wpedantic
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(test3_corner_cases)
 include(../../cmake/test_template.cmake)
@@ -57,9 +59,7 @@ include(${PROJECT_BINARY_DIR}/corner_cases.cmake)
 target_link_libraries(corner_cases PRIVATE zephyr_interface)
 target_link_libraries(app PRIVATE corner_cases)
 
-if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 11)
-  if (NOT VERBOSE)
-    # VERBOSE means including printk which doesn't build with these options.
-    target_compile_options(corner_cases PRIVATE -Wpedantic -Wconversion)
-  endif()
+if (NOT VERBOSE)
+  # VERBOSE means including printk which doesn't build with these options.
+  target_compile_options(corner_cases PRIVATE -Wpedantic -Wconversion)
 endif()

--- a/tests/encode/test3_corner_cases/CMakeLists.txt
+++ b/tests/encode/test3_corner_cases/CMakeLists.txt
@@ -14,9 +14,9 @@ include(../../cmake/test_template.cmake)
 
 set(py_command
   zcbor
+  code
   -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/corner_cases.cddl
   --default-max-qty 6
-  code
   --output-cmake ${PROJECT_BINARY_DIR}/corner_cases.cmake
   --copy-sources
   -t

--- a/tests/encode/test4_senml/CMakeLists.txt
+++ b/tests/encode/test4_senml/CMakeLists.txt
@@ -12,8 +12,8 @@ include(../../cmake/test_template.cmake)
 
 set(py_command
   zcbor
-  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/senml.cddl
   code
+  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/senml.cddl
   --output-cmake ${PROJECT_BINARY_DIR}/senml.cmake
   -t lwm2m_senml
   -e

--- a/tests/scripts/run_tests.py
+++ b/tests/scripts/run_tests.py
@@ -490,34 +490,52 @@ class Test17Inv(Test11Inv):
 
 
 class TestCLI(TestCase):
-    def get_std_args(self, input):
-        return ["zcbor", "--cddl", str(p_manifest12), "--default-max-qty", "16", "convert", "--input", str(input), "-t", "SUIT_Envelope_Tagged"]
+    def get_std_args(self, input, cmd="convert"):
+        return ["zcbor", cmd, "--cddl", str(p_manifest12), "--input", str(input), "-t", "SUIT_Envelope_Tagged"]
 
     def do_testn(self, n):
+        call00 = Popen(self.get_std_args(p_test_vectors12[n], cmd="validate"))
         call0 = Popen(self.get_std_args(p_test_vectors12[n]) + ["--output", "-", "--output-as", "cbor"], stdout=PIPE)
+        call00.communicate()
         stdout0, _ = call0.communicate()
+        self.assertEqual(0, call00.returncode)
         self.assertEqual(0, call0.returncode)
 
+        call01 = Popen(self.get_std_args("-", cmd="validate") + ["--input-as", "cbor"], stdin=PIPE)
         call1 = Popen(self.get_std_args("-") + ["--input-as", "cbor", "--output", "-", "--output-as", "json"], stdin=PIPE, stdout=PIPE)
+        call01.communicate(input=stdout0)
         stdout1, _ = call1.communicate(input=stdout0)
+        self.assertEqual(0, call01.returncode)
         self.assertEqual(0, call1.returncode)
 
+        call02 = Popen(self.get_std_args("-", cmd="validate") + ["--input-as", "json"], stdin=PIPE)
         call2 = Popen(self.get_std_args("-") + ["--input-as", "json", "--output", "-", "--output-as", "yaml"], stdin=PIPE, stdout=PIPE)
+        call02.communicate(input=stdout1)
         stdout2, _ = call2.communicate(input=stdout1)
+        self.assertEqual(0, call02.returncode)
         self.assertEqual(0, call2.returncode)
 
+        call03 = Popen(self.get_std_args("-", cmd="validate") + ["--input-as", "yaml"], stdin=PIPE)
         call3 = Popen(self.get_std_args("-") + ["--input-as", "yaml", "--output", "-", "--output-as", "cbor"], stdin=PIPE, stdout=PIPE)
+        call03.communicate(input=stdout2)
         stdout3, _ = call3.communicate(input=stdout2)
         self.assertEqual(0, call3.returncode)
+        self.assertEqual(0, call03.returncode)
 
         self.assertEqual(stdout0, stdout3)
 
+        call04 = Popen(self.get_std_args("-", cmd="validate") + ["--input-as", "cbor"], stdin=PIPE)
         call4 = Popen(self.get_std_args("-") + ["--input-as", "cbor", "--output", "-", "--output-as", "cborhex"], stdin=PIPE, stdout=PIPE)
+        call04.communicate(input=stdout3)
         stdout4, _ = call4.communicate(input=stdout3)
+        self.assertEqual(0, call04.returncode)
         self.assertEqual(0, call4.returncode)
 
+        call05 = Popen(self.get_std_args("-", cmd="validate") + ["--input-as", "cborhex"], stdin=PIPE)
         call5 = Popen(self.get_std_args("-") + ["--input-as", "cborhex", "--output", "-", "--output-as", "json"], stdin=PIPE, stdout=PIPE)
+        call05.communicate(input=stdout4)
         stdout5, _ = call5.communicate(input=stdout4)
+        self.assertEqual(0, call05.returncode)
         self.assertEqual(0, call5.returncode)
 
         self.assertEqual(stdout1, stdout5)
@@ -546,14 +564,14 @@ class TestCLI(TestCase):
         self.do_testn(5)
 
     def test_map_bstr(self):
-        args = ["zcbor", "--cddl", str(p_map_bstr_cddl), "convert", "--input", str(p_map_bstr_yaml), "-t", "map", "--output", "-"]
+        args = ["zcbor", "convert", "--cddl", str(p_map_bstr_cddl), "--input", str(p_map_bstr_yaml), "-t", "map", "--output", "-"]
         call1 = Popen(args, stdout=PIPE)
         stdout1, _ = call1.communicate()
         self.assertEqual(0, call1.returncode)
         self.assertEqual(dumps({"test": bytes.fromhex("1234abcd"), "test2": cbor2.CBORTag(1234, bytes.fromhex("1a2b3c4d")), ("test3",): dumps(1234)}), stdout1)
 
     def test_decode_encode(self):
-        args = ["zcbor", "--cddl", str(p_map_bstr_cddl), "code", "-t", "map"]
+        args = ["zcbor", "code", "--cddl", str(p_map_bstr_cddl), "-t", "map"]
         call1 = Popen(args, stdout=PIPE, stderr=PIPE)
 
         _, stderr1 = call1.communicate()
@@ -561,7 +579,7 @@ class TestCLI(TestCase):
         self.assertIn(b"error: Please specify at least one of --decode or --encode", stderr1)
 
     def test_output_present(self):
-        args = ["zcbor", "--cddl", str(p_map_bstr_cddl), "code", "-t", "map", "-d"]
+        args = ["zcbor", "code", "--cddl", str(p_map_bstr_cddl), "-t", "map", "-d"]
         call1 = Popen(args, stdout=PIPE, stderr=PIPE)
 
         _, stderr1 = call1.communicate()


### PR DESCRIPTION
    zcbor.py: Refactor CLI to add 'verify' and put all options after keyword
    
    Added the 'verify' keyword instead of using 'convert' with no output.
    'convert' now requires an output.
    
    All options now appear after the keyword. I.e. code/verify/convert are
    always first when invoking zbor.
    
    Also, do a slight refactor of the README
    
    Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>