### PR TITLE
zcbor.py: Add support for file headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ usage: zcbor code [-h] -c CDDL [--no-prelude] [-v]
                   ENTRY_TYPES [ENTRY_TYPES ...] [-d] [-e] [--time-header]
                   [--git-sha-header] [-b {32,64}]
                   [--include-prefix INCLUDE_PREFIX] [-s]
+                  [--file-header FILE_HEADER]
 
 Parse a CDDL file and produce C code that validates and xcodes CBOR.
 The output from this script is a C file and a header file. The header file
@@ -515,6 +516,9 @@ options:
                         labels or layout, or disable this option. This might
                         also make enum names different from the corresponding
                         union members.
+  --file-header FILE_HEADER
+                        Header to be included in the comment at the top of
+                        generated C files, e.g. copyright.
 
 ```
 

--- a/samples/pet/CMakeLists.txt
+++ b/samples/pet/CMakeLists.txt
@@ -19,6 +19,7 @@ if (REGENERATE_ZCBOR)
     --output-cmake ${CMAKE_CURRENT_LIST_DIR}/pet.cmake # The generated cmake file will be placed here
                                                        # This also causes the c code to be placed in
                                                        # ${CMAKE_CURRENT_LIST_DIR}/src and ${CMAKE_CURRENT_LIST_DIR}/include)
+    --file-header "Copyright (c) 2022 Nordic Semiconductor ASA\n\nSPDX-License-Identifier: Apache-2.0"
     )
   execute_process(COMMAND ${zcbor_command})
 endif()

--- a/samples/pet/include/pet_decode.h
+++ b/samples/pet/include/pet_decode.h
@@ -1,4 +1,8 @@
 /*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Generated using zcbor version 0.6.99
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3

--- a/samples/pet/include/pet_encode.h
+++ b/samples/pet/include/pet_encode.h
@@ -1,4 +1,8 @@
 /*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Generated using zcbor version 0.6.99
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3

--- a/samples/pet/include/pet_types.h
+++ b/samples/pet/include/pet_types.h
@@ -1,4 +1,8 @@
 /*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Generated using zcbor version 0.6.99
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3

--- a/samples/pet/pet.cmake
+++ b/samples/pet/pet.cmake
@@ -1,6 +1,11 @@
 #
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 # Generated using zcbor version 0.6.99
 # https://github.com/NordicSemiconductor/zcbor
+# Generated with a --default-max-qty of 3
 #
 
 add_library(pet)

--- a/samples/pet/src/pet_decode.c
+++ b/samples/pet/src/pet_decode.c
@@ -1,4 +1,8 @@
 /*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Generated using zcbor version 0.6.99
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3

--- a/samples/pet/src/pet_encode.c
+++ b/samples/pet/src/pet_encode.c
@@ -1,4 +1,8 @@
 /*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Generated using zcbor version 0.6.99
  * https://github.com/NordicSemiconductor/zcbor
  * Generated with a --default-max-qty of 3

--- a/tests/decode/test3_simple/CMakeLists.txt
+++ b/tests/decode/test3_simple/CMakeLists.txt
@@ -22,6 +22,7 @@ set(py_command_pet
   -d
   ${bit_arg}
   --short-names
+  --file-header "Copyright (c) 2020 Nordic Semiconductor ASA\n\nSPDX-License-Identifier: Apache-2.0"
   )
 set(py_command_serial_recovery
   zcbor

--- a/tests/scripts/test_repo_files.py
+++ b/tests/scripts/test_repo_files.py
@@ -113,6 +113,23 @@ class TestSamples(TestCase):
         self.maxDiff = None
         self.assertEqual(contents, new_contents)
 
+    def test_pet_file_header(self):
+        files = (list(p_pet_include.iterdir()) + list(p_pet_src.iterdir()) + [p_pet_cmake])
+        for p in [f for f in files if "pet" in f.name]:
+            with p.open('r') as f:
+                f.readline()  # discard
+                self.assertEqual(
+                    f.readline().strip(" *#\n"),
+                    "Copyright (c) 2022 Nordic Semiconductor ASA")
+                f.readline()  # discard
+                self.assertEqual(
+                    f.readline().strip(" *#\n"),
+                    "SPDX-License-Identifier: Apache-2.0")
+                f.readline()  # discard
+                self.assertIn("Generated using zcbor version", f.readline())
+                self.assertIn("https://github.com/NordicSemiconductor/zcbor", f.readline())
+                self.assertIn("Generated with a --default-max-qty of", f.readline())
+
 
 class TestDocs(TestCase):
     def __init__(self, *args, **kwargs):

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -2456,7 +2456,7 @@ int cbor_{self.xcode_func_name()}(
 
 
 class CodeRenderer():
-    def __init__(self, entry_types, modes, print_time, default_max_qty, git_sha=''):
+    def __init__(self, entry_types, modes, print_time, default_max_qty, git_sha='', file_header=''):
         self.entry_types = entry_types
         self.print_time = print_time
         self.default_max_qty = default_max_qty
@@ -2479,6 +2479,12 @@ class CodeRenderer():
 
         if git_sha:
             self.version += f'-{git_sha}'
+
+        self.file_header = file_header.strip() + "\n\n" if file_header.strip() else ""
+        self.file_header += f"""Generated using zcbor version {self.version}
+https://github.com/NordicSemiconductor/zcbor{'''
+at: ''' + datetime.now().strftime('%Y-%m-%d %H:%M:%S') if self.print_time else ''}
+Generated with a --default-max-qty of {self.default_max_qty}"""
 
     def header_guard(self, file_name):
         return path.basename(file_name).replace(".", "_").replace("-", "_").upper() + "__"
@@ -2595,13 +2601,13 @@ static bool {xcoder.func_name}(
 	return ZCBOR_SUCCESS;
 }}"""
 
+    def render_file_header(self, line_prefix):
+        lp = line_prefix
+        return (f"\n{lp} " + self.file_header.replace("\n", f"\n{lp} ")).replace(" \n", "\n")
+
     # Render the entire generated C file contents.
     def render_c_file(self, header_file_name, mode):
-        return f"""/*
- * Generated using zcbor version {self.version}
- * https://github.com/NordicSemiconductor/zcbor{'''
- * at: ''' + datetime.now().strftime('%Y-%m-%d %H:%M:%S') if self.print_time else ''}
- * Generated with a --default-max-qty of {self.default_max_qty}
+        return f"""/*{self.render_file_header(" *")}
  */
 
 #include <stdint.h>
@@ -2625,11 +2631,7 @@ static bool {xcoder.func_name}(
     # Render the entire generated header file contents.
     def render_h_file(self, type_def_file, header_guard, mode):
         return \
-            f"""/*
- * Generated using zcbor version {self.version}
- * https://github.com/NordicSemiconductor/zcbor{'''
- * at: ''' + datetime.now().strftime('%Y-%m-%d %H:%M:%S') if self.print_time else ''}
- * Generated with a --default-max-qty of {self.default_max_qty}
+            f"""/*{self.render_file_header(" *")}
  */
 
 #ifndef {header_guard}
@@ -2666,11 +2668,7 @@ extern "C" {{
                 [f"{typedef[1]} {{{linesep}{linesep.join(typedef[0][1:])};"
                     for typedef in self.type_defs[mode]])
         return \
-            f"""/*
- * Generated using zcbor version {self.version}
- * https://github.com/NordicSemiconductor/zcbor{'''
- * at: ''' + datetime.now().strftime('%Y-%m-%d %H:%M:%S') if self.print_time else ''}
- * Generated with a --default-max-qty of {self.default_max_qty}
+            f"""/*{self.render_file_header(" *")}
  */
 
 #ifndef {header_guard}
@@ -2713,10 +2711,7 @@ extern "C" {{
             return "${CMAKE_CURRENT_LIST_DIR}/" + path.relpath(Path(p), cmake_dir)
         return \
             f"""\
-#
-# Generated using zcbor version {self.version}
-# https://github.com/NordicSemiconductor/zcbor{'''
-# at: ''' + datetime.now().strftime('%Y-%m-%d %H:%M:%S') if self.print_time else ''}
+#{self.render_file_header("#")}
 #
 
 add_library({target_name})
@@ -2883,6 +2878,10 @@ the code will be running on.""")
 names identical which will cause a compile error. If so, tweak the CDDL labels
 or layout, or disable this option. This might also make enum names different
 from the corresponding union members.""")
+    code_parser.add_argument(
+        "--file-header", required=False, type=str, default="",
+        help="Header to be included in the comment at the top of generated C files, e.g. copyright."
+    )
     code_parser.set_defaults(process=process_code)
 
     validate_parent_parser = ArgumentParser(add_help=False)
@@ -3037,6 +3036,7 @@ def process_code(args):
                                          for entry in args.entry_types] for mode in modes},
                             modes=modes, print_time=args.time_header,
                             default_max_qty=args.default_max_qty, git_sha=git_sha,
+                            file_header=args.file_header
                             )
 
     c_code_dir = Path(c_code_root, "src")


### PR DESCRIPTION
These can be used for copyrights.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>