### PR TITLE
zcbor_common: Add a zcbor_entry_function helper

### DIFF
--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -284,6 +284,13 @@ bool zcbor_union_end_code(zcbor_state_t *state);
 void zcbor_new_state(zcbor_state_t *state_array, size_t n_states,
 		const uint8_t *payload, size_t payload_len, size_t elem_count);
 
+/** Do boilerplate entry function procedure.
+ *  Initialize states, call function, and check the result.
+ */
+int zcbor_entry_function(const uint8_t *payload, size_t payload_len,
+	void *result, size_t *payload_len_out, zcbor_state_t *state, zcbor_decoder_t func,
+	uint_fast32_t n_states, uint_fast32_t elem_count);
+
 #ifdef ZCBOR_STOP_ON_ERROR
 /** Check stored error and fail if present, but only if stop_on_error is true. */
 static inline bool zcbor_check_error(const zcbor_state_t *state)

--- a/samples/pet/src/pet_decode.c
+++ b/samples/pet/src/pet_decode.c
@@ -50,20 +50,6 @@ int cbor_decode_Pet(
 {
 	zcbor_state_t states[4];
 
-	zcbor_new_state(states, sizeof(states) / sizeof(zcbor_state_t), payload, payload_len, 1);
-
-	bool ret = decode_Pet(states, result);
-
-	if (ret && (payload_len_out != NULL)) {
-		*payload_len_out = MIN(payload_len,
-				(size_t)states[0].payload - (size_t)payload);
-	}
-
-	if (!ret) {
-		int err = zcbor_pop_error(states);
-
-		zcbor_print("Return error: %d\r\n", err);
-		return (err == ZCBOR_SUCCESS) ? ZCBOR_ERR_UNKNOWN : err;
-	}
-	return ZCBOR_SUCCESS;
+	return zcbor_entry_function(payload, payload_len, (void *)result, payload_len_out, states,
+		(zcbor_decoder_t *)decode_Pet, sizeof(states) / sizeof(zcbor_state_t), 1);
 }

--- a/samples/pet/src/pet_encode.c
+++ b/samples/pet/src/pet_encode.c
@@ -51,20 +51,6 @@ int cbor_encode_Pet(
 {
 	zcbor_state_t states[4];
 
-	zcbor_new_state(states, sizeof(states) / sizeof(zcbor_state_t), payload, payload_len, 1);
-
-	bool ret = encode_Pet(states, input);
-
-	if (ret && (payload_len_out != NULL)) {
-		*payload_len_out = MIN(payload_len,
-				(size_t)states[0].payload - (size_t)payload);
-	}
-
-	if (!ret) {
-		int err = zcbor_pop_error(states);
-
-		zcbor_print("Return error: %d\r\n", err);
-		return (err == ZCBOR_SUCCESS) ? ZCBOR_ERR_UNKNOWN : err;
-	}
-	return ZCBOR_SUCCESS;
+	return zcbor_entry_function(payload, payload_len, (void *)input, payload_len_out, states,
+		(zcbor_decoder_t *)encode_Pet, sizeof(states) / sizeof(zcbor_state_t), 1);
 }

--- a/src/zcbor_common.c
+++ b/src/zcbor_common.c
@@ -255,3 +255,27 @@ bool zcbor_array_at_end(zcbor_state_t *state)
 			&& (state->payload < state->payload_end)
 			&& (*state->payload == 0xFF)));
 }
+
+
+int zcbor_entry_function(const uint8_t *payload, size_t payload_len,
+	void *result, size_t *payload_len_out, zcbor_state_t *state, zcbor_decoder_t func,
+	uint_fast32_t n_states, uint_fast32_t elem_count)
+{
+	zcbor_new_state(state, n_states, payload, payload_len, elem_count);
+
+	bool ret = func(state, result);
+
+	if (!ret) {
+		int err = zcbor_pop_error(state);
+
+		err = (err == ZCBOR_SUCCESS) ? ZCBOR_ERR_UNKNOWN : err;
+		zcbor_print("Return error: %d\\r\\n", err);
+		return err;
+	}
+
+	if (payload_len_out != NULL) {
+		*payload_len_out = MIN(payload_len,
+				(size_t)state[0].payload - (size_t)payload);
+	}
+	return ZCBOR_SUCCESS;
+}

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -2625,23 +2625,9 @@ static bool {xcoder.func_name}(
 {{
 	zcbor_state_t states[{xcoder.num_backups() + 2}];
 
-	zcbor_new_state(states, sizeof(states) / sizeof(zcbor_state_t), payload, payload_len, {
-        xcoder.list_counts()[1]});
-
-	bool ret = {func_name}(states, {func_arg});
-
-	if (ret && (payload_len_out != NULL)) {{
-		*payload_len_out = MIN(payload_len,
-				(size_t)states[0].payload - (size_t)payload);
-	}}
-
-	if (!ret) {{
-		int err = zcbor_pop_error(states);
-
-		zcbor_print("Return error: %d\\r\\n", err);
-		return (err == ZCBOR_SUCCESS) ? ZCBOR_ERR_UNKNOWN : err;
-	}}
-	return ZCBOR_SUCCESS;
+	return zcbor_entry_function(payload, payload_len, (void *){func_arg}, payload_len_out, states,
+		(zcbor_decoder_t *){func_name}, sizeof(states) / sizeof(zcbor_state_t), {
+            xcoder.list_counts()[1]});
 }}"""
 
     def render_file_header(self, line_prefix):


### PR DESCRIPTION
This reduces the code size when multiple entry functions are defined.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>