### PR TITLE
C libraries: Various cleanup

### DIFF
--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -42,12 +42,14 @@ do {\
 	} \
 } while(0)
 
+
 static bool initial_checks(zcbor_state_t *state)
 {
 	ZCBOR_CHECK_ERROR();
 	ZCBOR_CHECK_PAYLOAD();
 	return true;
 }
+
 
 static bool type_check(zcbor_state_t *state, zcbor_major_type_t exp_major_type)
 {
@@ -61,6 +63,7 @@ static bool type_check(zcbor_state_t *state, zcbor_major_type_t exp_major_type)
 	}
 	return true;
 }
+
 
 #define INITIAL_CHECKS() \
 do {\
@@ -89,6 +92,7 @@ do { \
 	state->elem_count++; \
 	ZCBOR_FAIL(); \
 } while(0)
+
 
 /** Get a single value.
  *
@@ -287,6 +291,8 @@ bool zcbor_uint64_decode(zcbor_state_t *state, uint64_t *result)
 #ifdef ZCBOR_SUPPORTS_SIZE_T
 bool zcbor_size_decode(zcbor_state_t *state, size_t *result)
 {
+	INITIAL_CHECKS_WITH_TYPE(ZCBOR_MAJOR_TYPE_PINT);
+
 	return value_extract(state, result, sizeof(size_t));
 }
 #endif

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -32,10 +32,12 @@ static uint8_t log2ceil(uint_fast32_t val)
 	return 0;
 }
 
+
 static uint8_t get_additional(uint_fast32_t len, uint8_t value0)
 {
 	return len == 0 ? value0 : (uint8_t)(24 + log2ceil(len));
 }
+
 
 static bool encode_header_byte(zcbor_state_t *state,
 	zcbor_major_type_t major_type, uint8_t additional)
@@ -192,10 +194,7 @@ bool zcbor_int64_encode(zcbor_state_t *state, const int64_t *input)
 static bool uint32_encode(zcbor_state_t *state, const uint32_t *input,
 		zcbor_major_type_t major_type)
 {
-	if (!value_encode(state, major_type, input, 4)) {
-		ZCBOR_FAIL();
-	}
-	return true;
+	return value_encode(state, major_type, input, 4);
 }
 
 
@@ -211,10 +210,7 @@ bool zcbor_uint32_encode(zcbor_state_t *state, const uint32_t *input)
 static bool uint64_encode(zcbor_state_t *state, const uint64_t *input,
 		zcbor_major_type_t major_type)
 {
-	if (!value_encode(state, major_type, input, 8)) {
-		ZCBOR_FAIL();
-	}
-	return true;
+	return value_encode(state, major_type, input, 8);
 }
 
 
@@ -590,6 +586,7 @@ bool zcbor_multi_encode_minmax(uint_fast32_t min_encode,
 		ZCBOR_ERR(ZCBOR_ERR_ITERATIONS);
 	}
 }
+
 
 bool zcbor_multi_encode(uint_fast32_t num_encode,
 		zcbor_encoder_t encoder,

--- a/tests/unit/test1_unit_tests/src/main.c
+++ b/tests/unit/test1_unit_tests/src/main.c
@@ -112,6 +112,11 @@ void test_size(void)
 	zassert_false(zcbor_size_expect(&state_d, -6), NULL);
 	zassert_true(zcbor_size_expect(&state_d, 5), NULL);
 
+	zassert_true(zcbor_int32_put(&state_e, -7), NULL);
+	zassert_false(zcbor_size_expect(&state_d, -7), NULL);
+	zassert_false(zcbor_size_decode(&state_d, &read), NULL); // Negative number not supported.
+	zassert_true(zcbor_int32_expect(&state_d, -7), NULL);
+
 	zassert_true(zcbor_uint32_put(&state_e, 5), NULL);
 	zassert_true(zcbor_size_expect(&state_d, 5), NULL);
 


### PR DESCRIPTION
Including one bug fix where the major type wasn't checked when calling zcbor_size_decode().
Add test for bugfix.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>