### PR TITLE
zcbor.py: Clean up #includes in generated files

### DIFF
--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -5,8 +5,9 @@
  */
 
 #include <zephyr/ztest.h>
-#include "corner_cases.h"
-#include "zcbor_debug.h" // Enables use of print functions when debugging tests.
+#include <corner_cases.h>
+#include <zcbor_decode.h>
+#include <zcbor_debug.h> // Enables use of print functions when debugging tests.
 
 #define CONCAT_BYTE(a,b) a ## b
 

--- a/tests/encode/test2_simple/src/main.c
+++ b/tests/encode/test2_simple/src/main.c
@@ -5,8 +5,9 @@
  */
 
 #include <zephyr/ztest.h>
-#include "pet_encode.h"
-#include "zcbor_debug.h" // Enables use of print functions when debugging tests.
+#include <pet_encode.h>
+#include <zcbor_encode.h>
+#include <zcbor_debug.h> // Enables use of print functions when debugging tests.
 
 
 #define CONCAT_BYTE(a,b) a ## b

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -2612,7 +2612,6 @@ static bool {xcoder.func_name}(
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
-#include "zcbor_{mode}.h"
 #include "{type_def_file}"
 
 #ifdef __cplusplus
@@ -2635,6 +2634,10 @@ extern "C" {{
 """
 
     def render_type_file(self, header_guard, mode):
+        body = (
+            linesep + linesep).join(
+                [f"{typedef[1]} {{{linesep}{linesep.join(typedef[0][1:])};"
+                    for typedef in self.type_defs[mode]])
         return \
             f"""/*
  * Generated using zcbor version {self.version}
@@ -2649,8 +2652,7 @@ extern "C" {{
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
-#include <string.h>
-#include "zcbor_{mode}.h"
+{'#include <zcbor_common.h>' if "struct zcbor_string" in body else ""}
 
 #ifdef __cplusplus
 extern "C" {{
@@ -2665,9 +2667,7 @@ extern "C" {{
  */
 #define DEFAULT_MAX_QTY {self.default_max_qty}
 
-{(linesep+linesep).join(
-    [f"{typedef[1]} {{{linesep}{linesep.join(typedef[0][1:])};"
-        for typedef in self.type_defs[mode]])}
+{body}
 
 #ifdef __cplusplus
 }}


### PR DESCRIPTION
Remove unneeded includes from header files for easier mocking. Some additional cleanup

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>