### PR TITLE
zcbor_common.h: Rename ARRAY_SIZE to ZCBOR_ARRAY_SIZE

### DIFF
--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -70,8 +70,8 @@ do { \
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #endif
 
-#ifndef ARRAY_SIZE
-#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+#ifndef ZCBOR_ARRAY_SIZE
+#define ZCBOR_ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 #endif
 
 #if SIZE_MAX <= UINT64_MAX

--- a/include/zcbor_decode.h
+++ b/include/zcbor_decode.h
@@ -328,7 +328,7 @@ void zcbor_new_decode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
 #define ZCBOR_STATE_D(name, num_backups, payload, payload_size, elem_count) \
 zcbor_state_t name[((num_backups) + 2)]; \
 do { \
-	zcbor_new_decode_state(name, ARRAY_SIZE(name), payload, payload_size, elem_count); \
+	zcbor_new_decode_state(name, ZCBOR_ARRAY_SIZE(name), payload, payload_size, elem_count); \
 } while(0)
 
 #endif /* ZCBOR_DECODE_H__ */

--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -272,7 +272,7 @@ void zcbor_new_encode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
 #define ZCBOR_STATE_E(name, num_backups, payload, payload_size, elem_count) \
 zcbor_state_t name[((num_backups) + 2)]; \
 do { \
-	zcbor_new_encode_state(name, ARRAY_SIZE(name), payload, payload_size, elem_count); \
+	zcbor_new_encode_state(name, ZCBOR_ARRAY_SIZE(name), payload, payload_size, elem_count); \
 } while(0)
 
 #endif /* ZCBOR_ENCODE_H__ */


### PR DESCRIPTION
Since it causes include-order problems in Zephyr builds. ARRAY_SIZE() in zephyr/sys/util.h is not encased in #ifndef. Encasing zcbor's ARRAY_SIZE in #ifdef __ZEPHYR__ causes problems in zcbor's tests because util.h gives warnings under -Wconversion (which is used in zcbor tests).

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>