### PR TITLE
src: Make the zcbor source files compile with -Wall and -Wconversion

### DIFF
--- a/src/zcbor_common.c
+++ b/src/zcbor_common.c
@@ -90,7 +90,7 @@ bool zcbor_process_backup(zcbor_state_t *state, uint32_t flags,
 static void update_backups(zcbor_state_t *state, uint8_t const *new_payload_end)
 {
 	if (state->constant_state) {
-		for (int i = 0; i < state->constant_state->current_backup; i++) {
+		for (unsigned int i = 0; i < state->constant_state->current_backup; i++) {
 			state->constant_state->backup_list[i].payload_end = new_payload_end;
 			state->constant_state->backup_list[i].payload_moved = true;
 		}

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -115,6 +115,8 @@ static const void *get_result(const void *const input, uint_fast32_t max_result_
 #ifdef CONFIG_BIG_ENDIAN
 	return &((uint8_t *)input)[max_result_len - (result_len ? result_len : 1)];
 #else
+	(void)max_result_len;
+	(void)result_len;
 	return input;
 #endif
 }
@@ -163,7 +165,7 @@ bool zcbor_int_encode(zcbor_state_t *state, const void *input_int, size_t int_si
 		major_type = ZCBOR_MAJOR_TYPE_NINT;
 
 		/* Convert to CBOR's representation by flipping all bits. */
-		for (int i = 0; i < int_size; i++) {
+		for (unsigned int i = 0; i < int_size; i++) {
 			input_buf[i] = (uint8_t)~input_uint8[i];
 		}
 		input = input_buf;
@@ -321,7 +323,8 @@ bool zcbor_bstr_end_encode(zcbor_state_t *state, struct zcbor_string *result)
 static bool str_encode(zcbor_state_t *state,
 		const struct zcbor_string *input, zcbor_major_type_t major_type)
 {
-	if (input->len > (state->payload_end - state->payload)) {
+	ZCBOR_CHECK_PAYLOAD(); /* To make the size_t cast below safe. */
+	if (input->len > (size_t)(state->payload_end - state->payload)) {
 		ZCBOR_ERR(ZCBOR_ERR_NO_PAYLOAD);
 	}
 	if (!str_start_encode(state, input, major_type)) {
@@ -363,6 +366,8 @@ static bool list_map_start_encode(zcbor_state_t *state, uint_fast32_t max_num,
 	}
 	state->elem_count--; /* Because of dummy header. */
 #else
+	(void)max_num;
+
 	if (!encode_header_byte(state, major_type, ZCBOR_VALUE_IS_INDEFINITE_LENGTH)) {
 		ZCBOR_FAIL();
 	}
@@ -439,6 +444,8 @@ static bool list_map_end_encode(zcbor_state_t *state, uint_fast32_t max_num,
 		state->payload = payload;
 	}
 #else
+	(void)max_num;
+	(void)major_type;
 	if (!encode_header_byte(state, ZCBOR_MAJOR_TYPE_SIMPLE, ZCBOR_VALUE_IS_INDEFINITE_LENGTH)) {
 		ZCBOR_FAIL();
 	}
@@ -467,6 +474,7 @@ bool zcbor_list_map_end_force_encode(zcbor_state_t *state)
 		ZCBOR_FAIL();
 	}
 #endif
+	(void)state;
 	return true;
 }
 

--- a/tests/unit/test1_unit_tests/CMakeLists.txt
+++ b/tests/unit/test1_unit_tests/CMakeLists.txt
@@ -6,14 +6,24 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
+set_property(GLOBAL PROPERTY CSTD c11) # To avoid issues with c99 and -Wpedantic
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(test1_unit_tests)
 include(../../cmake/test_template.cmake)
 
 FILE(GLOB zcbor_sources ../../../src/*.c)
-target_sources(app PRIVATE
-  ${zcbor_sources})
+zephyr_library_named(zcbor)
+zephyr_library_sources(${zcbor_sources})
 
 target_include_directories(app PRIVATE ../../../include)
+target_include_directories(zcbor PRIVATE ../../../include)
+
+target_link_libraries(app PRIVATE zcbor)
 
 zephyr_compile_definitions(ZCBOR_STOP_ON_ERROR)
+
+if (NOT VERBOSE AND CONFIG_MINIMAL_LIBC)
+  # VERBOSE means including printk which doesn't build with these options.
+  target_compile_options(zcbor PRIVATE -Wpedantic -Wconversion -Wall -Wextra)
+endif()


### PR DESCRIPTION
Build with these in unit test 1.
Note that generated code has multiple problems when building with these flags that are difficult to resolve, so are not covered by this.

Fixes #299 