### PR TITLE
C libraries: Add new APIs zcbor_uint_(encode/decode)

### DIFF
--- a/include/zcbor_decode.h
+++ b/include/zcbor_decode.h
@@ -41,6 +41,7 @@ bool zcbor_uint32_decode(zcbor_state_t *state, uint32_t *result);
 bool zcbor_uint64_decode(zcbor_state_t *state, uint64_t *result);
 bool zcbor_size_decode(zcbor_state_t *state, size_t *result);
 bool zcbor_int_decode(zcbor_state_t *state, void *result_int, size_t int_size);
+bool zcbor_uint_decode(zcbor_state_t *state, void *result_uint, size_t uint_size);
 
 /** The following applies to all _expect() functions that don't have docs.
  *

--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -46,6 +46,7 @@ bool zcbor_size_put(zcbor_state_t *state, size_t input);
 bool zcbor_int_encode(zcbor_state_t *state, const void *input_int, size_t int_size);
 bool zcbor_int32_encode(zcbor_state_t *state, const int32_t *input);
 bool zcbor_int64_encode(zcbor_state_t *state, const int64_t *input);
+bool zcbor_uint_encode(zcbor_state_t *state, const void *input_uint, size_t uint_size);
 bool zcbor_uint32_encode(zcbor_state_t *state, const uint32_t *input);
 bool zcbor_uint64_encode(zcbor_state_t *state, const uint64_t *input);
 bool zcbor_size_encode(zcbor_state_t *state, const size_t *input);

--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -42,12 +42,14 @@ do {\
 	} \
 } while(0)
 
+
 static bool initial_checks(zcbor_state_t *state)
 {
 	ZCBOR_CHECK_ERROR();
 	ZCBOR_CHECK_PAYLOAD();
 	return true;
 }
+
 
 static bool type_check(zcbor_state_t *state, zcbor_major_type_t exp_major_type)
 {
@@ -61,6 +63,7 @@ static bool type_check(zcbor_state_t *state, zcbor_major_type_t exp_major_type)
 	}
 	return true;
 }
+
 
 #define INITIAL_CHECKS() \
 do {\
@@ -89,6 +92,7 @@ do { \
 	state->elem_count++; \
 	ZCBOR_FAIL(); \
 } while(0)
+
 
 /** Get a single value.
  *
@@ -218,12 +222,7 @@ bool zcbor_uint_decode(zcbor_state_t *state, void *result_uint, size_t uint_size
 
 bool zcbor_uint32_decode(zcbor_state_t *state, uint32_t *result)
 {
-	INITIAL_CHECKS_WITH_TYPE(ZCBOR_MAJOR_TYPE_PINT);
-
-	if (!value_extract(state, result, sizeof(*result))) {
-		ZCBOR_FAIL();
-	}
-	return true;
+	return zcbor_uint_decode(state, result, sizeof(*result));
 }
 
 
@@ -287,19 +286,14 @@ bool zcbor_int64_expect(zcbor_state_t *state, int64_t result)
 
 bool zcbor_uint64_decode(zcbor_state_t *state, uint64_t *result)
 {
-	INITIAL_CHECKS_WITH_TYPE(ZCBOR_MAJOR_TYPE_PINT);
-
-	if (!value_extract(state, result, sizeof(*result))) {
-		ZCBOR_FAIL();
-	}
-	return true;
+	return zcbor_uint_decode(state, result, sizeof(*result));
 }
 
 
 #ifdef ZCBOR_SUPPORTS_SIZE_T
 bool zcbor_size_decode(zcbor_state_t *state, size_t *result)
 {
-	return value_extract(state, result, sizeof(size_t));
+	return zcbor_uint_decode(state, result, sizeof(*result));
 }
 #endif
 

--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -204,6 +204,18 @@ bool zcbor_int64_decode(zcbor_state_t *state, int64_t *result)
 }
 
 
+bool zcbor_uint_decode(zcbor_state_t *state, void *result_uint, size_t uint_size)
+{
+	INITIAL_CHECKS_WITH_TYPE(ZCBOR_MAJOR_TYPE_PINT);
+
+	if (!value_extract(state, result_uint, uint_size)) {
+		zcbor_print("uint with size %d failed.\r\n", uint_size);
+		ZCBOR_FAIL();
+	}
+	return true;
+}
+
+
 bool zcbor_uint32_decode(zcbor_state_t *state, uint32_t *result)
 {
 	INITIAL_CHECKS_WITH_TYPE(ZCBOR_MAJOR_TYPE_PINT);

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -177,6 +177,15 @@ bool zcbor_int_encode(zcbor_state_t *state, const void *input_int, size_t int_si
 }
 
 
+bool zcbor_uint_encode(zcbor_state_t *state, const void *input_uint, size_t uint_size)
+{
+	if (!value_encode(state, ZCBOR_MAJOR_TYPE_PINT, input_uint, uint_size)) {
+		ZCBOR_FAIL();
+	}
+	return true;
+}
+
+
 bool zcbor_int32_encode(zcbor_state_t *state, const int32_t *input)
 {
 	return zcbor_int_encode(state, input, sizeof(*input));

--- a/tests/unit/test1_unit_tests/src/main.c
+++ b/tests/unit/test1_unit_tests/src/main.c
@@ -112,6 +112,11 @@ void test_size(void)
 	zassert_false(zcbor_size_expect(&state_d, -6), NULL);
 	zassert_true(zcbor_size_expect(&state_d, 5), NULL);
 
+	zassert_true(zcbor_int32_put(&state_e, -7), NULL);
+	zassert_false(zcbor_size_expect(&state_d, -7), NULL);
+	zassert_false(zcbor_size_decode(&state_d, &read), NULL); // Negative number not supported.
+	zassert_true(zcbor_int32_expect(&state_d, -7), NULL);
+
 	zassert_true(zcbor_uint32_put(&state_e, 5), NULL);
 	zassert_true(zcbor_size_expect(&state_d, 5), NULL);
 


### PR DESCRIPTION
Analogous to the 'int' variety which already exists. Add test.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>