### PR TITLE
Add support for simple values and rename "prim" to "simple"

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   merge-test-1:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         platform: ["native_posix", "native_posix_64", "mps2_an521"]
@@ -28,7 +28,7 @@ jobs:
         zephyr_toolchain_arch: ${{ matrix.platform == 'mps2_an521' && 'arm' || ''}}
 
   merge-test-2:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
@@ -101,7 +101,7 @@ jobs:
         python3 -m unittest test_repo_files
 
   release-test-1:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Release tests 1 (Fuzz)
     needs:
     - merge-test-1
@@ -145,7 +145,7 @@ jobs:
         path: dist/*
 
   release-test-2:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']

--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -148,14 +148,14 @@ typedef bool(zcbor_decoder_t)(zcbor_state_t *, void *);
  */
 typedef enum
 {
-	ZCBOR_MAJOR_TYPE_PINT = 0, ///! Positive Integer
-	ZCBOR_MAJOR_TYPE_NINT = 1, ///! Negative Integer
-	ZCBOR_MAJOR_TYPE_BSTR = 2, ///! Byte String
-	ZCBOR_MAJOR_TYPE_TSTR = 3, ///! Text String
-	ZCBOR_MAJOR_TYPE_LIST = 4, ///! List
-	ZCBOR_MAJOR_TYPE_MAP  = 5, ///! Map
-	ZCBOR_MAJOR_TYPE_TAG  = 6, ///! Semantic Tag
-	ZCBOR_MAJOR_TYPE_PRIM = 7, ///! Primitive Type
+	ZCBOR_MAJOR_TYPE_PINT   = 0, ///! Positive Integer
+	ZCBOR_MAJOR_TYPE_NINT   = 1, ///! Negative Integer
+	ZCBOR_MAJOR_TYPE_BSTR   = 2, ///! Byte String
+	ZCBOR_MAJOR_TYPE_TSTR   = 3, ///! Text String
+	ZCBOR_MAJOR_TYPE_LIST   = 4, ///! List
+	ZCBOR_MAJOR_TYPE_MAP    = 5, ///! Map
+	ZCBOR_MAJOR_TYPE_TAG    = 6, ///! Semantic Tag
+	ZCBOR_MAJOR_TYPE_SIMPLE = 7, ///! Simple values and floats
 } zcbor_major_type_t;
 
 
@@ -201,7 +201,7 @@ do { \
 #define ZCBOR_VALUE_IS_8_BYTES 27 ///! The next 8 bytes contain the value.
 #define ZCBOR_VALUE_IS_INDEFINITE_LENGTH 31 ///! The list or map has indefinite length, and will instead be terminated by a 0xFF token.
 
-#define ZCBOR_BOOL_TO_PRIM ((uint8_t)20) ///! In CBOR, false/true have the values 20/21
+#define ZCBOR_BOOL_TO_SIMPLE ((uint8_t)20) ///! In CBOR, false/true have the values 20/21
 
 #define ZCBOR_FLAG_RESTORE 1UL ///! Restore from the backup. Overwrite the current state with the state from the backup.
 #define ZCBOR_FLAG_CONSUME 2UL ///! Consume the backup. Remove the backup from the stack of backups.

--- a/include/zcbor_decode.h
+++ b/include/zcbor_decode.h
@@ -131,7 +131,11 @@ static inline bool zcbor_tstr_expect_ptr(zcbor_state_t *state, char const *ptr, 
 bool zcbor_tag_decode(zcbor_state_t *state, uint32_t *result);
 bool zcbor_tag_expect(zcbor_state_t *state, uint32_t result);
 
-/** Decode and consume a boolean primitive value. */
+/** Decode and consume a simple value. */
+bool zcbor_simple_decode(zcbor_state_t *state, uint8_t *result);
+bool zcbor_simple_expect(zcbor_state_t *state, uint8_t result);
+
+/** Decode and consume a boolean simple value. */
 bool zcbor_bool_decode(zcbor_state_t *state, bool *result);
 bool zcbor_bool_expect(zcbor_state_t *state, bool result);
 
@@ -143,7 +147,7 @@ bool zcbor_float64_expect(zcbor_state_t *state, double result);
 bool zcbor_float_decode(zcbor_state_t *state, double *result);
 bool zcbor_float_expect(zcbor_state_t *state, double result);
 
-/** Consume and expect a "nil"/"undefined" primitive value.
+/** Consume and expect a "nil"/"undefined" simple value.
  *
  * @param[inout] state   The current state of the encoding.
  * @param[in]    unused  Unused parameter to maintain signature parity with

--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -111,7 +111,11 @@ static inline bool zcbor_tstr_encode_ptr(zcbor_state_t *state, const char *ptr, 
 /** Encode a tag. Must be called before encoding the value being tagged. */
 bool zcbor_tag_encode(zcbor_state_t *state, uint32_t tag);
 
-/** Encode a boolean primitive value. */
+/** Encode a simple value. */
+bool zcbor_simple_encode(zcbor_state_t *state, uint8_t *input);
+bool zcbor_simple_put(zcbor_state_t *state, uint8_t input);
+
+/** Encode a boolean simple value. */
 bool zcbor_bool_put(zcbor_state_t *state, bool input);
 bool zcbor_bool_encode(zcbor_state_t *state, const bool *input);
 
@@ -121,7 +125,7 @@ bool zcbor_float32_encode(zcbor_state_t *state, const float *input);
 bool zcbor_float64_put(zcbor_state_t *state, double input);
 bool zcbor_float64_encode(zcbor_state_t *state, const double *input);
 
-/** Encode a "nil"/"undefined" primitive value. @p unused should be NULL.
+/** Encode a "nil"/"undefined" simple value. @p unused should be NULL.
  *
  * @param[inout] state   The current state of the encoding.
  * @param[in]    unused  Unused parameter to maintain signature parity with

--- a/tests/cases/corner_cases.cddl
+++ b/tests/cases/corner_cases.cddl
@@ -43,11 +43,11 @@ Strings = [
 	threehundrebytebstr: bstr .size 300,
 	#6.0(tentothirtybytetstr: tstr .size 10..30),
 	cborNumbers: bstr .cbor Numbers,
-	cborseqPrimitives: bstr .cborseq Primitives,
+	cborseqSimples: bstr .cborseq Simples,
 	?optCborStrings: bstr .cbor Strings,
 ]
 
-Primitives = [
+Simples = [
 	booltrue: true,
 	boolfalse: false,
 	boolval: bool,
@@ -55,8 +55,8 @@ Primitives = [
 	undef: undefined,
 ]
 
-Prim = Primitives
-Prim2 = Prim
+Simple1 = Simples
+Simple2 = Simple1
 
 Optional = [
 	#6.10(boolval: bool),

--- a/tests/decode/test5_corner_cases/CMakeLists.txt
+++ b/tests/decode/test5_corner_cases/CMakeLists.txt
@@ -27,7 +27,7 @@ set(py_command
     TaggedUnion
     NumberMap
     Strings
-    Prim2
+    Simple2
     Optional
     Union
     Map

--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -359,7 +359,7 @@ void test_strings(void)
 				0x1A, 0xFF, 0xFF, 0xFF, 0xFF, // 0xFFFFFFFF
 				0xD9, 0xFF, 0xFF, 0x09, // 9, tagged (0xFFFF)
 			END
-		STR_LEN(0x52, 3), // Primitives (len: 18)
+		STR_LEN(0x52, 3), // Simples (len: 18)
 			LIST(5),
 				0xF5, // True
 				0xF4, // False
@@ -410,7 +410,7 @@ void test_strings(void)
 					0x1A, 0xFF, 0xFF, 0xFF, 0xFF, // 0xFFFFFFFF
 					0xD9, 0xFF, 0xFF, 0x29, // -10, tagged (0xFFFF)
 				END
-			STR_LEN(0x46, 1), // Primitives (len: 6)
+			STR_LEN(0x46, 1), // Simples (len: 6)
 				LIST(5),
 					0xF5, // True
 					0xF4, // False
@@ -441,10 +441,10 @@ void test_strings(void)
 	zassert_equal(9, strings1.threehundrebytebstr.value[299], NULL);
 	zassert_equal(30, strings1.tentothirtybytetstr.len, NULL);
 	zassert_equal(STR_LEN(29, 1), strings1.cborNumbers.len, NULL);
-	zassert_equal(3, strings1.cborseqPrimitives_cbor_count, NULL);
-	zassert_false(strings1.cborseqPrimitives_cbor[0].boolval, NULL);
-	zassert_true(strings1.cborseqPrimitives_cbor[1].boolval, NULL);
-	zassert_false(strings1.cborseqPrimitives_cbor[2].boolval, NULL);
+	zassert_equal(3, strings1.cborseqSimples_cbor_count, NULL);
+	zassert_false(strings1.cborseqSimples_cbor[0].boolval, NULL);
+	zassert_true(strings1.cborseqSimples_cbor[1].boolval, NULL);
+	zassert_false(strings1.cborseqSimples_cbor[2].boolval, NULL);
 
 	zassert_equal(300, strings2.threehundrebytebstr.len, NULL);
 	zassert_equal(10, strings2.tentothirtybytetstr.len, NULL);
@@ -455,38 +455,38 @@ void test_strings(void)
 	zassert_equal(-2147483648, numbers2.negint, NULL);
 	zassert_equal(0xFFFFFFFF, numbers2.posint, NULL);
 	zassert_equal(-10, numbers2.tagged_int, NULL);
-	zassert_equal(1, strings2.cborseqPrimitives_cbor_count, NULL);
-	zassert_false(strings2.cborseqPrimitives_cbor[0].boolval, NULL);
+	zassert_equal(1, strings2.cborseqSimples_cbor_count, NULL);
+	zassert_false(strings2.cborseqSimples_cbor[0].boolval, NULL);
 }
 
-void test_primitives(void)
+void test_simples(void)
 {
-	uint8_t payload_prim1[] = {LIST(5), 0xF5, 0xF4, 0xF4, 0xF6, 0xF7, END};
-	uint8_t payload_prim2[] = {LIST(5), 0xF5, 0xF4, 0xF5, 0xF6, 0xF7, END};
-	uint8_t payload_prim_inv3[] = {LIST(5), 0xF7, 0xF4, 0xF4, 0xF6, 0xF7, END};
-	uint8_t payload_prim_inv4[] = {LIST(5), 0xF5, 0xF7, 0xF4, 0xF6, 0xF7, END};
-	uint8_t payload_prim_inv5[] = {LIST(5), 0xF5, 0xF4, 0xF7, 0xF6, 0xF7, END};
-	uint8_t payload_prim_inv6[] = {LIST(5), 0xF5, 0xF4, 0xF5, 0xF7, 0xF7, END};
-	uint8_t payload_prim_inv7[] = {LIST(5), 0xF5, 0xF4, 0xF5, 0xF6, 0xF6, END};
-	uint8_t payload_prim_inv8[] = {LIST(5), 0xF5, 0xF4, 0xF5, 0xF6, 0xF5, END};
-	uint8_t payload_prim_inv9[] = {LIST(5), 0xF5, 0xF4, 0xF6, 0xF6, 0xF7, END};
-	uint8_t payload_prim_inv10[] = {LIST(5), 0xF5, 0xF5, 0xF5, 0xF6, 0xF7, END};
-	uint8_t payload_prim_inv11[] = {LIST(5), 0xF4, 0xF4, 0xF5, 0xF6, 0xF7, END};
+	uint8_t payload_simple1[] = {LIST(5), 0xF5, 0xF4, 0xF4, 0xF6, 0xF7, END};
+	uint8_t payload_simple2[] = {LIST(5), 0xF5, 0xF4, 0xF5, 0xF6, 0xF7, END};
+	uint8_t payload_simple_inv3[] = {LIST(5), 0xF7, 0xF4, 0xF4, 0xF6, 0xF7, END};
+	uint8_t payload_simple_inv4[] = {LIST(5), 0xF5, 0xF7, 0xF4, 0xF6, 0xF7, END};
+	uint8_t payload_simple_inv5[] = {LIST(5), 0xF5, 0xF4, 0xF7, 0xF6, 0xF7, END};
+	uint8_t payload_simple_inv6[] = {LIST(5), 0xF5, 0xF4, 0xF5, 0xF7, 0xF7, END};
+	uint8_t payload_simple_inv7[] = {LIST(5), 0xF5, 0xF4, 0xF5, 0xF6, 0xF6, END};
+	uint8_t payload_simple_inv8[] = {LIST(5), 0xF5, 0xF4, 0xF5, 0xF6, 0xF5, END};
+	uint8_t payload_simple_inv9[] = {LIST(5), 0xF5, 0xF4, 0xF6, 0xF6, 0xF7, END};
+	uint8_t payload_simple_inv10[] = {LIST(5), 0xF5, 0xF5, 0xF5, 0xF6, 0xF7, END};
+	uint8_t payload_simple_inv11[] = {LIST(5), 0xF4, 0xF4, 0xF5, 0xF6, 0xF7, END};
 
-	struct Primitives result;
+	struct Simples result;
 	size_t len_decode;
 
-	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Prim2(payload_prim1, sizeof(payload_prim1), &result, &len_decode), NULL);
-	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Prim2(payload_prim2, sizeof(payload_prim2), &result, &len_decode), NULL);
-	zassert_equal(ZCBOR_ERR_WRONG_VALUE, cbor_decode_Prim2(payload_prim_inv3, sizeof(payload_prim_inv3), &result, &len_decode), NULL);
-	zassert_equal(ZCBOR_ERR_WRONG_VALUE, cbor_decode_Prim2(payload_prim_inv4, sizeof(payload_prim_inv4), &result, &len_decode), NULL);
-	zassert_equal(ZCBOR_ERR_WRONG_VALUE, cbor_decode_Prim2(payload_prim_inv5, sizeof(payload_prim_inv5), &result, &len_decode), NULL);
-	zassert_equal(ZCBOR_ERR_WRONG_VALUE, cbor_decode_Prim2(payload_prim_inv6, sizeof(payload_prim_inv6), &result, &len_decode), NULL);
-	zassert_equal(ZCBOR_ERR_WRONG_VALUE, cbor_decode_Prim2(payload_prim_inv7, sizeof(payload_prim_inv7), &result, &len_decode), NULL);
-	zassert_equal(ZCBOR_ERR_WRONG_VALUE, cbor_decode_Prim2(payload_prim_inv8, sizeof(payload_prim_inv8), &result, &len_decode), NULL);
-	zassert_equal(ZCBOR_ERR_WRONG_VALUE, cbor_decode_Prim2(payload_prim_inv9, sizeof(payload_prim_inv9), &result, &len_decode), NULL);
-	zassert_equal(ZCBOR_ERR_WRONG_VALUE, cbor_decode_Prim2(payload_prim_inv10, sizeof(payload_prim_inv10), &result, &len_decode), NULL);
-	zassert_equal(ZCBOR_ERR_WRONG_VALUE, cbor_decode_Prim2(payload_prim_inv11, sizeof(payload_prim_inv11), &result, &len_decode), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Simple2(payload_simple1, sizeof(payload_simple1), &result, &len_decode), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Simple2(payload_simple2, sizeof(payload_simple2), &result, &len_decode), NULL);
+	zassert_equal(ZCBOR_ERR_WRONG_VALUE, cbor_decode_Simple2(payload_simple_inv3, sizeof(payload_simple_inv3), &result, &len_decode), NULL);
+	zassert_equal(ZCBOR_ERR_WRONG_VALUE, cbor_decode_Simple2(payload_simple_inv4, sizeof(payload_simple_inv4), &result, &len_decode), NULL);
+	zassert_equal(ZCBOR_ERR_WRONG_TYPE, cbor_decode_Simple2(payload_simple_inv5, sizeof(payload_simple_inv5), &result, &len_decode), NULL);
+	zassert_equal(ZCBOR_ERR_WRONG_VALUE, cbor_decode_Simple2(payload_simple_inv6, sizeof(payload_simple_inv6), &result, &len_decode), NULL);
+	zassert_equal(ZCBOR_ERR_WRONG_VALUE, cbor_decode_Simple2(payload_simple_inv7, sizeof(payload_simple_inv7), &result, &len_decode), NULL);
+	zassert_equal(ZCBOR_ERR_WRONG_VALUE, cbor_decode_Simple2(payload_simple_inv8, sizeof(payload_simple_inv8), &result, &len_decode), NULL);
+	zassert_equal(ZCBOR_ERR_WRONG_TYPE, cbor_decode_Simple2(payload_simple_inv9, sizeof(payload_simple_inv9), &result, &len_decode), NULL);
+	zassert_equal(ZCBOR_ERR_WRONG_VALUE, cbor_decode_Simple2(payload_simple_inv10, sizeof(payload_simple_inv10), &result, &len_decode), NULL);
+	zassert_equal(ZCBOR_ERR_WRONG_VALUE, cbor_decode_Simple2(payload_simple_inv11, sizeof(payload_simple_inv11), &result, &len_decode), NULL);
 }
 
 void test_string_overflow(void)
@@ -1836,7 +1836,7 @@ void test_main(void)
 			 ztest_unit_test(test_tagged_union),
 			 ztest_unit_test(test_number_map),
 			 ztest_unit_test(test_strings),
-			 ztest_unit_test(test_primitives),
+			 ztest_unit_test(test_simples),
 			 ztest_unit_test(test_string_overflow),
 			 ztest_unit_test(test_optional),
 			 ztest_unit_test(test_union),

--- a/tests/encode/test3_corner_cases/CMakeLists.txt
+++ b/tests/encode/test3_corner_cases/CMakeLists.txt
@@ -26,7 +26,7 @@ set(py_command
   NumberMap
   TaggedUnion
   Strings
-  Prim2
+  Simple2
   Optional
   Union
   Map

--- a/tests/encode/test3_corner_cases/src/main.c
+++ b/tests/encode/test3_corner_cases/src/main.c
@@ -258,9 +258,9 @@ void test_strings(void)
 				0xD9, 0xFF, 0xFF, 9, // 9
 				END
 #ifndef ZCBOR_CANONICAL
-		0x55, // Primitives (len: 21)
+		0x55, // Simples (len: 21)
 #else
-		0x52, // Primitives (len: 18)
+		0x52, // Simples (len: 18)
 #endif
 			LIST(5), // List start
 				0xF5, // True
@@ -321,9 +321,9 @@ void test_strings(void)
 					0xD9, 0xFF, 0xFF, 0x29, // -10
 					END
 #ifndef ZCBOR_CANONICAL
-			0x47, // Primitives (len: 7)
+			0x47, // Simples (len: 7)
 #else
-			0x46, // Primitives (len: 6)
+			0x46, // Simples (len: 6)
 #endif
 				LIST(5), // List start
 					0xF5, // True
@@ -371,17 +371,17 @@ void test_strings(void)
 	strings1.threehundrebytebstr.value = bytes300;
 	strings1.tentothirtybytetstr.len = 30;
 	strings1.tentothirtybytetstr.value = bytes300;
-	strings1.cborseqPrimitives_cbor_count = 3;
-	strings1.cborseqPrimitives_cbor[0].boolval = false;
-	strings1.cborseqPrimitives_cbor[1].boolval = true;
-	strings1.cborseqPrimitives_cbor[2].boolval = false;
+	strings1.cborseqSimples_cbor_count = 3;
+	strings1.cborseqSimples_cbor[0].boolval = false;
+	strings1.cborseqSimples_cbor[1].boolval = true;
+	strings1.cborseqSimples_cbor[2].boolval = false;
 
 	strings2.threehundrebytebstr.len = 300;
 	strings2.threehundrebytebstr.value = bytes300;
 	strings2.tentothirtybytetstr.len = 9; // Invalid
 	strings2.tentothirtybytetstr.value = bytes300;
-	strings2.cborseqPrimitives_cbor_count = 1;
-	strings2.cborseqPrimitives_cbor[0].boolval = false;
+	strings2.cborseqSimples_cbor_count = 1;
+	strings2.cborseqSimples_cbor[0].boolval = false;
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Numbers(output2, sizeof(output2), &numbers1, &out_len), NULL);
 	strings1.cborNumbers.value = output2;
@@ -403,24 +403,24 @@ void test_strings(void)
 	zassert_mem_equal(exp_payload_strings1, output4, sizeof(exp_payload_strings1), NULL);
 }
 
-void test_primitives(void)
+void test_simples(void)
 {
-	uint8_t exp_payload_prim1[] = {LIST(5), 0xF5, 0xF4, 0xF4, 0xF6, 0xF7, END};
-	uint8_t exp_payload_prim2[] = {LIST(5), 0xF5, 0xF4, 0xF5, 0xF6, 0xF7, END};
+	uint8_t exp_payload_simple1[] = {LIST(5), 0xF5, 0xF4, 0xF4, 0xF6, 0xF7, END};
+	uint8_t exp_payload_simple2[] = {LIST(5), 0xF5, 0xF4, 0xF5, 0xF6, 0xF7, END};
 
-	struct Primitives input;
+	struct Simples input;
 	size_t len_encode;
 	uint8_t output[10];
 
 	input.boolval = false;
-	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Prim2(output, sizeof(output), &input, &len_encode), NULL);
-	zassert_equal(len_encode, sizeof(exp_payload_prim1), NULL);
-	zassert_mem_equal(exp_payload_prim1, output, sizeof(exp_payload_prim1), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Simple2(output, sizeof(output), &input, &len_encode), NULL);
+	zassert_equal(len_encode, sizeof(exp_payload_simple1), NULL);
+	zassert_mem_equal(exp_payload_simple1, output, sizeof(exp_payload_simple1), NULL);
 
 	input.boolval = true;
-	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Prim2(output, sizeof(output), &input, &len_encode), NULL);
-	zassert_equal(len_encode, sizeof(exp_payload_prim2), NULL);
-	zassert_mem_equal(exp_payload_prim2, output, sizeof(exp_payload_prim2), NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Simple2(output, sizeof(output), &input, &len_encode), NULL);
+	zassert_equal(len_encode, sizeof(exp_payload_simple2), NULL);
+	zassert_mem_equal(exp_payload_simple2, output, sizeof(exp_payload_simple2), NULL);
 }
 
 void test_optional(void)
@@ -1452,7 +1452,7 @@ void test_main(void)
 			 ztest_unit_test(test_tagged_union),
 			 ztest_unit_test(test_number_map),
 			 ztest_unit_test(test_strings),
-			 ztest_unit_test(test_primitives),
+			 ztest_unit_test(test_simples),
 			 ztest_unit_test(test_optional),
 			 ztest_unit_test(test_union),
 			 ztest_unit_test(test_levels),

--- a/tests/scripts/test_zcbor.py
+++ b/tests/scripts/test_zcbor.py
@@ -640,7 +640,7 @@ class TestUndefined(TestCase):
     def test_undefined_0(self):
         cddl_res = zcbor.DataTranslator.from_cddl(
             p_prelude.read_text() + '\n' + p_corner_cases.read_text(), 16)
-        cddl = cddl_res.my_types['Primitives']
+        cddl = cddl_res.my_types['Simples']
         test_yaml = "[true, false, true, null, [zcbor_undefined]]"
 
         decoded = cddl.decode_str_yaml(test_yaml)

--- a/tests/unit/test1_unit_tests/src/main.c
+++ b/tests/unit/test1_unit_tests/src/main.c
@@ -873,6 +873,32 @@ void test_encode_int_0(void)
 }
 
 
+void test_simple(void)
+{
+	uint8_t payload1[100];
+	ZCBOR_STATE_E(state_e, 1, payload1, sizeof(payload1), 0);
+	ZCBOR_STATE_D(state_d, 1, payload1, sizeof(payload1), 16);
+	uint8_t simple1 = 0;
+	uint8_t simple2 = 2;
+
+	zassert_true(zcbor_simple_encode(state_e, &simple1), NULL);
+	zassert_true(zcbor_simple_put(state_e, 14), NULL);
+	zassert_true(zcbor_simple_put(state_e, 22), NULL);
+	zassert_true(zcbor_simple_put(state_e, 24), NULL);
+	zassert_true(zcbor_simple_put(state_e, 255), NULL);
+
+	zassert_true(zcbor_simple_decode(state_d, &simple2), NULL);
+	zassert_true(zcbor_simple_expect(state_d, 14), NULL);
+	zassert_true(zcbor_nil_expect(state_d, NULL), NULL);
+	zassert_false(zcbor_undefined_expect(state_d, NULL), NULL);
+	zassert_true(zcbor_simple_expect(state_d, 24), NULL);
+	zassert_false(zcbor_simple_expect(state_d, 254), NULL);
+	zassert_true(zcbor_simple_decode(state_d, &simple1), NULL);
+	zassert_equal(0, simple2, NULL);
+	zassert_equal(255, simple1, NULL);
+}
+
+
 void test_main(void)
 {
 	ztest_test_suite(zcbor_unit_tests,
@@ -889,7 +915,8 @@ void test_main(void)
 			 ztest_unit_test(test_canonical_list),
 			 ztest_unit_test(test_int),
 			 ztest_unit_test(test_uint),
-			 ztest_unit_test(test_encode_int_0)
+			 ztest_unit_test(test_encode_int_0),
+			 ztest_unit_test(test_simple)
 	);
 	ztest_run_test_suite(zcbor_unit_tests);
 }


### PR DESCRIPTION
C libraries: Rename prim/primitive to simple

Which is what it's called in RFC8949.
Includes exposing new APIs: zcbor_simple_(encode/put/decode/expect)
Add some tests for the new APIs.

Note: The use of "Prim" in zcbor.py is different and is not touched by
this change.