### PR TITLE
Avoid leading and trailing as well as repeated underscores

### DIFF
--- a/samples/pet/include/pet_types.h
+++ b/samples/pet/include/pet_types.h
@@ -34,9 +34,9 @@ struct Pet {
 	size_t names_count;
 	struct zcbor_string birthday;
 	enum {
-		_Pet_species_cat = 1,
-		_Pet_species_dog = 2,
-		_Pet_species_other = 3,
+		Pet_species_cat = 1,
+		Pet_species_dog = 2,
+		Pet_species_other = 3,
 	} species_choice;
 };
 

--- a/samples/pet/src/main.c
+++ b/samples/pet/src/main.c
@@ -21,13 +21,13 @@ static void print_pet(const struct Pet *pet)
 		printf("%02x", pet->birthday.value[i]);
 	}
 	switch (pet->species_choice) {
-	case _Pet_species_cat:
+	case Pet_species_cat:
 		printf("\nSpecies: Cat\n\n");
 		return;
-	case _Pet_species_dog:
+	case Pet_species_dog:
 		printf("\nSpecies: Dog\n\n");
 		return;
-	case _Pet_species_other:
+	case Pet_species_other:
 		printf("\nSpecies: Other\n\n");
 		return;
 	}
@@ -101,7 +101,7 @@ static void get_pet3(void)
 	encoded_pet.names_count = 2;
 	encoded_pet.birthday.value = timestamp3;
 	encoded_pet.birthday.len = sizeof(timestamp3);
-	encoded_pet.species_choice = _Pet_species_other;
+	encoded_pet.species_choice = Pet_species_other;
 
 	err = cbor_encode_Pet(pet3, sizeof(pet3), &encoded_pet, NULL);
 

--- a/samples/pet/src/pet_decode.c
+++ b/samples/pet/src/pet_decode.c
@@ -31,9 +31,9 @@ static bool decode_Pet(
 	&& ((zcbor_bstr_decode(state, (&(*result).birthday)))
 	&& ((((((*result).birthday.len >= 8)
 	&& ((*result).birthday.len <= 8)) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false))) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false)))
-	&& ((((zcbor_int_decode(state, &(*result).species_choice, sizeof((*result).species_choice)))) && ((((((*result).species_choice == _Pet_species_cat) && ((1)))
-	|| (((*result).species_choice == _Pet_species_dog) && ((1)))
-	|| (((*result).species_choice == _Pet_species_other) && ((1)))) || (zcbor_error(state, ZCBOR_ERR_WRONG_VALUE), false)))))) || (zcbor_list_map_end_force_decode(state), false)) && zcbor_list_end_decode(state))));
+	&& ((((zcbor_int_decode(state, &(*result).species_choice, sizeof((*result).species_choice)))) && ((((((*result).species_choice == Pet_species_cat) && ((1)))
+	|| (((*result).species_choice == Pet_species_dog) && ((1)))
+	|| (((*result).species_choice == Pet_species_other) && ((1)))) || (zcbor_error(state, ZCBOR_ERR_WRONG_VALUE), false)))))) || (zcbor_list_map_end_force_decode(state), false)) && zcbor_list_end_decode(state))));
 
 	if (!tmp_result)
 		zcbor_trace();

--- a/samples/pet/src/pet_encode.c
+++ b/samples/pet/src/pet_encode.c
@@ -31,9 +31,9 @@ static bool encode_Pet(
 	&& (((((((*input).birthday.len >= 8)
 	&& ((*input).birthday.len <= 8)) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false))) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false))
 	&& (zcbor_bstr_encode(state, (&(*input).birthday))))
-	&& ((((*input).species_choice == _Pet_species_cat) ? ((zcbor_uint32_put(state, (1))))
-	: (((*input).species_choice == _Pet_species_dog) ? ((zcbor_uint32_put(state, (2))))
-	: (((*input).species_choice == _Pet_species_other) ? ((zcbor_uint32_put(state, (3))))
+	&& ((((*input).species_choice == Pet_species_cat) ? ((zcbor_uint32_put(state, (1))))
+	: (((*input).species_choice == Pet_species_dog) ? ((zcbor_uint32_put(state, (2))))
+	: (((*input).species_choice == Pet_species_other) ? ((zcbor_uint32_put(state, (3))))
 	: false))))) || (zcbor_list_map_end_force_encode(state), false)) && zcbor_list_end_encode(state, 3))));
 
 	if (!tmp_result)

--- a/tests/decode/test1_suit_old_formats/src/main.c
+++ b/tests/decode/test1_suit_old_formats/src/main.c
@@ -115,33 +115,33 @@ ZTEST(cbor_decode_test, test_1)
 			"test_vector2 failed");
 	zassert_equal(sizeof(test_vector2), decode_len, NULL);
 	zassert_equal(2, outerwrapper
-			._OuterWrapper_manifest_cbor
-			._Manifest_sequence,
-			"Sequence number incorrect (%d)", outerwrapper._OuterWrapper_manifest_cbor._Manifest_sequence);
+			.OuterWrapper_manifest_cbor
+			.Manifest_sequence,
+			"Sequence number incorrect (%d)", outerwrapper.OuterWrapper_manifest_cbor.Manifest_sequence);
 	zassert_true(outerwrapper
-			._OuterWrapper_manifest_cbor
-			._Manifest_payloads_present,
+			.OuterWrapper_manifest_cbor
+			.Manifest_payloads_present,
 			"Expected payloads entry");
 	zassert_equal(1, outerwrapper
-			._OuterWrapper_manifest_cbor
-			._Manifest_payloads_present,
+			.OuterWrapper_manifest_cbor
+			.Manifest_payloads_present,
 			"Expected payloads present");
 	zassert_equal(1, outerwrapper
-			._OuterWrapper_manifest_cbor
-			._Manifest_payloads
-			._Manifest_payloads__PayloadInfo_count,
+			.OuterWrapper_manifest_cbor
+			.Manifest_payloads
+			.Manifest_payloads_PayloadInfo_m_count,
 			"Expected single payloads entry, was %d",
 			outerwrapper
-			._OuterWrapper_manifest_cbor
-			._Manifest_payloads
-			._Manifest_payloads__PayloadInfo_count);
+			.OuterWrapper_manifest_cbor
+			.Manifest_payloads
+			.Manifest_payloads_PayloadInfo_m_count);
 	zassert_mem_equal(expected_tag,
 			outerwrapper
-			._OuterWrapper_manifest_cbor
-			._Manifest_payloads
-			._Manifest_payloads__PayloadInfo[0]
-			._PayloadInfo_payloadDigest
-			._COSE_Mac0_tag
+			.OuterWrapper_manifest_cbor
+			.Manifest_payloads
+			.Manifest_payloads_PayloadInfo_m[0]
+			.PayloadInfo_payloadDigest
+			.COSE_Mac0_tag
 			.value,
 			sizeof(expected_tag),
 			"Expected a certain payloads tag");
@@ -163,35 +163,35 @@ ZTEST(cbor_decode_test, test_2)
 			"test_vector3 failed");
 	zassert_equal(sizeof(test_vector3), decode_len, NULL);
 	zassert_equal(2, outerwrapper
-			._OuterWrapper_manifest_cbor
-			._Manifest_sequence,
-			"Sequence number incorrect (%d)", outerwrapper._OuterWrapper_manifest_cbor._Manifest_sequence);
+			.OuterWrapper_manifest_cbor
+			.Manifest_sequence,
+			"Sequence number incorrect (%d)", outerwrapper.OuterWrapper_manifest_cbor.Manifest_sequence);
 	zassert_equal(1, outerwrapper
-			._OuterWrapper_textExt_present,
+			.OuterWrapper_textExt_present,
 			"Expected text present");
 	zassert_equal(1, outerwrapper
-			._OuterWrapper_textExt
-			._OuterWrapper_textExt_cbor_count,
+			.OuterWrapper_textExt
+			.OuterWrapper_textExt_cbor_count,
 			"Expected single text entry");
 	zassert_equal(1, outerwrapper
-			._OuterWrapper_textExt
-			._OuterWrapper_textExt_cbor_count,
+			.OuterWrapper_textExt
+			.OuterWrapper_textExt_cbor_count,
 			"Expected single text entry");
 	zassert_equal(1, outerwrapper
-			._OuterWrapper_manifest_cbor
-			._Manifest_payloads
-			._Manifest_payloads__PayloadInfo_count,
+			.OuterWrapper_manifest_cbor
+			.Manifest_payloads
+			.Manifest_payloads_PayloadInfo_m_count,
 			"Expected single payloads entry, was %d",
 			outerwrapper
-			._OuterWrapper_manifest_cbor
-			._Manifest_payloads
-			._Manifest_payloads__PayloadInfo_count);
+			.OuterWrapper_manifest_cbor
+			.Manifest_payloads
+			.Manifest_payloads_PayloadInfo_m_count);
 	zassert_mem_equal(expected_updateDescription,
 			outerwrapper
-			._OuterWrapper_textExt
-			._OuterWrapper_textExt_cbor[0]
-			._Text_inttstr[0]
-			._Text_inttstr
+			.OuterWrapper_textExt
+			.OuterWrapper_textExt_cbor[0]
+			.Text_inttstr[0]
+			.Text_inttstr
 			.value,
 			sizeof(expected_updateDescription) - 1,
 			"Expected lorem ipsum text.");
@@ -208,159 +208,159 @@ ZTEST(cbor_decode_test, test_3)
 	zassert_equal(sizeof(test_vector4), decode_len, NULL);
 	zassert_equal(2,
 		      outerwrapper4
-		      ._SUIT_Outer_Wrapper_suit_manifest_cbor
-		      ._SUIT_Manifest_suit_manifest_sequence_number,
+		      .SUIT_Outer_Wrapper_suit_manifest_cbor
+		      .SUIT_Manifest_suit_manifest_sequence_number,
 		      "Sequence number incorrect");
 	zassert_equal(1,
 		      outerwrapper4
-		      ._SUIT_Outer_Wrapper_suit_manifest_cbor
-		      ._SUIT_Manifest_suit_install_present,
+		      .SUIT_Outer_Wrapper_suit_manifest_cbor
+		      .SUIT_Manifest_suit_install_present,
 		      "Expected install present");
-	zassert_equal(_SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr,
+	zassert_equal(SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr,
 		      outerwrapper4
-		      ._SUIT_Outer_Wrapper_suit_manifest_cbor
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Severable_Command_Sequence3_choice,
+		      .SUIT_Outer_Wrapper_suit_manifest_cbor
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Severable_Command_Sequence3_choice,
 		      "Expected install present");
 	zassert_equal(3,
 		      outerwrapper4
-		      ._SUIT_Outer_Wrapper_suit_manifest_cbor
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
-		      ._SUIT_Command_Sequence__SUIT_Command_count,
+		      .SUIT_Outer_Wrapper_suit_manifest_cbor
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
+		      .SUIT_Command_Sequence_SUIT_Command_m_count,
 		      "Expected x commands.");
-	zassert_equal(_SUIT_Command_union__SUIT_Directive,
+	zassert_equal(SUIT_Command_union_SUIT_Directive_m,
 		      outerwrapper4
-		      ._SUIT_Outer_Wrapper_suit_manifest_cbor
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
-		      ._SUIT_Command_Sequence__SUIT_Command[0]
-		      ._SUIT_Command_union_choice,
+		      .SUIT_Outer_Wrapper_suit_manifest_cbor
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
+		      .SUIT_Command_Sequence_SUIT_Command_m[0]
+		      .SUIT_Command_union_choice,
 		      "Expected directive");
-	zassert_equal(_SUIT_Directive_Set_Component_Index,
+	zassert_equal(SUIT_Directive_Set_Component_Index,
 		      outerwrapper4
-		      ._SUIT_Outer_Wrapper_suit_manifest_cbor
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
-		      ._SUIT_Command_Sequence__SUIT_Command[0]
-		      ._SUIT_Command_union__SUIT_Directive
-		      ._SUIT_Directive_choice,
+		      .SUIT_Outer_Wrapper_suit_manifest_cbor
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
+		      .SUIT_Command_Sequence_SUIT_Command_m[0]
+		      .SUIT_Command_union_SUIT_Directive_m
+		      .SUIT_Directive_choice,
 		      "Expected Component_Index");
-	zassert_equal(_SUIT_Directive_Set_Component_Index_uint,
+	zassert_equal(SUIT_Directive_Set_Component_Index_uint,
 		      outerwrapper4
-		      ._SUIT_Outer_Wrapper_suit_manifest_cbor
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
-		      ._SUIT_Command_Sequence__SUIT_Command[0]
-		      ._SUIT_Command_union__SUIT_Directive
-		      ._SUIT_Directive_Set_Component_Index_choice,
+		      .SUIT_Outer_Wrapper_suit_manifest_cbor
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
+		      .SUIT_Command_Sequence_SUIT_Command_m[0]
+		      .SUIT_Command_union_SUIT_Directive_m
+		      .SUIT_Directive_Set_Component_Index_choice,
 		      NULL);
-	zassert_equal(_SUIT_Command_union__SUIT_Directive,
+	zassert_equal(SUIT_Command_union_SUIT_Directive_m,
 		      outerwrapper4
-		      ._SUIT_Outer_Wrapper_suit_manifest_cbor
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
-		      ._SUIT_Command_Sequence__SUIT_Command[1]
-		      ._SUIT_Command_union_choice,
+		      .SUIT_Outer_Wrapper_suit_manifest_cbor
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
+		      .SUIT_Command_Sequence_SUIT_Command_m[1]
+		      .SUIT_Command_union_choice,
 		      "Expected directive");
-	zassert_equal(_SUIT_Directive_Set_Parameters,
+	zassert_equal(SUIT_Directive_Set_Parameters,
 		      outerwrapper4
-		      ._SUIT_Outer_Wrapper_suit_manifest_cbor
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
-		      ._SUIT_Command_Sequence__SUIT_Command[1]
-		      ._SUIT_Command_union__SUIT_Directive
-		      ._SUIT_Directive_choice,
+		      .SUIT_Outer_Wrapper_suit_manifest_cbor
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
+		      .SUIT_Command_Sequence_SUIT_Command_m[1]
+		      .SUIT_Command_union_SUIT_Directive_m
+		      .SUIT_Directive_choice,
 		      "Expected Set_Parameters");
 	zassert_equal(1,
 		      outerwrapper4
-		      ._SUIT_Outer_Wrapper_suit_manifest_cbor
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
-		      ._SUIT_Command_Sequence__SUIT_Command[1]
-		      ._SUIT_Command_union__SUIT_Directive
-		      ._SUIT_Directive_Set_Parameters__SUIT_Parameters_count,
+		      .SUIT_Outer_Wrapper_suit_manifest_cbor
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
+		      .SUIT_Command_Sequence_SUIT_Command_m[1]
+		      .SUIT_Command_union_SUIT_Directive_m
+		      .SUIT_Directive_Set_Parameters_SUIT_Parameters_m_count,
 		      "Expected 1 parameter");
-zassert_equal(_SUIT_Parameters_SUIT_Parameter_URI_List,
+zassert_equal(SUIT_Parameters_SUIT_Parameter_URI_List,
 		      outerwrapper4
-		      ._SUIT_Outer_Wrapper_suit_manifest_cbor
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
-		      ._SUIT_Command_Sequence__SUIT_Command[1]
-		      ._SUIT_Command_union__SUIT_Directive
-		      ._SUIT_Directive_Set_Parameters__SUIT_Parameters[0]
-		      ._SUIT_Directive_Set_Parameters__SUIT_Parameters
-		      ._SUIT_Parameters_choice,
+		      .SUIT_Outer_Wrapper_suit_manifest_cbor
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
+		      .SUIT_Command_Sequence_SUIT_Command_m[1]
+		      .SUIT_Command_union_SUIT_Directive_m
+		      .SUIT_Directive_Set_Parameters_SUIT_Parameters_m[0]
+		      .SUIT_Directive_Set_Parameters_SUIT_Parameters_m
+		      .SUIT_Parameters_choice,
 		      "Expected uri list parameter");
 	zassert_equal(1,
 		      outerwrapper4
-		      ._SUIT_Outer_Wrapper_suit_manifest_cbor
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
-		      ._SUIT_Command_Sequence__SUIT_Command[1]
-		      ._SUIT_Command_union__SUIT_Directive
-		      ._SUIT_Directive_Set_Parameters__SUIT_Parameters[0]
-		      ._SUIT_Directive_Set_Parameters__SUIT_Parameters
-		      ._SUIT_Parameters_SUIT_Parameter_URI_List_cbor
-		      ._SUIT_URI_List__SUIT_Prioritized_URI_count,
+		      .SUIT_Outer_Wrapper_suit_manifest_cbor
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
+		      .SUIT_Command_Sequence_SUIT_Command_m[1]
+		      .SUIT_Command_union_SUIT_Directive_m
+		      .SUIT_Directive_Set_Parameters_SUIT_Parameters_m[0]
+		      .SUIT_Directive_Set_Parameters_SUIT_Parameters_m
+		      .SUIT_Parameters_SUIT_Parameter_URI_List_cbor
+		      .SUIT_URI_List_SUIT_Prioritized_URI_m_count,
 		      "Expected 1 uri");
 	zassert_equal(0,
 		      outerwrapper4
-		      ._SUIT_Outer_Wrapper_suit_manifest_cbor
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
-		      ._SUIT_Command_Sequence__SUIT_Command[1]
-		      ._SUIT_Command_union__SUIT_Directive
-		      ._SUIT_Directive_Set_Parameters__SUIT_Parameters[0]
-		      ._SUIT_Directive_Set_Parameters__SUIT_Parameters
-		      ._SUIT_Parameters_SUIT_Parameter_URI_List_cbor
-		      ._SUIT_URI_List__SUIT_Prioritized_URI[0]
-		      ._SUIT_Prioritized_URI_priority,
+		      .SUIT_Outer_Wrapper_suit_manifest_cbor
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
+		      .SUIT_Command_Sequence_SUIT_Command_m[1]
+		      .SUIT_Command_union_SUIT_Directive_m
+		      .SUIT_Directive_Set_Parameters_SUIT_Parameters_m[0]
+		      .SUIT_Directive_Set_Parameters_SUIT_Parameters_m
+		      .SUIT_Parameters_SUIT_Parameter_URI_List_cbor
+		      .SUIT_URI_List_SUIT_Prioritized_URI_m[0]
+		      .SUIT_Prioritized_URI_priority,
 		      "Expected priority x");
 	zassert_mem_equal(expected_uri,
 		      outerwrapper4
-		      ._SUIT_Outer_Wrapper_suit_manifest_cbor
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
-		      ._SUIT_Command_Sequence__SUIT_Command[1]
-		      ._SUIT_Command_union__SUIT_Directive
-		      ._SUIT_Directive_Set_Parameters__SUIT_Parameters[0]
-		      ._SUIT_Directive_Set_Parameters__SUIT_Parameters
-		      ._SUIT_Parameters_SUIT_Parameter_URI_List_cbor
-		      ._SUIT_URI_List__SUIT_Prioritized_URI[0]
-		      ._SUIT_Prioritized_URI_uri.value,
+		      .SUIT_Outer_Wrapper_suit_manifest_cbor
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
+		      .SUIT_Command_Sequence_SUIT_Command_m[1]
+		      .SUIT_Command_union_SUIT_Directive_m
+		      .SUIT_Directive_Set_Parameters_SUIT_Parameters_m[0]
+		      .SUIT_Directive_Set_Parameters_SUIT_Parameters_m
+		      .SUIT_Parameters_SUIT_Parameter_URI_List_cbor
+		      .SUIT_URI_List_SUIT_Prioritized_URI_m[0]
+		      .SUIT_Prioritized_URI_uri.value,
 		      sizeof(expected_uri) - 1,
 		      "Expected example.com uri");
-	zassert_equal(_SUIT_Command_union__SUIT_Directive,
+	zassert_equal(SUIT_Command_union_SUIT_Directive_m,
 		      outerwrapper4
-		      ._SUIT_Outer_Wrapper_suit_manifest_cbor
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
-		      ._SUIT_Command_Sequence__SUIT_Command[2]
-		      ._SUIT_Command_union_choice,
+		      .SUIT_Outer_Wrapper_suit_manifest_cbor
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
+		      .SUIT_Command_Sequence_SUIT_Command_m[2]
+		      .SUIT_Command_union_choice,
 		      "Expected directive");
-	zassert_equal(_SUIT_Directive_Fetch,
+	zassert_equal(SUIT_Directive_Fetch,
 		      outerwrapper4
-		      ._SUIT_Outer_Wrapper_suit_manifest_cbor
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Manifest_suit_install
-		      ._SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
-		      ._SUIT_Command_Sequence__SUIT_Command[2]
-		      ._SUIT_Command_union__SUIT_Directive
-		      ._SUIT_Directive_choice,
+		      .SUIT_Outer_Wrapper_suit_manifest_cbor
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Manifest_suit_install
+		      .SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
+		      .SUIT_Command_Sequence_SUIT_Command_m[2]
+		      .SUIT_Command_union_SUIT_Directive_m
+		      .SUIT_Directive_choice,
 		      "Expected Directive_Fetch");
 }
 

--- a/tests/decode/test2_suit/src/main.c
+++ b/tests/decode/test2_suit/src/main.c
@@ -53,136 +53,136 @@ ZTEST(cbor_decode_test2, test_5)
 						&outerwrapper1, &decode_len);
 	zassert_equal(ZCBOR_SUCCESS, res, "top-level decoding failed.");
 	zassert_equal(sizeof(test_vector1), decode_len, NULL);
-	zassert_equal(_SUIT_Manifest_Wrapped_suit_manifest, outerwrapper1
-			._SUIT_Outer_Wrapper__SUIT_Manifest_Wrapped
-			._SUIT_Manifest_Wrapped_choice,
+	zassert_equal(SUIT_Manifest_Wrapped_suit_manifest, outerwrapper1
+			.SUIT_Outer_Wrapper_SUIT_Manifest_Wrapped_m
+			.SUIT_Manifest_Wrapped_choice,
 			"wrong manifest variant");
 	manifest = &outerwrapper1
-			._SUIT_Outer_Wrapper__SUIT_Manifest_Wrapped
-			._SUIT_Manifest_Wrapped_suit_manifest_cbor;
+			.SUIT_Outer_Wrapper_SUIT_Manifest_Wrapped_m
+			.SUIT_Manifest_Wrapped_suit_manifest_cbor;
 	zassert_equal(1, manifest
-			->_SUIT_Manifest_suit_manifest_sequence_number,
+			->SUIT_Manifest_suit_manifest_sequence_number,
 			"wrong sequence number");
 	zassert_equal(1, manifest
-			->_SUIT_Manifest_suit_common_present,
+			->SUIT_Manifest_suit_common_present,
 			"common should be present");
 	zassert_equal(0, manifest
-			->_SUIT_Manifest_suit_dependency_resolution_present,
+			->SUIT_Manifest_suit_dependency_resolution_present,
 			"should not be present");
 	zassert_equal(0, manifest
-			->_SUIT_Manifest_suit_payload_fetch_present,
+			->SUIT_Manifest_suit_payload_fetch_present,
 			"should not be present");
 	zassert_equal(0, manifest
-			->_SUIT_Manifest_suit_install_present,
+			->SUIT_Manifest_suit_install_present,
 			"should not be present");
 	zassert_equal(0, manifest
-			->_SUIT_Manifest_suit_validate_present,
+			->SUIT_Manifest_suit_validate_present,
 			"should not be present");
 	zassert_equal(0, manifest
-			->_SUIT_Manifest_suit_load_present,
+			->SUIT_Manifest_suit_load_present,
 			"should not be present");
 	zassert_equal(1, manifest
-			->_SUIT_Manifest_suit_run_present,
+			->SUIT_Manifest_suit_run_present,
 			"should not be present");
 	zassert_equal(0, manifest
-			->_SUIT_Manifest_suit_text_present,
+			->SUIT_Manifest_suit_text_present,
 			"should not be present");
 	zassert_equal(0, manifest
-			->_SUIT_Manifest_suit_coswid_present,
+			->SUIT_Manifest_suit_coswid_present,
 			"should not be present");
 	zassert_equal(1, manifest
-			->_SUIT_Manifest_suit_common
-			._SUIT_Manifest_suit_common_cbor
-			._SUIT_Common_suit_components
-			._SUIT_Common_suit_components_cbor
-			._SUIT_Components__SUIT_Component_Identifier_count,
+			->SUIT_Manifest_suit_common
+			.SUIT_Manifest_suit_common_cbor
+			.SUIT_Common_suit_components
+			.SUIT_Common_suit_components_cbor
+			.SUIT_Components_SUIT_Component_Identifier_m_count,
 			"Wrong number of common components");
 	component = &manifest
-			->_SUIT_Manifest_suit_common
-			._SUIT_Manifest_suit_common_cbor
-			._SUIT_Common_suit_components
-			._SUIT_Common_suit_components_cbor
-			._SUIT_Components__SUIT_Component_Identifier[0];
+			->SUIT_Manifest_suit_common
+			.SUIT_Manifest_suit_common_cbor
+			.SUIT_Common_suit_components
+			.SUIT_Common_suit_components_cbor
+			.SUIT_Components_SUIT_Component_Identifier_m[0];
 	zassert_equal(2, component
-			->_SUIT_Component_Identifier_bstr_count,
+			->SUIT_Component_Identifier_bstr_count,
 			"Wrong number of elements in component");
 	zassert_equal(sizeof(expected_component0), component
-			->_SUIT_Component_Identifier_bstr[0]
+			->SUIT_Component_Identifier_bstr[0]
 			.len,
 			"component elem 0 len doesn't match.");
 	zassert_mem_equal(expected_component0, component
-			->_SUIT_Component_Identifier_bstr[0]
+			->SUIT_Component_Identifier_bstr[0]
 			.value,
 			sizeof(expected_component0),
 			"component elem 0 doesn't match.");
 	zassert_equal(sizeof(expected_component1), component
-			->_SUIT_Component_Identifier_bstr[1]
+			->SUIT_Component_Identifier_bstr[1]
 			.len,
 			"component elem 1 len doesn't match.");
 	zassert_mem_equal(expected_component1, component
-			->_SUIT_Component_Identifier_bstr[1]
+			->SUIT_Component_Identifier_bstr[1]
 			.value,
 			sizeof(expected_component1),
 			"component elem 1 doesn't match.");
 
 	zcbor_print("\r\n");
 	zassert_equal(1, manifest
-			->_SUIT_Manifest_suit_common
-			._SUIT_Manifest_suit_common_cbor
-			._SUIT_Common_suit_common_sequence_present,
+			->SUIT_Manifest_suit_common
+			.SUIT_Manifest_suit_common_cbor
+			.SUIT_Common_suit_common_sequence_present,
 			"common sequence should be present.");
 	memset(&sequence, 0, sizeof(sequence));
 	res = cbor_decode_SUIT_Command_Sequence(
 			manifest
-			->_SUIT_Manifest_suit_common
-			._SUIT_Manifest_suit_common_cbor
-			._SUIT_Common_suit_common_sequence
-			._SUIT_Common_suit_common_sequence
+			->SUIT_Manifest_suit_common
+			.SUIT_Manifest_suit_common_cbor
+			.SUIT_Common_suit_common_sequence
+			.SUIT_Common_suit_common_sequence
 			.value,
 			manifest
-			->_SUIT_Manifest_suit_common
-			._SUIT_Manifest_suit_common_cbor
-			._SUIT_Common_suit_common_sequence
-			._SUIT_Common_suit_common_sequence
+			->SUIT_Manifest_suit_common
+			.SUIT_Manifest_suit_common_cbor
+			.SUIT_Common_suit_common_sequence
+			.SUIT_Common_suit_common_sequence
 			.len,
 			&sequence, &decode_len);
 	zassert_equal(ZCBOR_SUCCESS, res, "Parsing common sequence failed.");
 	zassert_equal(manifest
-			->_SUIT_Manifest_suit_common
-			._SUIT_Manifest_suit_common_cbor
-			._SUIT_Common_suit_common_sequence
-			._SUIT_Common_suit_common_sequence
+			->SUIT_Manifest_suit_common
+			.SUIT_Manifest_suit_common_cbor
+			.SUIT_Common_suit_common_sequence
+			.SUIT_Common_suit_common_sequence
 			.len, decode_len, NULL);
 	zassert_equal(1, sequence
-			._SUIT_Command_Sequence__SUIT_Command_count,
+			.SUIT_Command_Sequence_SUIT_Command_m_count,
 			"Should be one command (was %d).", sequence
-			._SUIT_Command_Sequence__SUIT_Command_count);
-	zassert_equal(_SUIT_Command__SUIT_Directive, sequence
-			._SUIT_Command_Sequence__SUIT_Command[0]
-			._SUIT_Command_choice,
+			.SUIT_Command_Sequence_SUIT_Command_m_count);
+	zassert_equal(SUIT_Command_SUIT_Directive_m, sequence
+			.SUIT_Command_Sequence_SUIT_Command_m[0]
+			.SUIT_Command_choice,
 			"Should be a directive.");
 	zassert_equal(2, sequence
-			._SUIT_Command_Sequence__SUIT_Command[0]
-			._SUIT_Command__SUIT_Directive
-			.___suit_directive_set_parameters_map__SUIT_Parameters_count,
+			.SUIT_Command_Sequence_SUIT_Command_m[0]
+			.SUIT_Command_SUIT_Directive_m
+			.suit_directive_set_parameters_m_l_map_SUIT_Parameters_m_count,
 			"Should be two vars (parameters).");
 	zcbor_print("\r\n");
 
 	memset(&sequence, 0, sizeof(sequence));
 	res = cbor_decode_SUIT_Command_Sequence(
 			manifest
-			->_SUIT_Manifest_suit_run
-			._SUIT_Manifest_suit_run
+			->SUIT_Manifest_suit_run
+			.SUIT_Manifest_suit_run
 			.value,
 			manifest
-			->_SUIT_Manifest_suit_run
-			._SUIT_Manifest_suit_run
+			->SUIT_Manifest_suit_run
+			.SUIT_Manifest_suit_run
 			.len,
 			&sequence, &decode_len);
 	zassert_equal(ZCBOR_SUCCESS, res, "Parsing run command sequence failed.");
 	zassert_equal(manifest
-			->_SUIT_Manifest_suit_run
-			._SUIT_Manifest_suit_run
+			->SUIT_Manifest_suit_run
+			.SUIT_Manifest_suit_run
 			.len, decode_len, NULL);
 }
 

--- a/tests/decode/test3_simple/src/main.c
+++ b/tests/decode/test3_simple/src/main.c
@@ -447,7 +447,7 @@ ZTEST(cbor_decode_test3, test_pet)
 	zassert_mem_equal("bar", pet.names[1].value, 3, "Expect first name 'bar'");
 	zassert_equal(8, pet.birthday.len, "Expect len 8 birthday");
 	zassert_mem_equal(exp_birthday, pet.birthday.value, 8, "Expect birthday");
-	zassert_equal(_Pet_species_dog, pet.species_choice, "Expect dog");
+	zassert_equal(Pet_species_dog, pet.species_choice, "Expect dog");
 }
 
 
@@ -490,16 +490,16 @@ ZTEST(cbor_decode_test3, test_serial1)
 
 	zassert_equal(5, upload.members_count,
 		"expect 5 members");
-	zassert_equal(_Member_data, upload.members[0].members
+	zassert_equal(Member_data, upload.members[0].members
 		.Member_choice, "expect data 1st");
-	zassert_equal(_Member_image, upload.members[1].members
+	zassert_equal(Member_image, upload.members[1].members
 		.Member_choice, "expect image 2nd");
-	zassert_equal(_Member_len, upload.members[2].members
+	zassert_equal(Member_len, upload.members[2].members
 		.Member_choice, "was %d\r\n", upload.members[2].members
 		.Member_choice);
-	zassert_equal(_Member_off, upload.members[3].members
+	zassert_equal(Member_off, upload.members[3].members
 		.Member_choice, "expect off 4th");
-	zassert_equal(_Member_sha, upload.members[4].members
+	zassert_equal(Member_sha, upload.members[4].members
 		.Member_choice, "expect sha 5th");
 }
 
@@ -514,15 +514,15 @@ ZTEST(cbor_decode_test3, test_serial2)
 
 	zassert_equal(5, upload.members_count,
 		"expect 5 members");
-	zassert_equal(_Member_data, upload.members[0].members
+	zassert_equal(Member_data, upload.members[0].members
 		.Member_choice, "expect data 1st");
-	zassert_equal(_Member_image, upload.members[1].members
+	zassert_equal(Member_image, upload.members[1].members
 		.Member_choice, "expect image 2nd");
-	zassert_equal(_Member_len, upload.members[2].members
+	zassert_equal(Member_len, upload.members[2].members
 		.Member_choice, "expect len 3rd");
-	zassert_equal(_Member_off, upload.members[3].members
+	zassert_equal(Member_off, upload.members[3].members
 		.Member_choice, "expect off 4th");
-	zassert_equal(_Member_sha, upload.members[4].members
+	zassert_equal(Member_sha, upload.members[4].members
 		.Member_choice, "expect sha 5th");
 }
 

--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -217,19 +217,19 @@ ZTEST(cbor_decode_test5, test_tagged_union)
 	const uint8_t payload_tagged_union2[] = {0xD9, 0x09, 0x29, 0x10};
 	const uint8_t payload_tagged_union3_inv[] = {0xD9, 0x10, 0xE1, 0x10};
 
-	struct TaggedUnion_ result;
+	struct TaggedUnion_r result;
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_TaggedUnion(payload_tagged_union1,
 		sizeof(payload_tagged_union1), &result, &decode_len), "%d\r\n");
 
 	zassert_equal(sizeof(payload_tagged_union1), decode_len, NULL);
-	zassert_equal(_TaggedUnion_bool, result.TaggedUnion_choice, NULL);
-	zassert_true(result._bool, NULL);
+	zassert_equal(TaggedUnion_bool, result.TaggedUnion_choice, NULL);
+	zassert_true(result.Bool, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_TaggedUnion(payload_tagged_union2,
 		sizeof(payload_tagged_union2), &result, &decode_len), NULL);
 
-	zassert_equal(_TaggedUnion_uint, result.TaggedUnion_choice, NULL);
+	zassert_equal(TaggedUnion_uint, result.TaggedUnion_choice, NULL);
 	zassert_equal(0x10, result.uint, NULL);
 
 	zassert_equal(ZCBOR_ERR_WRONG_TYPE, cbor_decode_TaggedUnion(payload_tagged_union3_inv,
@@ -658,43 +658,43 @@ ZTEST(cbor_decode_test5, test_union)
 		0x03, 0x23, 0x03, 0x23, 0x03, 0x23}; /* Too many */
 	size_t decode_len;
 
-	struct Union_ _union;
+	struct Union_r union_r;
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Union(payload_union1, sizeof(payload_union1),
-				&_union, NULL), NULL);
-	zassert_equal(_Union__Group, _union.Union_choice, NULL);
+				&union_r, NULL), NULL);
+	zassert_equal(Union_Group_m, union_r.Union_choice, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Union(payload_union2, sizeof(payload_union2),
-				&_union, NULL), NULL);
-	zassert_equal(_Union__MultiGroup, _union.Union_choice, NULL);
-	zassert_equal(1, _union._MultiGroup.MultiGroup_count, "was %d\r\n", _union._MultiGroup.MultiGroup_count);
+				&union_r, NULL), NULL);
+	zassert_equal(Union_MultiGroup_m, union_r.Union_choice, NULL);
+	zassert_equal(1, union_r.MultiGroup_m.MultiGroup_count, "was %d\r\n", union_r.MultiGroup_m.MultiGroup_count);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Union(payload_union3, sizeof(payload_union3),
-				&_union, NULL), NULL);
-	zassert_equal(_Union__uint3, _union.Union_choice, NULL);
+				&union_r, NULL), NULL);
+	zassert_equal(Union_uint3_l, union_r.Union_choice, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Union(payload_union4, sizeof(payload_union4),
-				&_union, NULL), NULL);
-	zassert_equal(_Union_hello_tstr, _union.Union_choice, NULL);
+				&union_r, NULL), NULL);
+	zassert_equal(Union_hello_tstr, union_r.Union_choice, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Union(payload_union6, sizeof(payload_union6),
-				&_union, &decode_len), NULL);
-	zassert_equal(_Union__MultiGroup, _union.Union_choice, NULL);
-	zassert_equal(6, _union._MultiGroup.MultiGroup_count, NULL);
+				&union_r, &decode_len), NULL);
+	zassert_equal(Union_MultiGroup_m, union_r.Union_choice, NULL);
+	zassert_equal(6, union_r.MultiGroup_m.MultiGroup_count, NULL);
 	zassert_equal(12, decode_len, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Union(payload_union7_long, sizeof(payload_union7_long),
-				&_union, &decode_len), NULL);
+				&union_r, &decode_len), NULL);
 	zassert_equal(2, decode_len, NULL);
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Union(payload_union8_long, sizeof(payload_union8_long),
-				&_union, &decode_len), NULL);
+				&union_r, &decode_len), NULL);
 	zassert_equal(2, decode_len, NULL);
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Union(payload_union9_long, sizeof(payload_union9_long),
-				&_union, &decode_len), NULL);
+				&union_r, &decode_len), NULL);
 	zassert_equal(2, decode_len, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Union(payload_union10_inv, sizeof(payload_union10_inv),
-				&_union, &decode_len), NULL);
-	zassert_equal(6, _union._MultiGroup.MultiGroup_count, NULL);
+				&union_r, &decode_len), NULL);
+	zassert_equal(6, union_r.MultiGroup_m.MultiGroup_count, NULL);
 	zassert_equal(12, decode_len, NULL);
 }
 
@@ -721,9 +721,9 @@ ZTEST(cbor_decode_test5, test_levels)
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Level1(payload_levels1,
 		sizeof(payload_levels1), &level1, NULL), NULL);
 
-	zassert_equal(2, level1._Level3_count, NULL);
-	zassert_equal(4, level1._Level3[0]._Level4_count, NULL);
-	zassert_equal(4, level1._Level3[1]._Level4_count, NULL);
+	zassert_equal(2, level1.Level3_m_count, NULL);
+	zassert_equal(4, level1.Level3_m[0].Level4_m_count, NULL);
+	zassert_equal(4, level1.Level3_m[1].Level4_m_count, NULL);
 }
 
 
@@ -770,13 +770,13 @@ ZTEST(cbor_decode_test5, test_map)
 
 	struct Map map;
 
-	zassert_equal(_union_nintuint, -8,
+	zassert_equal(union_nintuint, -8,
 		"The union_int optimization seems to not be working.\r\n");
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Map(payload_map1, sizeof(payload_map1),
 			&map, NULL), NULL);
 	zassert_false(map.listkey, NULL);
-	zassert_equal(_union_uint7uint, map.union_choice, NULL);
+	zassert_equal(union_uint7uint, map.union_choice, NULL);
 	zassert_equal(1, map.uint7uint, NULL);
 	zassert_equal(2, map.twotothree_count, NULL);
 	zassert_equal(5, map.twotothree[0].twotothree.len, NULL);
@@ -790,7 +790,7 @@ ZTEST(cbor_decode_test5, test_map)
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Map(payload_map3, sizeof(payload_map3),
 			&map, NULL), NULL);
 	zassert_true(map.listkey, NULL);
-	zassert_equal(_union_uint7uint, map.union_choice, NULL);
+	zassert_equal(union_uint7uint, map.union_choice, NULL);
 	zassert_equal(1, map.uint7uint, NULL);
 	zassert_equal(3, map.twotothree_count, NULL);
 	zassert_equal(5, map.twotothree[0].twotothree.len, NULL);
@@ -810,7 +810,7 @@ ZTEST(cbor_decode_test5, test_map)
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Map(payload_map5, sizeof(payload_map5),
 			&map, NULL), NULL);
 	zassert_false(map.listkey, NULL);
-	zassert_equal(_union_nintuint, map.union_choice, NULL);
+	zassert_equal(union_nintuint, map.union_choice, NULL);
 	zassert_equal(1, map.nintuint, NULL);
 	zassert_equal(2, map.twotothree_count, NULL);
 }
@@ -904,30 +904,30 @@ ZTEST(cbor_decode_test5, test_nested_map_list_map)
 	int ret = cbor_decode_NestedMapListMap(payload_nested_mlm1,
 			sizeof(payload_nested_mlm1), &maplistmap, NULL);
 	zassert_equal(ZCBOR_SUCCESS, ret, "%d\r\n", ret);
-	zassert_equal(1, maplistmap._map_count, NULL);
-	zassert_equal(0, maplistmap._map[0].map_count, NULL);
+	zassert_equal(1, maplistmap.map_l_count, NULL);
+	zassert_equal(0, maplistmap.map_l[0].map_count, NULL);
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_NestedMapListMap(payload_nested_mlm2,
 			sizeof(payload_nested_mlm2), &maplistmap, NULL), NULL);
-	zassert_equal(1, maplistmap._map_count, NULL);
-	zassert_equal(1, maplistmap._map[0].map_count, NULL);
+	zassert_equal(1, maplistmap.map_l_count, NULL);
+	zassert_equal(1, maplistmap.map_l[0].map_count, NULL);
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_NestedMapListMap(payload_nested_mlm3,
 			sizeof(payload_nested_mlm3), &maplistmap, NULL), NULL);
-	zassert_equal(1, maplistmap._map_count, NULL);
-	zassert_equal(2, maplistmap._map[0].map_count, NULL);
+	zassert_equal(1, maplistmap.map_l_count, NULL);
+	zassert_equal(2, maplistmap.map_l[0].map_count, NULL);
 	ret = cbor_decode_NestedMapListMap(payload_nested_mlm4_inv,
 			sizeof(payload_nested_mlm4_inv), &maplistmap, NULL);
 	zassert_equal(ZCBOR_ERR_ITERATIONS, ret, "%d\r\n", ret);
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_NestedMapListMap(payload_nested_mlm5,
 			sizeof(payload_nested_mlm5), &maplistmap, NULL), NULL);
-	zassert_equal(2, maplistmap._map_count, NULL);
-	zassert_equal(0, maplistmap._map[0].map_count, NULL);
-	zassert_equal(0, maplistmap._map[1].map_count, NULL);
+	zassert_equal(2, maplistmap.map_l_count, NULL);
+	zassert_equal(0, maplistmap.map_l[0].map_count, NULL);
+	zassert_equal(0, maplistmap.map_l[1].map_count, NULL);
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_NestedMapListMap(payload_nested_mlm6,
 			sizeof(payload_nested_mlm6), &maplistmap, NULL), NULL);
-	zassert_equal(3, maplistmap._map_count, NULL);
-	zassert_equal(0, maplistmap._map[0].map_count, NULL);
-	zassert_equal(0, maplistmap._map[1].map_count, NULL);
-	zassert_equal(2, maplistmap._map[2].map_count, NULL);
+	zassert_equal(3, maplistmap.map_l_count, NULL);
+	zassert_equal(0, maplistmap.map_l[0].map_count, NULL);
+	zassert_equal(0, maplistmap.map_l[1].map_count, NULL);
+	zassert_equal(2, maplistmap.map_l[2].map_count, NULL);
 }
 
 
@@ -1293,18 +1293,18 @@ ZTEST(cbor_decode_test5, test_unabstracted)
 					sizeof(payload_unabstracted0),
 					&result_unabstracted, &out_len), NULL);
 	zassert_equal(result_unabstracted.unabstractedunion1_choice,
-			_Unabstracted_unabstractedunion1_choice1, NULL);
+			Unabstracted_unabstractedunion1_choice1, NULL);
 	zassert_equal(result_unabstracted.unabstractedunion2_choice,
-			_Unabstracted_unabstractedunion2_uint3, NULL);
+			Unabstracted_unabstractedunion2_uint3, NULL);
 	zassert_equal(sizeof(payload_unabstracted0), out_len, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Unabstracted(payload_unabstracted1,
 					sizeof(payload_unabstracted1),
 					&result_unabstracted, &out_len), NULL);
 	zassert_equal(result_unabstracted.unabstractedunion1_choice,
-			_Unabstracted_unabstractedunion1_choice2, NULL);
+			Unabstracted_unabstractedunion1_choice2, NULL);
 	zassert_equal(result_unabstracted.unabstractedunion2_choice,
-			_Unabstracted_unabstractedunion2_choice4, NULL);
+			Unabstracted_unabstractedunion2_choice4, NULL);
 	zassert_equal(sizeof(payload_unabstracted1), out_len, NULL);
 
 	int ret = cbor_decode_Unabstracted(payload_unabstracted2_inv,
@@ -1360,13 +1360,13 @@ ZTEST(cbor_decode_test5, test_doublemap)
 					&result_doublemap, &out_len), NULL);
 	zassert_equal(result_doublemap.uintmap_count, 2, NULL);
 	zassert_equal(result_doublemap.uintmap[0].uintmap_key, 1, NULL);
-	zassert_true(result_doublemap.uintmap[0]._MyKeys.uint1int_present, NULL);
-	zassert_equal(result_doublemap.uintmap[0]._MyKeys.uint1int.uint1int, 1, NULL);
-	zassert_false(result_doublemap.uintmap[0]._MyKeys.uint2int_present, NULL);
+	zassert_true(result_doublemap.uintmap[0].MyKeys_m.uint1int_present, NULL);
+	zassert_equal(result_doublemap.uintmap[0].MyKeys_m.uint1int.uint1int, 1, NULL);
+	zassert_false(result_doublemap.uintmap[0].MyKeys_m.uint2int_present, NULL);
 	zassert_equal(result_doublemap.uintmap[1].uintmap_key, 2, NULL);
-	zassert_false(result_doublemap.uintmap[1]._MyKeys.uint1int_present, NULL);
-	zassert_true(result_doublemap.uintmap[1]._MyKeys.uint2int_present, NULL);
-	zassert_equal(result_doublemap.uintmap[1]._MyKeys.uint2int.uint2int, 2, NULL);
+	zassert_false(result_doublemap.uintmap[1].MyKeys_m.uint1int_present, NULL);
+	zassert_true(result_doublemap.uintmap[1].MyKeys_m.uint2int_present, NULL);
+	zassert_equal(result_doublemap.uintmap[1].MyKeys_m.uint2int.uint2int, 2, NULL);
 
 	int ret = cbor_decode_DoubleMap(payload_doublemap1_inv,
 					sizeof(payload_doublemap1_inv),
@@ -1814,22 +1814,22 @@ ZTEST(cbor_decode_test5, test_map_length)
 		sizeof(map_length_payload2), &result, &num_decode), NULL);
 	zassert_equal(sizeof(map_length_payload2), num_decode, NULL);
 	zassert_true(result.end_device_array_present, NULL);
-	zassert_equal(0, result.end_device_array._uuid_count, NULL);
+	zassert_equal(0, result.end_device_array.uuid_m_count, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_MapLength(map_length_payload3,
 		sizeof(map_length_payload3), &result, &num_decode), NULL);
 	zassert_equal(sizeof(map_length_payload3), num_decode, NULL);
 	zassert_true(result.end_device_array_present, NULL);
-	zassert_equal(1, result.end_device_array._uuid_count, NULL);
+	zassert_equal(1, result.end_device_array.uuid_m_count, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_MapLength(map_length_payload4,
 		sizeof(map_length_payload4), &result, &num_decode), NULL);
 	zassert_equal(sizeof(map_length_payload4), num_decode, NULL);
 	zassert_true(result.end_device_array_present, NULL);
-	zassert_equal(2, result.end_device_array._uuid_count, NULL);
-	zassert_equal(16, result.end_device_array._uuid[0].len, NULL);
-	zassert_equal(16, result.end_device_array._uuid[1].len, NULL);
-	zassert_equal(8, result.end_device_array._uuid[1].value[8], NULL);
+	zassert_equal(2, result.end_device_array.uuid_m_count, NULL);
+	zassert_equal(16, result.end_device_array.uuid_m[0].len, NULL);
+	zassert_equal(16, result.end_device_array.uuid_m[1].len, NULL);
+	zassert_equal(8, result.end_device_array.uuid_m[1].value[8], NULL);
 
 	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_decode_MapLength(map_length_payload5_inv,
 		sizeof(map_length_payload5_inv), &result, &num_decode), NULL);
@@ -1879,48 +1879,48 @@ ZTEST(cbor_decode_test5, test_union_int)
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_UnionInt1(union_int_payload1,
 		sizeof(union_int_payload1), &result1, &num_decode), NULL);
 	zassert_equal(sizeof(union_int_payload1), num_decode, NULL);
-	zassert_equal(result1.union_choice, _UnionInt1__union_uint1, NULL);
+	zassert_equal(result1.union_choice, UnionInt1_union_uint1_l, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_UnionInt2(union_int_payload1,
 		sizeof(union_int_payload1), &result2, &num_decode), NULL);
 	zassert_equal(sizeof(union_int_payload1), num_decode, NULL);
-	zassert_equal(result2.union_choice, _union__uint5, NULL);
+	zassert_equal(result2.union_choice, union_uint5_l, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_UnionInt1(union_int_payload2,
 		sizeof(union_int_payload2), &result1, &num_decode), NULL);
 	zassert_equal(sizeof(union_int_payload2), num_decode, NULL);
-	zassert_equal(result1.union_choice, _UnionInt1__union_uint2, NULL);
+	zassert_equal(result1.union_choice, UnionInt1_union_uint2_l, NULL);
 	zassert_equal(result1.bstr.len, 16, NULL);
 	zassert_mem_equal(result1.bstr.value, "This is thousand", 16, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_UnionInt2(union_int_payload2,
 		sizeof(union_int_payload2), &result2, &num_decode), NULL);
 	zassert_equal(sizeof(union_int_payload2), num_decode, NULL);
-	zassert_equal(result2.union_choice, _union__uint1000, NULL);
+	zassert_equal(result2.union_choice, union_uint1000_l, NULL);
 	zassert_equal(result2.bstr.len, 16, NULL);
 	zassert_mem_equal(result2.bstr.value, "This is thousand", 16, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_UnionInt1(union_int_payload3,
 		sizeof(union_int_payload3), &result1, &num_decode), NULL);
 	zassert_equal(sizeof(union_int_payload3), num_decode, NULL);
-	zassert_equal(result1.union_choice, _UnionInt1__union_uint3, NULL);
-	zassert_equal(result1._number.number_choice, _number_int, NULL);
-	zassert_equal(result1._number._int, 1, NULL);
+	zassert_equal(result1.union_choice, UnionInt1_union_uint3_l, NULL);
+	zassert_equal(result1.number_m.number_choice, number_int, NULL);
+	zassert_equal(result1.number_m.Int, 1, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_UnionInt2(union_int_payload3,
 		sizeof(union_int_payload3), &result2, &num_decode), NULL);
 	zassert_equal(sizeof(union_int_payload3), num_decode, NULL);
-	zassert_equal(result2.union_choice, _union__nint, NULL);
-	zassert_equal(result2._number.number_choice, _number_int, NULL);
-	zassert_equal(result2._number._int, 1, NULL);
+	zassert_equal(result2.union_choice, union_nint_l, NULL);
+	zassert_equal(result2.number_m.number_choice, number_int, NULL);
+	zassert_equal(result2.number_m.Int, 1, NULL);
 
 	int err = cbor_decode_UnionInt2(union_int_payload6,
 		sizeof(union_int_payload6), &result2, &num_decode);
 	zassert_equal(ZCBOR_SUCCESS, err, "%d\r\n", err);
 	zassert_equal(sizeof(union_int_payload6), num_decode, NULL);
-	zassert_equal(result2.union_choice, _UnionInt2_union__Structure_One, NULL);
-	zassert_equal(result2._Structure_One.some_array.len, 2, NULL);
-	zassert_mem_equal(result2._Structure_One.some_array.value, "hi", 2, NULL);
+	zassert_equal(result2.union_choice, UnionInt2_union_Structure_One_m, NULL);
+	zassert_equal(result2.Structure_One_m.some_array.len, 2, NULL);
+	zassert_mem_equal(result2.Structure_One_m.some_array.value, "hi", 2, NULL);
 
 	err = cbor_decode_UnionInt1(union_int_payload4_inv,
 		sizeof(union_int_payload4_inv), &result1, &num_decode);

--- a/tests/decode/test7_suit9_simple/src/main.c
+++ b/tests/decode/test7_suit9_simple/src/main.c
@@ -105,8 +105,8 @@ ZTEST(cbor_decode_test7, test_suit9_simple2)
 	zassert_equal(ZCBOR_SUCCESS, res, "top-level decoding failed.");
 
 	res = cbor_decode_SUIT_Manifest(
-		envelope1._SUIT_Envelope_suit_manifest.value,
-		envelope1._SUIT_Envelope_suit_manifest.len, &manifest, NULL);
+		envelope1.SUIT_Envelope_suit_manifest.value,
+		envelope1.SUIT_Envelope_suit_manifest.len, &manifest, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, res, "manifest decoding failed.");
 }
@@ -125,8 +125,8 @@ ZTEST(cbor_decode_test7, test_suit9_simple5)
 	zassert_equal(ZCBOR_SUCCESS, res, "top-level decoding failed.");
 
 	res = cbor_decode_SUIT_Manifest(
-		envelope1._SUIT_Envelope_suit_manifest.value,
-		envelope1._SUIT_Envelope_suit_manifest.len, &manifest, NULL);
+		envelope1.SUIT_Envelope_suit_manifest.value,
+		envelope1.SUIT_Envelope_suit_manifest.len, &manifest, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, res, "manifest decoding failed.");
 }

--- a/tests/decode/test9_manifest14/src/main.c
+++ b/tests/decode/test9_manifest14/src/main.c
@@ -40,35 +40,35 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_auth)
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Envelope_Tagged(example0, sizeof(example0), &envelope, &out_len), NULL);
 	zassert_equal(sizeof(example0), out_len, NULL);
 
-	digest = &envelope._SUIT_Envelope_suit_authentication_wrapper_cbor._SUIT_Authentication_SUIT_Digest_bstr_cbor;
-	zassert_equal(_suit_cose_hash_algs__cose_alg_sha_256,
-		digest->_SUIT_Digest_suit_digest_algorithm_id._suit_cose_hash_algs_choice, NULL);
+	digest = &envelope.SUIT_Envelope_suit_authentication_wrapper_cbor.SUIT_Authentication_SUIT_Digest_bstr_cbor;
+	zassert_equal(suit_cose_hash_algs_cose_alg_sha_256_m,
+		digest->SUIT_Digest_suit_digest_algorithm_id.suit_cose_hash_algs_choice, NULL);
 	zassert_equal(sizeof(exp_digest),
-		digest->_SUIT_Digest_suit_digest_bytes.len, NULL);
+		digest->SUIT_Digest_suit_digest_bytes.len, NULL);
 	zassert_mem_equal(exp_digest,
-		digest->_SUIT_Digest_suit_digest_bytes.value,
-		digest->_SUIT_Digest_suit_digest_bytes.len, NULL);
-	zassert_equal(1, envelope._SUIT_Envelope_suit_authentication_wrapper_cbor._SUIT_Authentication_Block_bstr_count, NULL);
-	zassert_equal(_SUIT_Authentication_Block__COSE_Sign1_Tagged,
-		envelope._SUIT_Envelope_suit_authentication_wrapper_cbor._SUIT_Authentication_Block_bstr[0]._SUIT_Authentication_Block_bstr_cbor._SUIT_Authentication_Block_choice, NULL);
-	cose_sign1 = &envelope._SUIT_Envelope_suit_authentication_wrapper_cbor._SUIT_Authentication_Block_bstr[0]._SUIT_Authentication_Block_bstr_cbor._SUIT_Authentication_Block__COSE_Sign1_Tagged;
-	zassert_equal(_empty_or_serialized_map_header_map_bstr,
-		cose_sign1->_COSE_Sign1__Headers._Headers_protected._empty_or_serialized_map_choice, NULL);
-	zassert_equal(0, cose_sign1->_COSE_Sign1__Headers._Headers_protected._empty_or_serialized_map_header_map_bstr_cbor._header_map_label_count, NULL);
-	zassert_true(cose_sign1->_COSE_Sign1__Headers._Headers_protected._empty_or_serialized_map_header_map_bstr_cbor._header_map__Generic_Headers._Generic_Headers_uint1union_present, NULL);
-	zassert_false(cose_sign1->_COSE_Sign1__Headers._Headers_protected._empty_or_serialized_map_header_map_bstr_cbor._header_map__Generic_Headers._Generic_Headers___label_present, NULL);
-	zassert_false(cose_sign1->_COSE_Sign1__Headers._Headers_protected._empty_or_serialized_map_header_map_bstr_cbor._header_map__Generic_Headers._Generic_Headers_uint3union_present, NULL);
-	zassert_false(cose_sign1->_COSE_Sign1__Headers._Headers_protected._empty_or_serialized_map_header_map_bstr_cbor._header_map__Generic_Headers._Generic_Headers_uint4bstr_present, NULL);
-	zassert_false(cose_sign1->_COSE_Sign1__Headers._Headers_protected._empty_or_serialized_map_header_map_bstr_cbor._header_map__Generic_Headers._Generic_Headers_uint5bstr_present, NULL);
-	zassert_false(cose_sign1->_COSE_Sign1__Headers._Headers_protected._empty_or_serialized_map_header_map_bstr_cbor._header_map__Generic_Headers._Generic_Headers_uint6bstr_present, NULL);
-	zassert_equal(_Generic_Headers_uint1union_int,
-		cose_sign1->_COSE_Sign1__Headers._Headers_protected._empty_or_serialized_map_header_map_bstr_cbor._header_map__Generic_Headers._Generic_Headers_uint1union._Generic_Headers_uint1union_choice, NULL);
+		digest->SUIT_Digest_suit_digest_bytes.value,
+		digest->SUIT_Digest_suit_digest_bytes.len, NULL);
+	zassert_equal(1, envelope.SUIT_Envelope_suit_authentication_wrapper_cbor.SUIT_Authentication_Block_bstr_count, NULL);
+	zassert_equal(SUIT_Authentication_Block_COSE_Sign1_Tagged_m,
+		envelope.SUIT_Envelope_suit_authentication_wrapper_cbor.SUIT_Authentication_Block_bstr[0].SUIT_Authentication_Block_bstr_cbor.SUIT_Authentication_Block_choice, NULL);
+	cose_sign1 = &envelope.SUIT_Envelope_suit_authentication_wrapper_cbor.SUIT_Authentication_Block_bstr[0].SUIT_Authentication_Block_bstr_cbor.SUIT_Authentication_Block_COSE_Sign1_Tagged_m;
+	zassert_equal(empty_or_serialized_map_header_map_bstr,
+		cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_choice, NULL);
+	zassert_equal(0, cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_header_map_bstr_cbor.header_map_label_count, NULL);
+	zassert_true(cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_header_map_bstr_cbor.header_map_Generic_Headers_m.Generic_Headers_uint1union_present, NULL);
+	zassert_false(cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_header_map_bstr_cbor.header_map_Generic_Headers_m.Generic_Headers_label_m_l_present, NULL);
+	zassert_false(cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_header_map_bstr_cbor.header_map_Generic_Headers_m.Generic_Headers_uint3union_present, NULL);
+	zassert_false(cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_header_map_bstr_cbor.header_map_Generic_Headers_m.Generic_Headers_uint4bstr_present, NULL);
+	zassert_false(cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_header_map_bstr_cbor.header_map_Generic_Headers_m.Generic_Headers_uint5bstr_present, NULL);
+	zassert_false(cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_header_map_bstr_cbor.header_map_Generic_Headers_m.Generic_Headers_uint6bstr_present, NULL);
+	zassert_equal(Generic_Headers_uint1union_int,
+		cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_header_map_bstr_cbor.header_map_Generic_Headers_m.Generic_Headers_uint1union.Generic_Headers_uint1union_choice, NULL);
 	zassert_equal(-7,
-		cose_sign1->_COSE_Sign1__Headers._Headers_protected._empty_or_serialized_map_header_map_bstr_cbor._header_map__Generic_Headers._Generic_Headers_uint1union._Generic_Headers_uint1union_int, NULL);
-	zassert_equal(sizeof(exp_signature), cose_sign1->_COSE_Sign1_signature.len, NULL);
-	zassert_mem_equal(exp_signature, cose_sign1->_COSE_Sign1_signature.value,
-		cose_sign1->_COSE_Sign1_signature.len, NULL);
-	zassert_equal(_COSE_Sign1_payload_nil, cose_sign1->_COSE_Sign1_payload_choice, NULL);
+		cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_header_map_bstr_cbor.header_map_Generic_Headers_m.Generic_Headers_uint1union.Generic_Headers_uint1union_int, NULL);
+	zassert_equal(sizeof(exp_signature), cose_sign1->COSE_Sign1_signature.len, NULL);
+	zassert_mem_equal(exp_signature, cose_sign1->COSE_Sign1_signature.value,
+		cose_sign1->COSE_Sign1_signature.len, NULL);
+	zassert_equal(COSE_Sign1_payload_nil, cose_sign1->COSE_Sign1_payload_choice, NULL);
 }
 
 
@@ -79,8 +79,8 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_common_sequence)
 	struct SUIT_Manifest manifest;
 	struct SUIT_Common_Sequence common_sequence;
 	struct SUIT_Command_Sequence command_sequence;
-	struct SUIT_Parameters_ *parameter;
-	struct SUIT_Condition_ *condition;
+	struct SUIT_Parameters_r *parameter;
+	struct SUIT_Condition_r *condition;
 	size_t out_len;
 	uint8_t exp_vendor_id[] = {
 		0xfa, 0x6b, 0x4a, 0x53, 0xd5, 0xad, 0x5f, 0xdf,
@@ -97,92 +97,92 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_common_sequence)
 		0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10,
 	};
 	uint32_t exp_rep_policy = (
-		(1 << _suit_reporting_bits_suit_send_record_success)
-		| (1 << _suit_reporting_bits_suit_send_record_failure)
-		| (1 << _suit_reporting_bits_suit_send_sysinfo_success)
-		| (1 << _suit_reporting_bits_suit_send_sysinfo_failure));
+		(1 << suit_reporting_bits_suit_send_record_success)
+		| (1 << suit_reporting_bits_suit_send_record_failure)
+		| (1 << suit_reporting_bits_suit_send_sysinfo_success)
+		| (1 << suit_reporting_bits_suit_send_sysinfo_failure));
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Envelope_Tagged(example0, sizeof(example0), &envelope, &out_len), NULL);
 	zassert_equal(sizeof(example0), out_len, NULL);
-	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Manifest(envelope._SUIT_Envelope_suit_manifest.value,
-		envelope._SUIT_Envelope_suit_manifest.len, &manifest, &out_len), NULL);
-	zassert_equal(envelope._SUIT_Envelope_suit_manifest.len, out_len, NULL);
-	zassert_true(manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_components_present, NULL);
-	zassert_true(manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence_present, NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Manifest(envelope.SUIT_Envelope_suit_manifest.value,
+		envelope.SUIT_Envelope_suit_manifest.len, &manifest, &out_len), NULL);
+	zassert_equal(envelope.SUIT_Envelope_suit_manifest.len, out_len, NULL);
+	zassert_true(manifest.SUIT_Manifest_suit_common_cbor.SUIT_Common_suit_components_present, NULL);
+	zassert_true(manifest.SUIT_Manifest_suit_common_cbor.SUIT_Common_suit_common_sequence_present, NULL);
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Common_Sequence(
-		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.value,
-		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.len,
+		manifest.SUIT_Manifest_suit_common_cbor.SUIT_Common_suit_common_sequence.SUIT_Common_suit_common_sequence.value,
+		manifest.SUIT_Manifest_suit_common_cbor.SUIT_Common_suit_common_sequence.SUIT_Common_suit_common_sequence.len,
 		&common_sequence, &out_len), NULL);
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Command_Sequence(
-		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.value,
-		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.len,
+		manifest.SUIT_Manifest_suit_common_cbor.SUIT_Common_suit_common_sequence.SUIT_Common_suit_common_sequence.value,
+		manifest.SUIT_Manifest_suit_common_cbor.SUIT_Common_suit_common_sequence.SUIT_Common_suit_common_sequence.len,
 		&command_sequence, &out_len), NULL);
 	zassert_equal(
-		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.len,
+		manifest.SUIT_Manifest_suit_common_cbor.SUIT_Common_suit_common_sequence.SUIT_Common_suit_common_sequence.len,
 		out_len, NULL);
-	zassert_equal(3, common_sequence._SUIT_Common_Sequence_union_count, NULL);
-	zassert_equal(_SUIT_Common_Sequence_union__SUIT_Common_Commands, common_sequence._SUIT_Common_Sequence_union[0]._SUIT_Common_Sequence_union_choice, NULL);
-	zassert_equal(_SUIT_Common_Commands___suit_directive_override_parameters, common_sequence._SUIT_Common_Sequence_union[0]._SUIT_Common_Sequence_union__SUIT_Common_Commands._SUIT_Common_Commands_choice, NULL);
-	zassert_equal(4, common_sequence._SUIT_Common_Sequence_union[0]._SUIT_Common_Sequence_union__SUIT_Common_Commands.___suit_directive_override_parameters_map__SUIT_Parameters_count, NULL);
-	parameter = &common_sequence._SUIT_Common_Sequence_union[0]._SUIT_Common_Sequence_union__SUIT_Common_Commands.___suit_directive_override_parameters_map__SUIT_Parameters[0].___suit_directive_override_parameters_map__SUIT_Parameters;
+	zassert_equal(3, common_sequence.SUIT_Common_Sequence_union_count, NULL);
+	zassert_equal(SUIT_Common_Sequence_union_SUIT_Common_Commands_m, common_sequence.SUIT_Common_Sequence_union[0].SUIT_Common_Sequence_union_choice, NULL);
+	zassert_equal(SUIT_Common_Commands_suit_directive_override_parameters_m_l, common_sequence.SUIT_Common_Sequence_union[0].SUIT_Common_Sequence_union_SUIT_Common_Commands_m.SUIT_Common_Commands_choice, NULL);
+	zassert_equal(4, common_sequence.SUIT_Common_Sequence_union[0].SUIT_Common_Sequence_union_SUIT_Common_Commands_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m_count, NULL);
+	parameter = &common_sequence.SUIT_Common_Sequence_union[0].SUIT_Common_Sequence_union_SUIT_Common_Commands_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m[0].suit_directive_override_parameters_m_l_map_SUIT_Parameters_m;
 	zassert_equal(
-		_SUIT_Parameters_suit_parameter_vendor_identifier,
-		parameter->_SUIT_Parameters_choice, NULL);
+		SUIT_Parameters_suit_parameter_vendor_identifier,
+		parameter->SUIT_Parameters_choice, NULL);
 	zassert_equal(
-		_SUIT_Parameters_suit_parameter_vendor_identifier__RFC4122_UUID,
-		parameter->_SUIT_Parameters_suit_parameter_vendor_identifier_choice, NULL);
+		SUIT_Parameters_suit_parameter_vendor_identifier_RFC4122_UUID_m,
+		parameter->SUIT_Parameters_suit_parameter_vendor_identifier_choice, NULL);
 	zassert_equal(
-		parameter->_SUIT_Parameters_suit_parameter_vendor_identifier__RFC4122_UUID.len,
+		parameter->SUIT_Parameters_suit_parameter_vendor_identifier_RFC4122_UUID_m.len,
 		sizeof(exp_vendor_id), NULL);
 	zassert_mem_equal(exp_vendor_id,
-		parameter->_SUIT_Parameters_suit_parameter_vendor_identifier__RFC4122_UUID.value,
-		parameter->_SUIT_Parameters_suit_parameter_vendor_identifier__RFC4122_UUID.len, NULL);
+		parameter->SUIT_Parameters_suit_parameter_vendor_identifier_RFC4122_UUID_m.value,
+		parameter->SUIT_Parameters_suit_parameter_vendor_identifier_RFC4122_UUID_m.len, NULL);
 
-	parameter = &common_sequence._SUIT_Common_Sequence_union[0]._SUIT_Common_Sequence_union__SUIT_Common_Commands.___suit_directive_override_parameters_map__SUIT_Parameters[1].___suit_directive_override_parameters_map__SUIT_Parameters;
+	parameter = &common_sequence.SUIT_Common_Sequence_union[0].SUIT_Common_Sequence_union_SUIT_Common_Commands_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m[1].suit_directive_override_parameters_m_l_map_SUIT_Parameters_m;
 	zassert_equal(
-		_SUIT_Parameters_suit_parameter_class_identifier,
-		parameter->_SUIT_Parameters_choice, NULL);
+		SUIT_Parameters_suit_parameter_class_identifier,
+		parameter->SUIT_Parameters_choice, NULL);
 	zassert_equal(
-		parameter->_SUIT_Parameters_suit_parameter_class_identifier.len,
+		parameter->SUIT_Parameters_suit_parameter_class_identifier.len,
 		sizeof(exp_class_id), NULL);
 	zassert_mem_equal(exp_class_id,
-		parameter->_SUIT_Parameters_suit_parameter_class_identifier.value,
-		parameter->_SUIT_Parameters_suit_parameter_class_identifier.len, NULL);
+		parameter->SUIT_Parameters_suit_parameter_class_identifier.value,
+		parameter->SUIT_Parameters_suit_parameter_class_identifier.len, NULL);
 
-	parameter = &common_sequence._SUIT_Common_Sequence_union[0]._SUIT_Common_Sequence_union__SUIT_Common_Commands.___suit_directive_override_parameters_map__SUIT_Parameters[2].___suit_directive_override_parameters_map__SUIT_Parameters;
+	parameter = &common_sequence.SUIT_Common_Sequence_union[0].SUIT_Common_Sequence_union_SUIT_Common_Commands_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m[2].suit_directive_override_parameters_m_l_map_SUIT_Parameters_m;
 	zassert_equal(
-		_SUIT_Parameters_suit_parameter_image_digest,
-		parameter->_SUIT_Parameters_choice, NULL);
+		SUIT_Parameters_suit_parameter_image_digest,
+		parameter->SUIT_Parameters_choice, NULL);
 	zassert_equal(
-		parameter->_SUIT_Parameters_suit_parameter_image_digest_cbor._SUIT_Digest_suit_digest_bytes.len,
+		parameter->SUIT_Parameters_suit_parameter_image_digest_cbor.SUIT_Digest_suit_digest_bytes.len,
 		sizeof(exp_digest), NULL);
-	zassert_equal(_suit_cose_hash_algs__cose_alg_sha_256,
-		parameter->_SUIT_Parameters_suit_parameter_image_digest_cbor._SUIT_Digest_suit_digest_algorithm_id._suit_cose_hash_algs_choice, NULL);
+	zassert_equal(suit_cose_hash_algs_cose_alg_sha_256_m,
+		parameter->SUIT_Parameters_suit_parameter_image_digest_cbor.SUIT_Digest_suit_digest_algorithm_id.suit_cose_hash_algs_choice, NULL);
 	zassert_mem_equal(exp_digest,
-		parameter->_SUIT_Parameters_suit_parameter_image_digest_cbor._SUIT_Digest_suit_digest_bytes.value,
-		parameter->_SUIT_Parameters_suit_parameter_image_digest_cbor._SUIT_Digest_suit_digest_bytes.len, NULL);
+		parameter->SUIT_Parameters_suit_parameter_image_digest_cbor.SUIT_Digest_suit_digest_bytes.value,
+		parameter->SUIT_Parameters_suit_parameter_image_digest_cbor.SUIT_Digest_suit_digest_bytes.len, NULL);
 
-	parameter = &common_sequence._SUIT_Common_Sequence_union[0]._SUIT_Common_Sequence_union__SUIT_Common_Commands.___suit_directive_override_parameters_map__SUIT_Parameters[3].___suit_directive_override_parameters_map__SUIT_Parameters;
+	parameter = &common_sequence.SUIT_Common_Sequence_union[0].SUIT_Common_Sequence_union_SUIT_Common_Commands_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m[3].suit_directive_override_parameters_m_l_map_SUIT_Parameters_m;
 	zassert_equal(
-		_SUIT_Parameters_suit_parameter_image_size,
-		parameter->_SUIT_Parameters_choice, NULL);
-	zassert_equal(34768, parameter->_SUIT_Parameters_suit_parameter_image_size, NULL);
+		SUIT_Parameters_suit_parameter_image_size,
+		parameter->SUIT_Parameters_choice, NULL);
+	zassert_equal(34768, parameter->SUIT_Parameters_suit_parameter_image_size, NULL);
 
-	zassert_equal(_SUIT_Common_Sequence_union__SUIT_Condition, common_sequence._SUIT_Common_Sequence_union[1]._SUIT_Common_Sequence_union_choice, NULL);
-	condition = &common_sequence._SUIT_Common_Sequence_union[1]._SUIT_Common_Sequence_union__SUIT_Condition;
-	zassert_equal(_SUIT_Condition___suit_condition_vendor_identifier,
-		condition->_SUIT_Condition_choice, NULL);
+	zassert_equal(SUIT_Common_Sequence_union_SUIT_Condition_m, common_sequence.SUIT_Common_Sequence_union[1].SUIT_Common_Sequence_union_choice, NULL);
+	condition = &common_sequence.SUIT_Common_Sequence_union[1].SUIT_Common_Sequence_union_SUIT_Condition_m;
+	zassert_equal(SUIT_Condition_suit_condition_vendor_identifier_m_l,
+		condition->SUIT_Condition_choice, NULL);
 	zassert_equal(exp_rep_policy,
-		condition->_SUIT_Condition___suit_condition_vendor_identifier__SUIT_Rep_Policy, NULL);
+		condition->SUIT_Condition_suit_condition_vendor_identifier_m_l_SUIT_Rep_Policy_m, NULL);
 	zassert_equal(exp_rep_policy,
-		condition->_SUIT_Condition___suit_condition_class_identifier__SUIT_Rep_Policy, NULL);
+		condition->SUIT_Condition_suit_condition_class_identifier_m_l_SUIT_Rep_Policy_m, NULL);
 
-	zassert_equal(_SUIT_Common_Sequence_union__SUIT_Condition, common_sequence._SUIT_Common_Sequence_union[2]._SUIT_Common_Sequence_union_choice, NULL);
-	condition = &common_sequence._SUIT_Common_Sequence_union[2]._SUIT_Common_Sequence_union__SUIT_Condition;
-	zassert_equal(_SUIT_Condition___suit_condition_class_identifier,
-		condition->_SUIT_Condition_choice, NULL);
+	zassert_equal(SUIT_Common_Sequence_union_SUIT_Condition_m, common_sequence.SUIT_Common_Sequence_union[2].SUIT_Common_Sequence_union_choice, NULL);
+	condition = &common_sequence.SUIT_Common_Sequence_union[2].SUIT_Common_Sequence_union_SUIT_Condition_m;
+	zassert_equal(SUIT_Condition_suit_condition_class_identifier_m_l,
+		condition->SUIT_Condition_choice, NULL);
 	zassert_equal(exp_rep_policy,
-		condition->_SUIT_Condition___suit_condition_class_identifier__SUIT_Rep_Policy, NULL);
+		condition->SUIT_Condition_suit_condition_class_identifier_m_l_SUIT_Rep_Policy_m, NULL);
 }
 
 /* Check the common sequence when decoded as a command sequence.
@@ -195,8 +195,8 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_common_sequence_as_command_sequence)
 	struct SUIT_Manifest manifest;
 	struct SUIT_Common_Sequence common_sequence;
 	struct SUIT_Command_Sequence command_sequence;
-	struct SUIT_Parameters_ *parameter;
-	struct SUIT_Condition_ *condition;
+	struct SUIT_Parameters_r *parameter;
+	struct SUIT_Condition_r *condition;
 	size_t out_len;
 	uint8_t exp_vendor_id[] = {
 		0xfa, 0x6b, 0x4a, 0x53, 0xd5, 0xad, 0x5f, 0xdf,
@@ -213,96 +213,96 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_common_sequence_as_command_sequence)
 		0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10,
 	};
 	uint32_t exp_rep_policy = (
-		(1 << _suit_reporting_bits_suit_send_record_success)
-		| (1 << _suit_reporting_bits_suit_send_record_failure)
-		| (1 << _suit_reporting_bits_suit_send_sysinfo_success)
-		| (1 << _suit_reporting_bits_suit_send_sysinfo_failure));
+		(1 << suit_reporting_bits_suit_send_record_success)
+		| (1 << suit_reporting_bits_suit_send_record_failure)
+		| (1 << suit_reporting_bits_suit_send_sysinfo_success)
+		| (1 << suit_reporting_bits_suit_send_sysinfo_failure));
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Envelope_Tagged(example0, sizeof(example0), &envelope, &out_len), NULL);
 	zassert_equal(sizeof(example0), out_len, NULL);
-	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Manifest(envelope._SUIT_Envelope_suit_manifest.value,
-		envelope._SUIT_Envelope_suit_manifest.len, &manifest, &out_len), NULL);
-	zassert_equal(envelope._SUIT_Envelope_suit_manifest.len, out_len, NULL);
-	zassert_true(manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_components_present, NULL);
-	zassert_true(manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence_present, NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Manifest(envelope.SUIT_Envelope_suit_manifest.value,
+		envelope.SUIT_Envelope_suit_manifest.len, &manifest, &out_len), NULL);
+	zassert_equal(envelope.SUIT_Envelope_suit_manifest.len, out_len, NULL);
+	zassert_true(manifest.SUIT_Manifest_suit_common_cbor.SUIT_Common_suit_components_present, NULL);
+	zassert_true(manifest.SUIT_Manifest_suit_common_cbor.SUIT_Common_suit_common_sequence_present, NULL);
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Common_Sequence(
-		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.value,
-		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.len,
+		manifest.SUIT_Manifest_suit_common_cbor.SUIT_Common_suit_common_sequence.SUIT_Common_suit_common_sequence.value,
+		manifest.SUIT_Manifest_suit_common_cbor.SUIT_Common_suit_common_sequence.SUIT_Common_suit_common_sequence.len,
 		&common_sequence, &out_len), NULL);
 	zassert_equal(
-		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.len,
+		manifest.SUIT_Manifest_suit_common_cbor.SUIT_Common_suit_common_sequence.SUIT_Common_suit_common_sequence.len,
 		out_len, NULL);
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Command_Sequence(
-		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.value,
-		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.len,
+		manifest.SUIT_Manifest_suit_common_cbor.SUIT_Common_suit_common_sequence.SUIT_Common_suit_common_sequence.value,
+		manifest.SUIT_Manifest_suit_common_cbor.SUIT_Common_suit_common_sequence.SUIT_Common_suit_common_sequence.len,
 		&command_sequence, &out_len), NULL);
 	zassert_equal(
-		manifest._SUIT_Manifest_suit_common_cbor._SUIT_Common_suit_common_sequence._SUIT_Common_suit_common_sequence.len,
+		manifest.SUIT_Manifest_suit_common_cbor.SUIT_Common_suit_common_sequence.SUIT_Common_suit_common_sequence.len,
 		out_len, NULL);
-	zassert_equal(3, command_sequence._SUIT_Command_Sequence_union_count, NULL);
-	zassert_equal(_SUIT_Command_Sequence_union__SUIT_Directive, command_sequence._SUIT_Command_Sequence_union[0]._SUIT_Command_Sequence_union_choice, NULL);
-	zassert_equal(_SUIT_Directive___suit_directive_override_parameters, command_sequence._SUIT_Command_Sequence_union[0]._SUIT_Command_Sequence_union__SUIT_Directive._SUIT_Directive_choice, NULL);
-	zassert_equal(4, command_sequence._SUIT_Command_Sequence_union[0]._SUIT_Command_Sequence_union__SUIT_Directive.___suit_directive_override_parameters_map__SUIT_Parameters_count, NULL);
+	zassert_equal(3, command_sequence.SUIT_Command_Sequence_union_count, NULL);
+	zassert_equal(SUIT_Command_Sequence_union_SUIT_Directive_m, command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_choice, NULL);
+	zassert_equal(SUIT_Directive_suit_directive_override_parameters_m_l, command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_SUIT_Directive_m.SUIT_Directive_choice, NULL);
+	zassert_equal(4, command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_SUIT_Directive_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m_count, NULL);
 
-	parameter = &command_sequence._SUIT_Command_Sequence_union[0]._SUIT_Command_Sequence_union__SUIT_Directive.___suit_directive_override_parameters_map__SUIT_Parameters[0].___suit_directive_override_parameters_map__SUIT_Parameters;
+	parameter = &command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_SUIT_Directive_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m[0].suit_directive_override_parameters_m_l_map_SUIT_Parameters_m;
 	zassert_equal(
-		_SUIT_Parameters_suit_parameter_vendor_identifier,
-		parameter->_SUIT_Parameters_choice, NULL);
+		SUIT_Parameters_suit_parameter_vendor_identifier,
+		parameter->SUIT_Parameters_choice, NULL);
 	zassert_equal(
-		_SUIT_Parameters_suit_parameter_vendor_identifier__RFC4122_UUID,
-		parameter->_SUIT_Parameters_suit_parameter_vendor_identifier_choice, NULL);
+		SUIT_Parameters_suit_parameter_vendor_identifier_RFC4122_UUID_m,
+		parameter->SUIT_Parameters_suit_parameter_vendor_identifier_choice, NULL);
 	zassert_equal(
-		parameter->_SUIT_Parameters_suit_parameter_vendor_identifier__RFC4122_UUID.len,
+		parameter->SUIT_Parameters_suit_parameter_vendor_identifier_RFC4122_UUID_m.len,
 		sizeof(exp_vendor_id), NULL);
 	zassert_mem_equal(exp_vendor_id,
-		parameter->_SUIT_Parameters_suit_parameter_vendor_identifier__RFC4122_UUID.value,
-		parameter->_SUIT_Parameters_suit_parameter_vendor_identifier__RFC4122_UUID.len, NULL);
+		parameter->SUIT_Parameters_suit_parameter_vendor_identifier_RFC4122_UUID_m.value,
+		parameter->SUIT_Parameters_suit_parameter_vendor_identifier_RFC4122_UUID_m.len, NULL);
 
-	parameter = &command_sequence._SUIT_Command_Sequence_union[0]._SUIT_Command_Sequence_union__SUIT_Directive.___suit_directive_override_parameters_map__SUIT_Parameters[1].___suit_directive_override_parameters_map__SUIT_Parameters;
+	parameter = &command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_SUIT_Directive_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m[1].suit_directive_override_parameters_m_l_map_SUIT_Parameters_m;
 	zassert_equal(
-		_SUIT_Parameters_suit_parameter_class_identifier,
-		parameter->_SUIT_Parameters_choice, NULL);
+		SUIT_Parameters_suit_parameter_class_identifier,
+		parameter->SUIT_Parameters_choice, NULL);
 	zassert_equal(
-		parameter->_SUIT_Parameters_suit_parameter_class_identifier.len,
+		parameter->SUIT_Parameters_suit_parameter_class_identifier.len,
 		sizeof(exp_class_id), NULL);
 	zassert_mem_equal(exp_class_id,
-		parameter->_SUIT_Parameters_suit_parameter_class_identifier.value,
-		parameter->_SUIT_Parameters_suit_parameter_class_identifier.len, NULL);
+		parameter->SUIT_Parameters_suit_parameter_class_identifier.value,
+		parameter->SUIT_Parameters_suit_parameter_class_identifier.len, NULL);
 
-	parameter = &command_sequence._SUIT_Command_Sequence_union[0]._SUIT_Command_Sequence_union__SUIT_Directive.___suit_directive_override_parameters_map__SUIT_Parameters[2].___suit_directive_override_parameters_map__SUIT_Parameters;
+	parameter = &command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_SUIT_Directive_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m[2].suit_directive_override_parameters_m_l_map_SUIT_Parameters_m;
 	zassert_equal(
-		_SUIT_Parameters_suit_parameter_image_digest,
-		parameter->_SUIT_Parameters_choice, NULL);
+		SUIT_Parameters_suit_parameter_image_digest,
+		parameter->SUIT_Parameters_choice, NULL);
 	zassert_equal(
-		parameter->_SUIT_Parameters_suit_parameter_image_digest_cbor._SUIT_Digest_suit_digest_bytes.len,
+		parameter->SUIT_Parameters_suit_parameter_image_digest_cbor.SUIT_Digest_suit_digest_bytes.len,
 		sizeof(exp_digest), NULL);
-	zassert_equal(_suit_cose_hash_algs__cose_alg_sha_256,
-		parameter->_SUIT_Parameters_suit_parameter_image_digest_cbor._SUIT_Digest_suit_digest_algorithm_id._suit_cose_hash_algs_choice, NULL);
+	zassert_equal(suit_cose_hash_algs_cose_alg_sha_256_m,
+		parameter->SUIT_Parameters_suit_parameter_image_digest_cbor.SUIT_Digest_suit_digest_algorithm_id.suit_cose_hash_algs_choice, NULL);
 	zassert_mem_equal(exp_digest,
-		parameter->_SUIT_Parameters_suit_parameter_image_digest_cbor._SUIT_Digest_suit_digest_bytes.value,
-		parameter->_SUIT_Parameters_suit_parameter_image_digest_cbor._SUIT_Digest_suit_digest_bytes.len, NULL);
+		parameter->SUIT_Parameters_suit_parameter_image_digest_cbor.SUIT_Digest_suit_digest_bytes.value,
+		parameter->SUIT_Parameters_suit_parameter_image_digest_cbor.SUIT_Digest_suit_digest_bytes.len, NULL);
 
-	parameter = &command_sequence._SUIT_Command_Sequence_union[0]._SUIT_Command_Sequence_union__SUIT_Directive.___suit_directive_override_parameters_map__SUIT_Parameters[3].___suit_directive_override_parameters_map__SUIT_Parameters;
+	parameter = &command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_SUIT_Directive_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m[3].suit_directive_override_parameters_m_l_map_SUIT_Parameters_m;
 	zassert_equal(
-		_SUIT_Parameters_suit_parameter_image_size,
-		parameter->_SUIT_Parameters_choice, NULL);
-	zassert_equal(34768, parameter->_SUIT_Parameters_suit_parameter_image_size, NULL);
+		SUIT_Parameters_suit_parameter_image_size,
+		parameter->SUIT_Parameters_choice, NULL);
+	zassert_equal(34768, parameter->SUIT_Parameters_suit_parameter_image_size, NULL);
 
-	zassert_equal(_SUIT_Command_Sequence_union__SUIT_Condition, command_sequence._SUIT_Command_Sequence_union[1]._SUIT_Command_Sequence_union_choice, NULL);
-	condition = &command_sequence._SUIT_Command_Sequence_union[1]._SUIT_Command_Sequence_union__SUIT_Condition;
-	zassert_equal(_SUIT_Condition___suit_condition_vendor_identifier,
-		condition->_SUIT_Condition_choice, NULL);
+	zassert_equal(SUIT_Command_Sequence_union_SUIT_Condition_m, command_sequence.SUIT_Command_Sequence_union[1].SUIT_Command_Sequence_union_choice, NULL);
+	condition = &command_sequence.SUIT_Command_Sequence_union[1].SUIT_Command_Sequence_union_SUIT_Condition_m;
+	zassert_equal(SUIT_Condition_suit_condition_vendor_identifier_m_l,
+		condition->SUIT_Condition_choice, NULL);
 	zassert_equal(exp_rep_policy,
-		condition->_SUIT_Condition___suit_condition_vendor_identifier__SUIT_Rep_Policy, NULL);
+		condition->SUIT_Condition_suit_condition_vendor_identifier_m_l_SUIT_Rep_Policy_m, NULL);
 	zassert_equal(exp_rep_policy,
-		condition->_SUIT_Condition___suit_condition_class_identifier__SUIT_Rep_Policy, NULL);
+		condition->SUIT_Condition_suit_condition_class_identifier_m_l_SUIT_Rep_Policy_m, NULL);
 
-	zassert_equal(_SUIT_Command_Sequence_union__SUIT_Condition, command_sequence._SUIT_Command_Sequence_union[2]._SUIT_Command_Sequence_union_choice, NULL);
-	condition = &command_sequence._SUIT_Command_Sequence_union[2]._SUIT_Command_Sequence_union__SUIT_Condition;
-	zassert_equal(_SUIT_Condition___suit_condition_class_identifier,
-		condition->_SUIT_Condition_choice, NULL);
+	zassert_equal(SUIT_Command_Sequence_union_SUIT_Condition_m, command_sequence.SUIT_Command_Sequence_union[2].SUIT_Command_Sequence_union_choice, NULL);
+	condition = &command_sequence.SUIT_Command_Sequence_union[2].SUIT_Command_Sequence_union_SUIT_Condition_m;
+	zassert_equal(SUIT_Condition_suit_condition_class_identifier_m_l,
+		condition->SUIT_Condition_choice, NULL);
 	zassert_equal(exp_rep_policy,
-		condition->_SUIT_Condition___suit_condition_class_identifier__SUIT_Rep_Policy, NULL);
+		condition->SUIT_Condition_suit_condition_class_identifier_m_l_SUIT_Rep_Policy_m, NULL);
 }
 
 ZTEST(cbor_decode_test9, test_suit14_ex0_validate_run)
@@ -310,54 +310,54 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_validate_run)
 	struct SUIT_Envelope envelope;
 	struct SUIT_Manifest manifest;
 	struct SUIT_Command_Sequence command_sequence;
-	struct SUIT_Condition_ *condition;
-	struct SUIT_Directive_ *directive;
+	struct SUIT_Condition_r *condition;
+	struct SUIT_Directive_r *directive;
 	size_t out_len;
 	uint32_t exp_rep_policy1 = (
-		(1 << _suit_reporting_bits_suit_send_record_success)
-		| (1 << _suit_reporting_bits_suit_send_record_failure)
-		| (1 << _suit_reporting_bits_suit_send_sysinfo_success)
-		| (1 << _suit_reporting_bits_suit_send_sysinfo_failure));
-	uint32_t exp_rep_policy2 = (1 << _suit_reporting_bits_suit_send_record_failure);
+		(1 << suit_reporting_bits_suit_send_record_success)
+		| (1 << suit_reporting_bits_suit_send_record_failure)
+		| (1 << suit_reporting_bits_suit_send_sysinfo_success)
+		| (1 << suit_reporting_bits_suit_send_sysinfo_failure));
+	uint32_t exp_rep_policy2 = (1 << suit_reporting_bits_suit_send_record_failure);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Envelope_Tagged(example0, sizeof(example0), &envelope, &out_len), NULL);
 	zassert_equal(sizeof(example0), out_len, NULL);
-	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Manifest(envelope._SUIT_Envelope_suit_manifest.value,
-		envelope._SUIT_Envelope_suit_manifest.len, &manifest, &out_len), NULL);
-	zassert_equal(envelope._SUIT_Envelope_suit_manifest.len, out_len, NULL);
-	zassert_true(manifest._SUIT_Manifest__SUIT_Unseverable_Members._SUIT_Unseverable_Members_suit_validate_present, NULL);
-	zassert_false(manifest._SUIT_Manifest__SUIT_Unseverable_Members._SUIT_Unseverable_Members_suit_load_present, NULL);
-	zassert_true(manifest._SUIT_Manifest__SUIT_Unseverable_Members._SUIT_Unseverable_Members_suit_run_present, NULL);
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Manifest(envelope.SUIT_Envelope_suit_manifest.value,
+		envelope.SUIT_Envelope_suit_manifest.len, &manifest, &out_len), NULL);
+	zassert_equal(envelope.SUIT_Envelope_suit_manifest.len, out_len, NULL);
+	zassert_true(manifest.SUIT_Manifest_SUIT_Unseverable_Members_m.SUIT_Unseverable_Members_suit_validate_present, NULL);
+	zassert_false(manifest.SUIT_Manifest_SUIT_Unseverable_Members_m.SUIT_Unseverable_Members_suit_load_present, NULL);
+	zassert_true(manifest.SUIT_Manifest_SUIT_Unseverable_Members_m.SUIT_Unseverable_Members_suit_run_present, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Command_Sequence(
-		manifest._SUIT_Manifest__SUIT_Unseverable_Members._SUIT_Unseverable_Members_suit_validate._SUIT_Unseverable_Members_suit_validate.value,
-		manifest._SUIT_Manifest__SUIT_Unseverable_Members._SUIT_Unseverable_Members_suit_validate._SUIT_Unseverable_Members_suit_validate.len,
+		manifest.SUIT_Manifest_SUIT_Unseverable_Members_m.SUIT_Unseverable_Members_suit_validate.SUIT_Unseverable_Members_suit_validate.value,
+		manifest.SUIT_Manifest_SUIT_Unseverable_Members_m.SUIT_Unseverable_Members_suit_validate.SUIT_Unseverable_Members_suit_validate.len,
 		&command_sequence, &out_len), NULL);
 	zassert_equal(
-		manifest._SUIT_Manifest__SUIT_Unseverable_Members._SUIT_Unseverable_Members_suit_validate._SUIT_Unseverable_Members_suit_validate.len,
+		manifest.SUIT_Manifest_SUIT_Unseverable_Members_m.SUIT_Unseverable_Members_suit_validate.SUIT_Unseverable_Members_suit_validate.len,
 		out_len, NULL);
-	zassert_equal(1, command_sequence._SUIT_Command_Sequence_union_count, NULL);
-	zassert_equal(_SUIT_Command_Sequence_union__SUIT_Condition, command_sequence._SUIT_Command_Sequence_union[0]._SUIT_Command_Sequence_union_choice, NULL);
-	condition = &command_sequence._SUIT_Command_Sequence_union[0]._SUIT_Command_Sequence_union__SUIT_Condition;
-	zassert_equal(_SUIT_Condition___suit_condition_image_match,
-		condition->_SUIT_Condition_choice, NULL);
+	zassert_equal(1, command_sequence.SUIT_Command_Sequence_union_count, NULL);
+	zassert_equal(SUIT_Command_Sequence_union_SUIT_Condition_m, command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_choice, NULL);
+	condition = &command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_SUIT_Condition_m;
+	zassert_equal(SUIT_Condition_suit_condition_image_match_m_l,
+		condition->SUIT_Condition_choice, NULL);
 	zassert_equal(exp_rep_policy1,
-		condition->_SUIT_Condition___suit_condition_image_match__SUIT_Rep_Policy, NULL);
+		condition->SUIT_Condition_suit_condition_image_match_m_l_SUIT_Rep_Policy_m, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Command_Sequence(
-		manifest._SUIT_Manifest__SUIT_Unseverable_Members._SUIT_Unseverable_Members_suit_run._SUIT_Unseverable_Members_suit_run.value,
-		manifest._SUIT_Manifest__SUIT_Unseverable_Members._SUIT_Unseverable_Members_suit_run._SUIT_Unseverable_Members_suit_run.len,
+		manifest.SUIT_Manifest_SUIT_Unseverable_Members_m.SUIT_Unseverable_Members_suit_run.SUIT_Unseverable_Members_suit_run.value,
+		manifest.SUIT_Manifest_SUIT_Unseverable_Members_m.SUIT_Unseverable_Members_suit_run.SUIT_Unseverable_Members_suit_run.len,
 		&command_sequence, &out_len), NULL);
 	zassert_equal(
-		manifest._SUIT_Manifest__SUIT_Unseverable_Members._SUIT_Unseverable_Members_suit_run._SUIT_Unseverable_Members_suit_run.len,
+		manifest.SUIT_Manifest_SUIT_Unseverable_Members_m.SUIT_Unseverable_Members_suit_run.SUIT_Unseverable_Members_suit_run.len,
 		out_len, NULL);
-	zassert_equal(1, command_sequence._SUIT_Command_Sequence_union_count, NULL);
-	zassert_equal(_SUIT_Command_Sequence_union__SUIT_Directive, command_sequence._SUIT_Command_Sequence_union[0]._SUIT_Command_Sequence_union_choice, NULL);
-	directive = &command_sequence._SUIT_Command_Sequence_union[0]._SUIT_Command_Sequence_union__SUIT_Directive;
-	zassert_equal(_SUIT_Directive___suit_directive_run,
-		directive->_SUIT_Directive_choice, NULL);
+	zassert_equal(1, command_sequence.SUIT_Command_Sequence_union_count, NULL);
+	zassert_equal(SUIT_Command_Sequence_union_SUIT_Directive_m, command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_choice, NULL);
+	directive = &command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_SUIT_Directive_m;
+	zassert_equal(SUIT_Directive_suit_directive_run_m_l,
+		directive->SUIT_Directive_choice, NULL);
 	zassert_equal(exp_rep_policy2,
-		directive->_SUIT_Directive___suit_directive_run__SUIT_Rep_Policy, NULL);
+		directive->SUIT_Directive_suit_directive_run_m_l_SUIT_Rep_Policy_m, NULL);
 
 }
 

--- a/tests/encode/test1_suit/src/main.c
+++ b/tests/encode/test1_suit/src/main.c
@@ -263,48 +263,48 @@ void test_command_sequence(struct zcbor_string *sequence_str,
 		sequence_str->len,
 		NULL);
 
-	for (uint32_t i = 0; i < sequence1._SUIT_Command_Sequence_union_count; i++) {
-		struct SUIT_Directive_ *directive;
+	for (uint32_t i = 0; i < sequence1.SUIT_Command_Sequence_union_count; i++) {
+		struct SUIT_Directive_r *directive;
 		bool directive_present;
 		directive = &sequence1
-			._SUIT_Command_Sequence_union[i]
-			._SUIT_Command_Sequence_union__SUIT_Directive;
+			.SUIT_Command_Sequence_union[i]
+			.SUIT_Command_Sequence_union_SUIT_Directive_m;
 		directive_present = sequence1
-			._SUIT_Command_Sequence_union[i]
-			._SUIT_Command_Sequence_union_choice
-			== _SUIT_Command_Sequence_union__SUIT_Directive;
+			.SUIT_Command_Sequence_union[i]
+			.SUIT_Command_Sequence_union_choice
+			== SUIT_Command_Sequence_union_SUIT_Directive_m;
 
 		run_seq = &directive
-			->_SUIT_Directive___suit_directive_run_sequence_SUIT_Command_Sequence_bstr;
+			->SUIT_Directive_suit_directive_run_sequence_m_l_SUIT_Command_Sequence_bstr;
 		run_seq_present = directive_present
 			&& directive
-			->_SUIT_Directive_choice
-			== _SUIT_Directive___suit_directive_run_sequence;
+			->SUIT_Directive_choice
+			== SUIT_Directive_suit_directive_run_sequence_m_l;
 		test_command_sequence(run_seq, run_seq_present, "run_seq");
 
 		for (uint32_t j = 0; j < directive
-			->_SUIT_Directive___suit_directive_try_each__SUIT_Directive_Try_Each_Argument
-			._SUIT_Directive_Try_Each_Argument_SUIT_Command_Sequence_bstr_count; j++) {
+			->SUIT_Directive_suit_directive_try_each_m_l_SUIT_Directive_Try_Each_Argument_m
+			.SUIT_Directive_Try_Each_Argument_SUIT_Command_Sequence_bstr_count; j++) {
 
 			try_each1 = &directive
-				->_SUIT_Directive___suit_directive_try_each__SUIT_Directive_Try_Each_Argument
-				._SUIT_Directive_Try_Each_Argument_SUIT_Command_Sequence_bstr[j];
+				->SUIT_Directive_suit_directive_try_each_m_l_SUIT_Directive_Try_Each_Argument_m
+				.SUIT_Directive_Try_Each_Argument_SUIT_Command_Sequence_bstr[j];
 			try_each1_present = directive_present
-				&& directive->_SUIT_Directive_choice
-				== _SUIT_Directive___suit_directive_try_each;
+				&& directive->SUIT_Directive_choice
+				== SUIT_Directive_suit_directive_try_each_m_l;
 			test_command_sequence(try_each1, try_each1_present, "try_each1");
 		}
 
 		try_each2 = &directive
-			->_SUIT_Directive___suit_directive_try_each__SUIT_Directive_Try_Each_Argument
-			._SUIT_Directive_Try_Each_Argument_union_SUIT_Command_Sequence_bstr;
+			->SUIT_Directive_suit_directive_try_each_m_l_SUIT_Directive_Try_Each_Argument_m
+			.SUIT_Directive_Try_Each_Argument_union_SUIT_Command_Sequence_bstr;
 		try_each2_present = directive_present
-			&& directive->_SUIT_Directive_choice
-			== _SUIT_Directive___suit_directive_try_each
+			&& directive->SUIT_Directive_choice
+			== SUIT_Directive_suit_directive_try_each_m_l
 			&& directive
-			->_SUIT_Directive___suit_directive_try_each__SUIT_Directive_Try_Each_Argument
-			._SUIT_Directive_Try_Each_Argument_union_choice
-			== _SUIT_Directive_Try_Each_Argument_union_SUIT_Command_Sequence_bstr;
+			->SUIT_Directive_suit_directive_try_each_m_l_SUIT_Directive_Try_Each_Argument_m
+			.SUIT_Directive_Try_Each_Argument_union_choice
+			== SUIT_Directive_Try_Each_Argument_union_SUIT_Command_Sequence_bstr;
 		test_command_sequence(try_each2, try_each2_present, "try_each2");
 
 	}
@@ -345,95 +345,95 @@ void test_manifest(const uint8_t *input, uint32_t len)
 	zassert_equal(ZCBOR_SUCCESS, res, "top-level decoding failed.");
 
 	dependency1 = &outerwrapper1
-		._SUIT_Outer_Wrapper_suit_dependency_resolution
-		._SUIT_Outer_Wrapper_suit_dependency_resolution;
+		.SUIT_Outer_Wrapper_suit_dependency_resolution
+		.SUIT_Outer_Wrapper_suit_dependency_resolution;
 	dependency1_present = outerwrapper1
-		._SUIT_Outer_Wrapper_suit_dependency_resolution_present;
+		.SUIT_Outer_Wrapper_suit_dependency_resolution_present;
 	test_command_sequence(dependency1, dependency1_present, "dependency1");
 
 	fetch1 = &outerwrapper1
-		._SUIT_Outer_Wrapper_suit_payload_fetch
-		._SUIT_Outer_Wrapper_suit_payload_fetch;
+		.SUIT_Outer_Wrapper_suit_payload_fetch
+		.SUIT_Outer_Wrapper_suit_payload_fetch;
 	fetch1_present = outerwrapper1
-		._SUIT_Outer_Wrapper_suit_payload_fetch_present;
+		.SUIT_Outer_Wrapper_suit_payload_fetch_present;
 	test_command_sequence(fetch1, fetch1_present, "fetch1");
 
 	install1 = &outerwrapper1
-		._SUIT_Outer_Wrapper_suit_install
-		._SUIT_Outer_Wrapper_suit_install;
+		.SUIT_Outer_Wrapper_suit_install
+		.SUIT_Outer_Wrapper_suit_install;
 	install1_present = outerwrapper1
-		._SUIT_Outer_Wrapper_suit_install_present;
+		.SUIT_Outer_Wrapper_suit_install_present;
 	test_command_sequence(install1, install1_present, "install1");
 
 	manifest = &outerwrapper1
-		._SUIT_Outer_Wrapper__SUIT_Manifest_Wrapped
-		._SUIT_Manifest_Wrapped_suit_manifest_cbor;
+		.SUIT_Outer_Wrapper_SUIT_Manifest_Wrapped_m
+		.SUIT_Manifest_Wrapped_suit_manifest_cbor;
 
 	common_seq = &manifest
-		->_SUIT_Manifest_suit_common
-		._SUIT_Manifest_suit_common_cbor
-		._SUIT_Common_suit_common_sequence
-		._SUIT_Common_suit_common_sequence;
+		->SUIT_Manifest_suit_common
+		.SUIT_Manifest_suit_common_cbor
+		.SUIT_Common_suit_common_sequence
+		.SUIT_Common_suit_common_sequence;
 	common_seq_present = manifest
-		->_SUIT_Manifest_suit_common_present
+		->SUIT_Manifest_suit_common_present
 		&& manifest
-		->_SUIT_Manifest_suit_common
-		._SUIT_Manifest_suit_common_cbor
-		._SUIT_Common_suit_common_sequence_present;
+		->SUIT_Manifest_suit_common
+		.SUIT_Manifest_suit_common_cbor
+		.SUIT_Common_suit_common_sequence_present;
 	test_command_sequence(common_seq, common_seq_present, "common_seq");
 
 	dependency2 = &manifest
-		->_SUIT_Manifest_suit_dependency_resolution
-		._SUIT_Manifest_suit_dependency_resolution_SUIT_Command_Sequence_bstr;
+		->SUIT_Manifest_suit_dependency_resolution
+		.SUIT_Manifest_suit_dependency_resolution_SUIT_Command_Sequence_bstr;
 	dependency2_present = manifest
-		->_SUIT_Manifest_suit_dependency_resolution_present
+		->SUIT_Manifest_suit_dependency_resolution_present
 		&& manifest
-		->_SUIT_Manifest_suit_dependency_resolution
-		._SUIT_Manifest_suit_dependency_resolution_choice ==
-		_SUIT_Manifest_suit_dependency_resolution_SUIT_Command_Sequence_bstr;
+		->SUIT_Manifest_suit_dependency_resolution
+		.SUIT_Manifest_suit_dependency_resolution_choice ==
+		SUIT_Manifest_suit_dependency_resolution_SUIT_Command_Sequence_bstr;
 	test_command_sequence(dependency2, dependency2_present, "dependency2");
 
 	fetch2 = &manifest
-		->_SUIT_Manifest_suit_payload_fetch
-		._SUIT_Manifest_suit_payload_fetch_SUIT_Command_Sequence_bstr;
+		->SUIT_Manifest_suit_payload_fetch
+		.SUIT_Manifest_suit_payload_fetch_SUIT_Command_Sequence_bstr;
 	fetch2_present = manifest
-		->_SUIT_Manifest_suit_payload_fetch_present
+		->SUIT_Manifest_suit_payload_fetch_present
 		&& manifest
-		->_SUIT_Manifest_suit_payload_fetch
-		._SUIT_Manifest_suit_payload_fetch_choice ==
-		_SUIT_Manifest_suit_payload_fetch_SUIT_Command_Sequence_bstr;
+		->SUIT_Manifest_suit_payload_fetch
+		.SUIT_Manifest_suit_payload_fetch_choice ==
+		SUIT_Manifest_suit_payload_fetch_SUIT_Command_Sequence_bstr;
 	test_command_sequence(fetch2, fetch2_present, "fetch2");
 
 	install2 = &manifest
-		->_SUIT_Manifest_suit_install
-		._SUIT_Manifest_suit_install_SUIT_Command_Sequence_bstr;
+		->SUIT_Manifest_suit_install
+		.SUIT_Manifest_suit_install_SUIT_Command_Sequence_bstr;
 	install2_present = manifest
-		->_SUIT_Manifest_suit_install_present
+		->SUIT_Manifest_suit_install_present
 		&& manifest
-		->_SUIT_Manifest_suit_install
-		._SUIT_Manifest_suit_install_choice ==
-		_SUIT_Manifest_suit_install_SUIT_Command_Sequence_bstr;
+		->SUIT_Manifest_suit_install
+		.SUIT_Manifest_suit_install_choice ==
+		SUIT_Manifest_suit_install_SUIT_Command_Sequence_bstr;
 	test_command_sequence(install2, install2_present, "install2");
 
 	validate = &manifest
-		->_SUIT_Manifest_suit_validate
-		._SUIT_Manifest_suit_validate;
+		->SUIT_Manifest_suit_validate
+		.SUIT_Manifest_suit_validate;
 	validate_present = manifest
-		->_SUIT_Manifest_suit_validate_present;
+		->SUIT_Manifest_suit_validate_present;
 	test_command_sequence(validate, validate_present, "validate");
 
 	load = &manifest
-		->_SUIT_Manifest_suit_load
-		._SUIT_Manifest_suit_load;
+		->SUIT_Manifest_suit_load
+		.SUIT_Manifest_suit_load;
 	load_present = manifest
-		->_SUIT_Manifest_suit_load_present;
+		->SUIT_Manifest_suit_load_present;
 	test_command_sequence(load, load_present, "load");
 
 	run = &manifest
-		->_SUIT_Manifest_suit_run
-		._SUIT_Manifest_suit_run;
+		->SUIT_Manifest_suit_run
+		.SUIT_Manifest_suit_run;
 	run_present = manifest
-		->_SUIT_Manifest_suit_run_present;
+		->SUIT_Manifest_suit_run_present;
 	test_command_sequence(run, run_present, "run");
 
 	res = cbor_encode_SUIT_Outer_Wrapper(output,

--- a/tests/encode/test2_simple/src/main.c
+++ b/tests/encode/test2_simple/src/main.c
@@ -41,7 +41,7 @@ ZTEST(cbor_encode_test2, test_pet)
 		.names = {{.value = "foo", .len = 3}, {.value = "bar", .len = 3}},
 		.names_count = 2,
 		.birthday = {.value = (uint8_t[]){1,2,3,4,5,6,7,8}, .len = 8},
-		.species_choice = _Pet_species_dog
+		.species_choice = Pet_species_dog
 	};
 	uint8_t exp_output[] = {
 		LIST(3),

--- a/tests/encode/test3_corner_cases/src/main.c
+++ b/tests/encode/test3_corner_cases/src/main.c
@@ -122,9 +122,9 @@ ZTEST(cbor_encode_test3, test_tagged_union)
 
 	uint8_t output[5];
 
-	struct TaggedUnion_ input;
-	input.TaggedUnion_choice = _TaggedUnion_bool;
-	input._bool = true;
+	struct TaggedUnion_r input;
+	input.TaggedUnion_choice = TaggedUnion_bool;
+	input.Bool = true;
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_TaggedUnion(output,
 		sizeof(output), &input, &encode_len), "%d\r\n");
@@ -132,7 +132,7 @@ ZTEST(cbor_encode_test3, test_tagged_union)
 	zassert_equal(sizeof(exp_payload_tagged_union1), encode_len, NULL);
 	zassert_mem_equal(exp_payload_tagged_union1, output, sizeof(exp_payload_tagged_union1), NULL);
 
-	input.TaggedUnion_choice = _TaggedUnion_uint;
+	input.TaggedUnion_choice = TaggedUnion_uint;
 	input.uint = 0x10;
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_TaggedUnion(output,
@@ -512,43 +512,43 @@ ZTEST(cbor_encode_test3, test_union)
 		0x03, 0x23, 0x03, 0x23, 0x03, 0x23
 	};
 
-	struct Union_ _union1 = {.Union_choice = _Union__Group};
-	struct Union_ _union2 = {.Union_choice = _Union__MultiGroup, ._MultiGroup.MultiGroup_count = 1};
-	struct Union_ _union3 = {.Union_choice = _Union__uint3};
-	struct Union_ _union4 = {.Union_choice = _Union_hello_tstr};
-	struct Union_ _union5 = {.Union_choice = _Union__MultiGroup, ._MultiGroup.MultiGroup_count = 6};
-	struct Union_ _union6_inv = {.Union_choice = _Union__MultiGroup, ._MultiGroup.MultiGroup_count = 7};
+	struct Union_r union1 = {.Union_choice = Union_Group_m};
+	struct Union_r union2 = {.Union_choice = Union_MultiGroup_m, .MultiGroup_m.MultiGroup_count = 1};
+	struct Union_r union3 = {.Union_choice = Union_uint3_l};
+	struct Union_r union4 = {.Union_choice = Union_hello_tstr};
+	struct Union_r union5 = {.Union_choice = Union_MultiGroup_m, .MultiGroup_m.MultiGroup_count = 6};
+	struct Union_r union6_inv = {.Union_choice = Union_MultiGroup_m, .MultiGroup_m.MultiGroup_count = 7};
 
 	uint8_t output[15];
 	size_t out_len;
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Union(output, sizeof(output),
-				&_union1, &out_len), NULL);
+				&union1, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_union1), out_len, NULL);
 	zassert_mem_equal(exp_payload_union1, output, sizeof(exp_payload_union1), NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Union(output, sizeof(output),
-				&_union2, &out_len), NULL);
+				&union2, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_union2), out_len, NULL);
 	zassert_mem_equal(exp_payload_union2, output, sizeof(exp_payload_union2), NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Union(output, sizeof(output),
-				&_union3, &out_len), NULL);
+				&union3, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_union3), out_len, NULL);
 	zassert_mem_equal(exp_payload_union3, output, sizeof(exp_payload_union3), NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Union(output, sizeof(output),
-				&_union4, &out_len), NULL);
+				&union4, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_union4), out_len, NULL);
 	zassert_mem_equal(exp_payload_union4, output, sizeof(exp_payload_union4), NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Union(output, sizeof(output),
-				&_union5, &out_len), NULL);
+				&union5, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_union5), out_len, NULL);
 	zassert_mem_equal(exp_payload_union5, output, sizeof(exp_payload_union5), NULL);
 
 	zassert_equal(ZCBOR_ERR_ITERATIONS, cbor_encode_Union(output, sizeof(output),
-				&_union6_inv, &out_len), NULL);
+				&union6_inv, &out_len), NULL);
 }
 
 ZTEST(cbor_encode_test3, test_levels)
@@ -572,8 +572,8 @@ ZTEST(cbor_encode_test3, test_levels)
 	uint8_t output[32];
 	size_t out_len;
 
-	struct Level2 level1 = {._Level3_count = 2, ._Level3 = {
-		{._Level4_count = 4}, {._Level4_count = 4}
+	struct Level2 level1 = {.Level3_m_count = 2, .Level3_m = {
+		{.Level4_m_count = 4}, {.Level4_m_count = 4}
 	}};
 	_Static_assert(sizeof(exp_payload_levels1) <= sizeof(output),
 		"Payload is larger than output");
@@ -613,7 +613,7 @@ ZTEST(cbor_encode_test3, test_map)
 	};
 
 	struct Map map1 = {
-		.union_choice = _union_uint7uint,
+		.union_choice = union_uint7uint,
 		.uint7uint = 1,
 		.twotothree_count = 2,
 		.twotothree = {
@@ -623,7 +623,7 @@ ZTEST(cbor_encode_test3, test_map)
 	};
 	struct Map map2 = {
 		.listkey = true,
-		.union_choice = _union_uint7uint,
+		.union_choice = union_uint7uint,
 		.uint7uint = 1,
 		.twotothree_count = 3,
 		.twotothree = {
@@ -633,7 +633,7 @@ ZTEST(cbor_encode_test3, test_map)
 		}
 	};
 	struct Map map3 = {
-		.union_choice = _union_nintuint,
+		.union_choice = union_nintuint,
 		.nintuint = 1,
 		.twotothree_count = 2,
 		.twotothree = {
@@ -740,31 +740,31 @@ ZTEST(cbor_encode_test3, test_nested_map_list_map)
 	const uint8_t exp_payload_nested_mlm4[] = {MAP(2), LIST(0), END LIST(0), END LIST(0), END LIST(0), END END};
 	const uint8_t exp_payload_nested_mlm5[] = {MAP(3), LIST(0), END LIST(0), END LIST(0), END LIST(0), END LIST(0), END LIST(2), MAP(0), END MAP(0), END END END};
 	struct NestedMapListMap maplistmap1 = {
-		._map_count = 1,
-		._map = {{0}}
+		.map_l_count = 1,
+		.map_l = {{0}}
 	};
 	struct NestedMapListMap maplistmap2 = {
-		._map_count = 1,
-		._map = {
+		.map_l_count = 1,
+		.map_l = {
 			{.map_count = 1}
 		}
 	};
 	struct NestedMapListMap maplistmap3 = {
-		._map_count = 1,
-		._map = {
+		.map_l_count = 1,
+		.map_l = {
 			{.map_count = 2}
 		}
 	};
 	struct NestedMapListMap maplistmap4 = {
-		._map_count = 2,
-		._map = {
+		.map_l_count = 2,
+		.map_l = {
 			{.map_count = 0},
 			{.map_count = 0},
 		}
 	};
 	struct NestedMapListMap maplistmap5 = {
-		._map_count = 3,
-		._map = {
+		.map_l_count = 3,
+		.map_l = {
 			{.map_count = 0},
 			{.map_count = 0},
 			{.map_count = 2},
@@ -1072,12 +1072,12 @@ ZTEST(cbor_encode_test3, test_unabstracted)
 	uint8_t exp_payload_unabstracted0[] = {LIST(2), 0x01, 0x03, END};
 	uint8_t exp_payload_unabstracted1[] = {LIST(2), 0x02, 0x04, END};
 	struct Unabstracted result_unabstracted0 = {
-		.unabstractedunion1_choice = _Unabstracted_unabstractedunion1_choice1,
-		.unabstractedunion2_choice = _Unabstracted_unabstractedunion2_uint3,
+		.unabstractedunion1_choice = Unabstracted_unabstractedunion1_choice1,
+		.unabstractedunion2_choice = Unabstracted_unabstractedunion2_uint3,
 	};
 	struct Unabstracted result_unabstracted1 = {
-		.unabstractedunion1_choice = _Unabstracted_unabstractedunion1_choice2,
-		.unabstractedunion2_choice = _Unabstracted_unabstractedunion2_choice4,
+		.unabstractedunion1_choice = Unabstracted_unabstractedunion1_choice2,
+		.unabstractedunion2_choice = Unabstracted_unabstractedunion2_choice4,
 	};
 	uint8_t output[4];
 	size_t out_len;
@@ -1153,14 +1153,14 @@ ZTEST(cbor_encode_test3, test_doublemap)
 		.uintmap = {
 			{
 				.uintmap_key = 1,
-				._MyKeys = {
+				.MyKeys_m = {
 					.uint1int_present = true,
 					.uint1int = {.uint1int = 1},
 				}
 			},
 			{
 				.uintmap_key = 2,
-				._MyKeys = {
+				.MyKeys_m = {
 					.uint2int_present = true,
 					.uint2int = {.uint2int = 2},
 				}
@@ -1351,7 +1351,7 @@ ZTEST(cbor_encode_test3, test_map_length)
 	uint8_t output[60];
 
 	uint8_t mac[] = {1, 2, 3, 4, 5, 6};
-	uint8_t uuid[] = {8, 7, 6, 5, 4, 3, 2, 1, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+	uint8_t uuid_m[] = {8, 7, 6, 5, 4, 3, 2, 1, 8, 7, 6, 5, 4, 3, 2, 1, 0};
 
 	input.result = 1;
 	input.mac_addr.len = 6;
@@ -1364,23 +1364,23 @@ ZTEST(cbor_encode_test3, test_map_length)
 	zassert_mem_equal(exp_map_length_payload1, output, num_encode, NULL);
 
 	input.end_device_array_present = true;
-	input.end_device_array._uuid_count = 0;
+	input.end_device_array.uuid_m_count = 0;
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_MapLength(output,
 		sizeof(output), &input, &num_encode), NULL);
 	zassert_equal(sizeof(exp_map_length_payload2), num_encode, "%d != %d\r\n", sizeof(exp_map_length_payload2), num_encode);
 	zassert_mem_equal(exp_map_length_payload2, output, num_encode, NULL);
 
-	input.end_device_array._uuid_count = 1;
-	input.end_device_array._uuid[0].len = 16;
-	input.end_device_array._uuid[0].value = uuid;
+	input.end_device_array.uuid_m_count = 1;
+	input.end_device_array.uuid_m[0].len = 16;
+	input.end_device_array.uuid_m[0].value = uuid_m;
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_MapLength(output,
 		sizeof(output), &input, &num_encode), NULL);
 	zassert_equal(sizeof(exp_map_length_payload3), num_encode, "%d != %d\r\n", sizeof(exp_map_length_payload3), num_encode);
 	zassert_mem_equal(exp_map_length_payload3, output, num_encode, NULL);
 
-	input.end_device_array._uuid_count = 2;
-	input.end_device_array._uuid[1].len = 16;
-	input.end_device_array._uuid[1].value = uuid;
+	input.end_device_array.uuid_m_count = 2;
+	input.end_device_array.uuid_m[1].len = 16;
+	input.end_device_array.uuid_m[1].value = uuid_m;
 	int err = cbor_encode_MapLength(output,
 		sizeof(output), &input, &num_encode);
 	zassert_equal(ZCBOR_SUCCESS, err, "%d\r\b", err);
@@ -1392,7 +1392,7 @@ ZTEST(cbor_encode_test3, test_map_length)
 		sizeof(output), &input, &num_encode), NULL);
 
 	input.mac_addr.len++;
-	input.end_device_array._uuid[1].len++;
+	input.end_device_array.uuid_m[1].len++;
 	err = cbor_encode_MapLength(output,
 		sizeof(output), &input, &num_encode);
 	zassert_equal(ZCBOR_ERR_WRONG_RANGE, err, "%d\r\b", err);
@@ -1421,13 +1421,13 @@ ZTEST(cbor_encode_test3, test_union_int)
 	size_t num_encode;
 	uint8_t output[60];
 
-	input.union_choice = _union__uint5;
+	input.union_choice = union_uint5_l;
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_UnionInt2(output, sizeof(output),
 			&input, &num_encode), NULL);
 	zassert_equal(sizeof(exp_union_int_payload1), num_encode, NULL);
 	zassert_mem_equal(exp_union_int_payload1, output, num_encode, NULL);
 
-	input.union_choice = _union__uint1000;
+	input.union_choice = union_uint1000_l;
 	input.bstr.len = 16;
 	input.bstr.value = (uint8_t *)&"This is thousand";
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_UnionInt2(output, sizeof(output),
@@ -1435,17 +1435,17 @@ ZTEST(cbor_encode_test3, test_union_int)
 	zassert_equal(sizeof(exp_union_int_payload2), num_encode, NULL);
 	zassert_mem_equal(exp_union_int_payload2, output, num_encode, NULL);
 
-	input.union_choice = _union__nint;
-	input._number.number_choice = _number_int;
-	input._number._int = 1;
+	input.union_choice = union_nint_l;
+	input.number_m.number_choice = number_int;
+	input.number_m.Int = 1;
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_UnionInt2(output, sizeof(output),
 			&input, &num_encode), NULL);
 	zassert_equal(sizeof(exp_union_int_payload3), num_encode, NULL);
 	zassert_mem_equal(exp_union_int_payload3, output, num_encode, NULL);
 
-	input.union_choice = _UnionInt2_union__Structure_One;
-	input._Structure_One.some_array.value = (uint8_t *)&"hi";
-	input._Structure_One.some_array.len = 2;
+	input.union_choice = UnionInt2_union_Structure_One_m;
+	input.Structure_One_m.some_array.value = (uint8_t *)&"hi";
+	input.Structure_One_m.some_array.len = 2;
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_UnionInt2(output, sizeof(output),
 			&input, &num_encode), NULL);
 	zassert_equal(sizeof(exp_union_int_payload4), num_encode, NULL);

--- a/tests/encode/test4_senml/src/main.c
+++ b/tests/encode/test4_senml/src/main.c
@@ -33,23 +33,23 @@
 ZTEST(cbor_encode_test4, test_senml)
 {
 	struct lwm2m_senml input = {
-		._lwm2m_senml__record[0] = {
-			._record_bn = {._record_bn = {.value = "Foo", .len = 3}},
-			._record_bn_present = 1,
-			._record_bt = {._record_bt = 42},
-			._record_bt_present = 1,
-			._record_n = {._record_n = {.value = "Bar", .len = 3}},
-			._record_n_present = 1,
-			._record_t = {._record_t = 7},
-			._record_t_present = 1,
-			._record_union = {
-				._union_vb = true,
-				._record_union_choice = _union_vb,
+		.lwm2m_senml_record_m[0] = {
+			.record_bn = {.record_bn = {.value = "Foo", .len = 3}},
+			.record_bn_present = 1,
+			.record_bt = {.record_bt = 42},
+			.record_bt_present = 1,
+			.record_n = {.record_n = {.value = "Bar", .len = 3}},
+			.record_n_present = 1,
+			.record_t = {.record_t = 7},
+			.record_t_present = 1,
+			.record_union = {
+				.union_vb = true,
+				.record_union_choice = union_vb,
 			},
-			._record_union_present = 1,
-			._record__key_value_pair_count = 0,
+			.record_union_present = 1,
+			.record_key_value_pair_m_count = 0,
 		},
-		._lwm2m_senml__record_count = 1,
+		.lwm2m_senml_record_m_count = 1,
 	};
 	uint8_t payload[100];
 	size_t encode_len;

--- a/tests/fuzz/fuzz_manifest12.c
+++ b/tests/fuzz/fuzz_manifest12.c
@@ -15,118 +15,118 @@ bool fuzz_one_input(const uint8_t *data, size_t size)
         return ret;
     }
 
-    for (int i = 0; i < result._SUIT_Envelope_suit_integrated_dependency_key_count; i++) {
+    for (int i = 0; i < result.SUIT_Envelope_suit_integrated_dependency_key_count; i++) {
         ret = cbor_decode_SUIT_Envelope(
-            result._SUIT_Envelope_suit_integrated_dependency_key[i]._SUIT_Envelope_suit_integrated_dependency_key.value,
-            result._SUIT_Envelope_suit_integrated_dependency_key[i]._SUIT_Envelope_suit_integrated_dependency_key.len,
+            result.SUIT_Envelope_suit_integrated_dependency_key[i].SUIT_Envelope_suit_integrated_dependency_key.value,
+            result.SUIT_Envelope_suit_integrated_dependency_key[i].SUIT_Envelope_suit_integrated_dependency_key.len,
             &result2, &payload_len_out);
         if (!ret) {
             return ret;
         }
     }
 
-    if (result._SUIT_Envelope_suit_manifest_cbor
-              ._SUIT_Manifest__SUIT_Severable_Manifest_Members
-              ._SUIT_Severable_Manifest_Members_suit_dependency_resolution_present) {
+    if (result.SUIT_Envelope_suit_manifest_cbor
+              .SUIT_Manifest_SUIT_Severable_Manifest_Members_m
+              .SUIT_Severable_Manifest_Members_suit_dependency_resolution_present) {
         ret = cbor_decode_SUIT_Command_Sequence(
-            result._SUIT_Envelope_suit_manifest_cbor
-                ._SUIT_Manifest__SUIT_Severable_Manifest_Members
-                ._SUIT_Severable_Manifest_Members_suit_dependency_resolution
-                ._SUIT_Severable_Manifest_Members_suit_dependency_resolution.value,
-            result._SUIT_Envelope_suit_manifest_cbor
-                ._SUIT_Manifest__SUIT_Severable_Manifest_Members
-                ._SUIT_Severable_Manifest_Members_suit_dependency_resolution
-                ._SUIT_Severable_Manifest_Members_suit_dependency_resolution.len,
+            result.SUIT_Envelope_suit_manifest_cbor
+                .SUIT_Manifest_SUIT_Severable_Manifest_Members_m
+                .SUIT_Severable_Manifest_Members_suit_dependency_resolution
+                .SUIT_Severable_Manifest_Members_suit_dependency_resolution.value,
+            result.SUIT_Envelope_suit_manifest_cbor
+                .SUIT_Manifest_SUIT_Severable_Manifest_Members_m
+                .SUIT_Severable_Manifest_Members_suit_dependency_resolution
+                .SUIT_Severable_Manifest_Members_suit_dependency_resolution.len,
             &command_seq, &payload_len_out);
         if (!ret) {
             return ret;
         }
     }
 
-    if (result._SUIT_Envelope_suit_manifest_cbor
-              ._SUIT_Manifest__SUIT_Severable_Manifest_Members
-              ._SUIT_Severable_Manifest_Members_suit_payload_fetch_present) {
+    if (result.SUIT_Envelope_suit_manifest_cbor
+              .SUIT_Manifest_SUIT_Severable_Manifest_Members_m
+              .SUIT_Severable_Manifest_Members_suit_payload_fetch_present) {
         ret = cbor_decode_SUIT_Command_Sequence(
-            result._SUIT_Envelope_suit_manifest_cbor
-                ._SUIT_Manifest__SUIT_Severable_Manifest_Members
-                ._SUIT_Severable_Manifest_Members_suit_payload_fetch
-                ._SUIT_Severable_Manifest_Members_suit_payload_fetch.value,
-            result._SUIT_Envelope_suit_manifest_cbor
-                ._SUIT_Manifest__SUIT_Severable_Manifest_Members
-                ._SUIT_Severable_Manifest_Members_suit_payload_fetch
-                ._SUIT_Severable_Manifest_Members_suit_payload_fetch.len,
+            result.SUIT_Envelope_suit_manifest_cbor
+                .SUIT_Manifest_SUIT_Severable_Manifest_Members_m
+                .SUIT_Severable_Manifest_Members_suit_payload_fetch
+                .SUIT_Severable_Manifest_Members_suit_payload_fetch.value,
+            result.SUIT_Envelope_suit_manifest_cbor
+                .SUIT_Manifest_SUIT_Severable_Manifest_Members_m
+                .SUIT_Severable_Manifest_Members_suit_payload_fetch
+                .SUIT_Severable_Manifest_Members_suit_payload_fetch.len,
             &command_seq, &payload_len_out);
         if (!ret) {
             return ret;
         }
     }
 
-    if (result._SUIT_Envelope_suit_manifest_cbor
-              ._SUIT_Manifest__SUIT_Severable_Manifest_Members
-              ._SUIT_Severable_Manifest_Members_suit_install_present) {
+    if (result.SUIT_Envelope_suit_manifest_cbor
+              .SUIT_Manifest_SUIT_Severable_Manifest_Members_m
+              .SUIT_Severable_Manifest_Members_suit_install_present) {
         ret = cbor_decode_SUIT_Command_Sequence(
-            result._SUIT_Envelope_suit_manifest_cbor
-                ._SUIT_Manifest__SUIT_Severable_Manifest_Members
-                ._SUIT_Severable_Manifest_Members_suit_install
-                ._SUIT_Severable_Manifest_Members_suit_install.value,
-            result._SUIT_Envelope_suit_manifest_cbor
-                ._SUIT_Manifest__SUIT_Severable_Manifest_Members
-                ._SUIT_Severable_Manifest_Members_suit_install
-                ._SUIT_Severable_Manifest_Members_suit_install.len,
+            result.SUIT_Envelope_suit_manifest_cbor
+                .SUIT_Manifest_SUIT_Severable_Manifest_Members_m
+                .SUIT_Severable_Manifest_Members_suit_install
+                .SUIT_Severable_Manifest_Members_suit_install.value,
+            result.SUIT_Envelope_suit_manifest_cbor
+                .SUIT_Manifest_SUIT_Severable_Manifest_Members_m
+                .SUIT_Severable_Manifest_Members_suit_install
+                .SUIT_Severable_Manifest_Members_suit_install.len,
             &command_seq, &payload_len_out);
         if (!ret) {
             return ret;
         }
     }
 
-    if (result._SUIT_Envelope_suit_manifest_cbor
-              ._SUIT_Manifest__SUIT_Unseverable_Members
-              ._SUIT_Unseverable_Members_suit_validate_present) {
+    if (result.SUIT_Envelope_suit_manifest_cbor
+              .SUIT_Manifest_SUIT_Unseverable_Members_m
+              .SUIT_Unseverable_Members_suit_validate_present) {
         ret = cbor_decode_SUIT_Command_Sequence(
-            result._SUIT_Envelope_suit_manifest_cbor
-                ._SUIT_Manifest__SUIT_Unseverable_Members
-                ._SUIT_Unseverable_Members_suit_validate
-                ._SUIT_Unseverable_Members_suit_validate.value,
-            result._SUIT_Envelope_suit_manifest_cbor
-                ._SUIT_Manifest__SUIT_Unseverable_Members
-                ._SUIT_Unseverable_Members_suit_validate
-                ._SUIT_Unseverable_Members_suit_validate.len,
+            result.SUIT_Envelope_suit_manifest_cbor
+                .SUIT_Manifest_SUIT_Unseverable_Members_m
+                .SUIT_Unseverable_Members_suit_validate
+                .SUIT_Unseverable_Members_suit_validate.value,
+            result.SUIT_Envelope_suit_manifest_cbor
+                .SUIT_Manifest_SUIT_Unseverable_Members_m
+                .SUIT_Unseverable_Members_suit_validate
+                .SUIT_Unseverable_Members_suit_validate.len,
             &command_seq, &payload_len_out);
         if (!ret) {
             return ret;
         }
     }
 
-    if (result._SUIT_Envelope_suit_manifest_cbor
-              ._SUIT_Manifest__SUIT_Unseverable_Members
-              ._SUIT_Unseverable_Members_suit_load_present) {
+    if (result.SUIT_Envelope_suit_manifest_cbor
+              .SUIT_Manifest_SUIT_Unseverable_Members_m
+              .SUIT_Unseverable_Members_suit_load_present) {
         ret = cbor_decode_SUIT_Command_Sequence(
-            result._SUIT_Envelope_suit_manifest_cbor
-                ._SUIT_Manifest__SUIT_Unseverable_Members
-                ._SUIT_Unseverable_Members_suit_load
-                ._SUIT_Unseverable_Members_suit_load.value,
-            result._SUIT_Envelope_suit_manifest_cbor
-                ._SUIT_Manifest__SUIT_Unseverable_Members
-                ._SUIT_Unseverable_Members_suit_load
-                ._SUIT_Unseverable_Members_suit_load.len,
+            result.SUIT_Envelope_suit_manifest_cbor
+                .SUIT_Manifest_SUIT_Unseverable_Members_m
+                .SUIT_Unseverable_Members_suit_load
+                .SUIT_Unseverable_Members_suit_load.value,
+            result.SUIT_Envelope_suit_manifest_cbor
+                .SUIT_Manifest_SUIT_Unseverable_Members_m
+                .SUIT_Unseverable_Members_suit_load
+                .SUIT_Unseverable_Members_suit_load.len,
             &command_seq, &payload_len_out);
         if (!ret) {
             return ret;
         }
     }
 
-    if (result._SUIT_Envelope_suit_manifest_cbor
-              ._SUIT_Manifest__SUIT_Unseverable_Members
-              ._SUIT_Unseverable_Members_suit_run_present) {
+    if (result.SUIT_Envelope_suit_manifest_cbor
+              .SUIT_Manifest_SUIT_Unseverable_Members_m
+              .SUIT_Unseverable_Members_suit_run_present) {
         ret = cbor_decode_SUIT_Command_Sequence(
-            result._SUIT_Envelope_suit_manifest_cbor
-                ._SUIT_Manifest__SUIT_Unseverable_Members
-                ._SUIT_Unseverable_Members_suit_run
-                ._SUIT_Unseverable_Members_suit_run.value,
-            result._SUIT_Envelope_suit_manifest_cbor
-                ._SUIT_Manifest__SUIT_Unseverable_Members
-                ._SUIT_Unseverable_Members_suit_run
-                ._SUIT_Unseverable_Members_suit_run.len,
+            result.SUIT_Envelope_suit_manifest_cbor
+                .SUIT_Manifest_SUIT_Unseverable_Members_m
+                .SUIT_Unseverable_Members_suit_run
+                .SUIT_Unseverable_Members_suit_run.value,
+            result.SUIT_Envelope_suit_manifest_cbor
+                .SUIT_Manifest_SUIT_Unseverable_Members_m
+                .SUIT_Unseverable_Members_suit_run
+                .SUIT_Unseverable_Members_suit_run.len,
             &command_seq, &payload_len_out);
         if (!ret) {
             return ret;

--- a/tests/scripts/test_zcbor.py
+++ b/tests/scripts/test_zcbor.py
@@ -77,24 +77,24 @@ class TestEx0Manifest12(TestManifest):
     def test_signature(self):
         self.assertEqual(
             1,
-            self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].COSE_Sign1_Tagged.protected.uintint[0].uintint_key)
+            self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].COSE_Sign1_Tagged_m.protected.uintint[0].uintint_key)
         self.assertEqual(
             -7,
-            self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].COSE_Sign1_Tagged.protected.uintint[0].uintint)
+            self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].COSE_Sign1_Tagged_m.protected.uintint[0].uintint)
         self.assertEqual(
             bytes.fromhex("a19fd1f23b17beed321cece7423dfb48c457b8f1f6ac83577a3c10c6773f6f3a7902376b59540920b6c5f57bac5fc8543d8f5d3d974faa2e6d03daa534b443a7"),
-            self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].COSE_Sign1_Tagged.signature)
+            self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].COSE_Sign1_Tagged_m.signature)
 
     def test_validate_run(self):
         self.assertEqual(
-            "suit_condition_image_match",
-            self.decoded.suit_manifest.SUIT_Unseverable_Members.suit_validate[0].suit_validate.union[0].SUIT_Condition.union_choice)
+            "suit_condition_image_match_m_l",
+            self.decoded.suit_manifest.SUIT_Unseverable_Members.suit_validate[0].suit_validate.union[0].SUIT_Condition_m.union_choice)
         self.assertEqual(
-            "suit_directive_run",
-            self.decoded.suit_manifest.SUIT_Unseverable_Members.suit_run[0].suit_run.union[0].SUIT_Directive.union_choice)
+            "suit_directive_run_m_l",
+            self.decoded.suit_manifest.SUIT_Unseverable_Members.suit_run[0].suit_run.union[0].SUIT_Directive_m.union_choice)
 
     def test_image_size(self):
-        self.assertEqual(34768, self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands.suit_directive_override_parameters.map[3].suit_parameter_image_size)
+        self.assertEqual(34768, self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands_m.suit_directive_override_parameters_m_l.map[3].suit_parameter_image_size)
 
 
 class TestEx0InvManifest12(TestManifest):
@@ -119,7 +119,7 @@ class TestEx1Manifest12(TestManifest):
     def test_uri(self):
         self.assertEqual(
             "http://example.com/file.bin",
-            self.decoded.suit_manifest.SUIT_Severable_Manifest_Members.suit_install[0].suit_install.union[0].SUIT_Directive.suit_directive_set_parameters.map[0].suit_parameter_uri)
+            self.decoded.suit_manifest.SUIT_Severable_Manifest_Members.suit_install[0].suit_install.union[0].SUIT_Directive_m.suit_directive_set_parameters_m_l.map[0].suit_parameter_uri)
 
 
 class TestEx2Manifest12(TestManifest):
@@ -130,7 +130,7 @@ class TestEx2Manifest12(TestManifest):
     def test_severed_uri(self):
         self.assertEqual(
             "http://example.com/very/long/path/to/file/file.bin",
-            self.decoded.SUIT_Severable_Manifest_Members.suit_install[0].suit_install.union[0].SUIT_Directive.suit_directive_set_parameters.map[0].suit_parameter_uri)
+            self.decoded.SUIT_Severable_Manifest_Members.suit_install[0].suit_install.union[0].SUIT_Directive_m.suit_directive_set_parameters_m_l.map[0].suit_parameter_uri)
 
     def test_severed_text(self):
         self.assertIn(
@@ -155,10 +155,10 @@ class TestEx3Manifest12(TestManifest):
     def test_A_B_offset(self):
         self.assertEqual(
             33792,
-            self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[1].SUIT_Common_Commands.suit_directive_try_each.SUIT_Directive_Try_Each_Argument.SUIT_Command_Sequence_bstr[0].union[0].SUIT_Directive.suit_directive_override_parameters.map[0].suit_parameter_component_offset)
+            self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[1].SUIT_Common_Commands_m.suit_directive_try_each_m_l.SUIT_Directive_Try_Each_Argument_m.SUIT_Command_Sequence_bstr[0].union[0].SUIT_Directive_m.suit_directive_override_parameters_m_l.map[0].suit_parameter_component_offset)
         self.assertEqual(
             541696,
-            self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[1].SUIT_Common_Commands.suit_directive_try_each.SUIT_Directive_Try_Each_Argument.SUIT_Command_Sequence_bstr[1].union[0].SUIT_Directive.suit_directive_override_parameters.map[0].suit_parameter_component_offset)
+            self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[1].SUIT_Common_Commands_m.suit_directive_try_each_m_l.SUIT_Directive_Try_Each_Argument_m.SUIT_Command_Sequence_bstr[1].union[0].SUIT_Directive_m.suit_directive_override_parameters_m_l.map[0].suit_parameter_component_offset)
 
 
 class TestEx4Manifest12(TestManifest):
@@ -169,10 +169,10 @@ class TestEx4Manifest12(TestManifest):
     def test_load_decompress(self):
         self.assertEqual(
             0,
-            self.decoded.suit_manifest.SUIT_Unseverable_Members.suit_load[0].suit_load.union[1].SUIT_Directive.suit_directive_set_parameters.map[3].suit_parameter_source_component)
+            self.decoded.suit_manifest.SUIT_Unseverable_Members.suit_load[0].suit_load.union[1].SUIT_Directive_m.suit_directive_set_parameters_m_l.map[3].suit_parameter_source_component)
         self.assertEqual(
-            "SUIT_Compression_Algorithm_zlib",
-            self.decoded.suit_manifest.SUIT_Unseverable_Members.suit_load[0].suit_load.union[1].SUIT_Directive.suit_directive_set_parameters.map[2].suit_parameter_compression_info.suit_compression_algorithm)
+            "SUIT_Compression_Algorithm_zlib_m",
+            self.decoded.suit_manifest.SUIT_Unseverable_Members.suit_load[0].suit_load.union[1].SUIT_Directive_m.suit_directive_set_parameters_m_l.map[2].suit_parameter_compression_info.suit_compression_algorithm)
 
 
 class TestEx5Manifest12(TestManifest):
@@ -182,11 +182,11 @@ class TestEx5Manifest12(TestManifest):
 
     def test_two_image_match(self):
         self.assertEqual(
-            "suit_condition_image_match",
-            self.decoded.suit_manifest.SUIT_Severable_Manifest_Members.suit_install[0].suit_install.union[3].SUIT_Condition.union_choice)
+            "suit_condition_image_match_m_l",
+            self.decoded.suit_manifest.SUIT_Severable_Manifest_Members.suit_install[0].suit_install.union[3].SUIT_Condition_m.union_choice)
         self.assertEqual(
-            "suit_condition_image_match",
-            self.decoded.suit_manifest.SUIT_Severable_Manifest_Members.suit_install[0].suit_install.union[7].SUIT_Condition.union_choice)
+            "suit_condition_image_match_m_l",
+            self.decoded.suit_manifest.SUIT_Severable_Manifest_Members.suit_install[0].suit_install.union[7].SUIT_Condition_m.union_choice)
 
 
 def dumps(obj):
@@ -203,11 +203,11 @@ class TestEx0Manifest14(TestManifest):
         self.key = VerifyingKey.from_pem(p_manifest14_pub.read_text())
 
     def do_test_authentication(self):
-        self.assertEqual("COSE_Sign1_Tagged", self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].union_choice)
-        self.assertEqual(-7, self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].COSE_Sign1_Tagged.Headers.protected.header_map_bstr.Generic_Headers.uint1union[0].int)
+        self.assertEqual("COSE_Sign1_Tagged_m", self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].union_choice)
+        self.assertEqual(-7, self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].COSE_Sign1_Tagged_m.Headers_m.protected.header_map_bstr.Generic_Headers.uint1union[0].int)
 
-        manifest_signature = self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].COSE_Sign1_Tagged.signature
-        signature_header = self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].COSE_Sign1_Tagged.Headers.protected.header_map_bstr_bstr
+        manifest_signature = self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].COSE_Sign1_Tagged_m.signature
+        signature_header = self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].COSE_Sign1_Tagged_m.Headers_m.protected.header_map_bstr_bstr
         manifest_suit_digest = self.decoded.suit_authentication_wrapper.SUIT_Digest_bstr_bstr
 
         sig_struct = dumps(["Signature1", signature_header, b'', manifest_suit_digest])
@@ -246,24 +246,24 @@ class TestEx1Manifest14(TestManifest):
         self.manifest_digest = bytes.fromhex("60c61d6eb7a1aaeddc49ce8157a55cff0821537eeee77a4ded44155b03045132")
 
     def test_structure(self):
-        self.assertEqual("COSE_Sign1_Tagged", self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].union_choice)
-        self.assertEqual(-7, self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].COSE_Sign1_Tagged.Headers.protected.header_map_bstr.Generic_Headers.uint1union[0].int)
+        self.assertEqual("COSE_Sign1_Tagged_m", self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].union_choice)
+        self.assertEqual(-7, self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].COSE_Sign1_Tagged_m.Headers_m.protected.header_map_bstr.Generic_Headers.uint1union[0].int)
         self.assertEqual(self.manifest_digest, self.decoded.suit_authentication_wrapper.SUIT_Digest_bstr.suit_digest_bytes)
         self.assertEqual(1, self.decoded.suit_manifest.suit_manifest_sequence_number)
-        self.assertEqual(bytes.fromhex("fa6b4a53d5ad5fdfbe9de663e4d41ffe"), self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands.suit_directive_override_parameters.map[0].suit_parameter_vendor_identifier.RFC4122_UUID)
-        self.assertEqual(bytes.fromhex("1492af1425695e48bf429b2d51f2ab45"), self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands.suit_directive_override_parameters.map[1].suit_parameter_class_identifier)
-        self.assertEqual(bytes.fromhex("00112233445566778899aabbccddeeff0123456789abcdeffedcba9876543210"), self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands.suit_directive_override_parameters.map[2].suit_parameter_image_digest.suit_digest_bytes)
-        self.assertEqual('cose_alg_sha_256', self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands.suit_directive_override_parameters.map[2].suit_parameter_image_digest.suit_digest_algorithm_id.union_choice)
-        self.assertEqual(34768, self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands.suit_directive_override_parameters.map[3].suit_parameter_image_size)
-        self.assertEqual(4, len(self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands.suit_directive_override_parameters.map))
-        self.assertEqual(15, self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[1].SUIT_Condition.suit_condition_vendor_identifier.SUIT_Rep_Policy)
-        self.assertEqual(15, self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[2].SUIT_Condition.suit_condition_class_identifier.SUIT_Rep_Policy)
+        self.assertEqual(bytes.fromhex("fa6b4a53d5ad5fdfbe9de663e4d41ffe"), self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands_m.suit_directive_override_parameters_m_l.map[0].suit_parameter_vendor_identifier.RFC4122_UUID_m)
+        self.assertEqual(bytes.fromhex("1492af1425695e48bf429b2d51f2ab45"), self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands_m.suit_directive_override_parameters_m_l.map[1].suit_parameter_class_identifier)
+        self.assertEqual(bytes.fromhex("00112233445566778899aabbccddeeff0123456789abcdeffedcba9876543210"), self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands_m.suit_directive_override_parameters_m_l.map[2].suit_parameter_image_digest.suit_digest_bytes)
+        self.assertEqual('cose_alg_sha_256_m', self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands_m.suit_directive_override_parameters_m_l.map[2].suit_parameter_image_digest.suit_digest_algorithm_id.union_choice)
+        self.assertEqual(34768, self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands_m.suit_directive_override_parameters_m_l.map[3].suit_parameter_image_size)
+        self.assertEqual(4, len(self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands_m.suit_directive_override_parameters_m_l.map))
+        self.assertEqual(15, self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[1].SUIT_Condition_m.suit_condition_vendor_identifier_m_l.SUIT_Rep_Policy_m)
+        self.assertEqual(15, self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[2].SUIT_Condition_m.suit_condition_class_identifier_m_l.SUIT_Rep_Policy_m)
         self.assertEqual(3, len(self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union))
         self.assertEqual(2, len(self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0]))
-        self.assertEqual(2, len(self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands))
-        self.assertEqual(1, len(self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands.suit_directive_override_parameters))
-        self.assertEqual(4, len(self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands.suit_directive_override_parameters.map))
-        self.assertEqual(2, len(self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands.suit_directive_override_parameters.map[0]))
+        self.assertEqual(2, len(self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands_m))
+        self.assertEqual(1, len(self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands_m.suit_directive_override_parameters_m_l))
+        self.assertEqual(4, len(self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands_m.suit_directive_override_parameters_m_l.map))
+        self.assertEqual(2, len(self.decoded.suit_manifest.suit_common.suit_common_sequence[0].suit_common_sequence.union[0].SUIT_Common_Commands_m.suit_directive_override_parameters_m_l.map[0]))
 
     def test_cbor_pen(self):
         data = bytes.fromhex(p_test_vectors14[1].read_text().replace("\n", ""))
@@ -353,7 +353,7 @@ class TestEx2Manifest14(TestManifest):
     def test_text(self):
         self.assertEqual(
             bytes.fromhex('2bfc4d0cc6680be7dd9f5ca30aa2bb5d1998145de33d54101b80e2ca49faf918'),
-            self.decoded.suit_manifest.SUIT_Severable_Members_Choice.suit_text[0].SUIT_Digest.suit_digest_bytes)
+            self.decoded.suit_manifest.SUIT_Severable_Members_Choice.suit_text[0].SUIT_Digest_m.suit_digest_bytes)
         self.assertEqual(
             bytes.fromhex('2bfc4d0cc6680be7dd9f5ca30aa2bb5d1998145de33d54101b80e2ca49faf918'),
             sha256(dumps(self.decoded.SUIT_Severable_Manifest_Members.suit_text[0].suit_text_bstr)).digest())
@@ -381,9 +381,9 @@ class TestEx3Manifest14(TestManifest):
         self.slots = (33792, 541696)
 
     def test_try_each(self):
-        self.assertEqual(2, len(self.decoded.suit_manifest.SUIT_Severable_Members_Choice.suit_install[0].SUIT_Command_Sequence_bstr.union[0].SUIT_Directive.suit_directive_try_each.SUIT_Directive_Try_Each_Argument.SUIT_Command_Sequence_bstr))
-        self.assertEqual(self.slots[0], self.decoded.suit_manifest.SUIT_Severable_Members_Choice.suit_install[0].SUIT_Command_Sequence_bstr.union[0].SUIT_Directive.suit_directive_try_each.SUIT_Directive_Try_Each_Argument.SUIT_Command_Sequence_bstr[0].union[0].SUIT_Directive.suit_directive_override_parameters.map[0].suit_parameter_component_slot)
-        self.assertEqual(self.slots[1], self.decoded.suit_manifest.SUIT_Severable_Members_Choice.suit_install[0].SUIT_Command_Sequence_bstr.union[0].SUIT_Directive.suit_directive_try_each.SUIT_Directive_Try_Each_Argument.SUIT_Command_Sequence_bstr[1].union[0].SUIT_Directive.suit_directive_override_parameters.map[0].suit_parameter_component_slot)
+        self.assertEqual(2, len(self.decoded.suit_manifest.SUIT_Severable_Members_Choice.suit_install[0].SUIT_Command_Sequence_bstr.union[0].SUIT_Directive_m.suit_directive_try_each_m_l.SUIT_Directive_Try_Each_Argument_m.SUIT_Command_Sequence_bstr))
+        self.assertEqual(self.slots[0], self.decoded.suit_manifest.SUIT_Severable_Members_Choice.suit_install[0].SUIT_Command_Sequence_bstr.union[0].SUIT_Directive_m.suit_directive_try_each_m_l.SUIT_Directive_Try_Each_Argument_m.SUIT_Command_Sequence_bstr[0].union[0].SUIT_Directive_m.suit_directive_override_parameters_m_l.map[0].suit_parameter_component_slot)
+        self.assertEqual(self.slots[1], self.decoded.suit_manifest.SUIT_Severable_Members_Choice.suit_install[0].SUIT_Command_Sequence_bstr.union[0].SUIT_Directive_m.suit_directive_try_each_m_l.SUIT_Directive_Try_Each_Argument_m.SUIT_Command_Sequence_bstr[1].union[0].SUIT_Directive_m.suit_directive_override_parameters_m_l.map[0].suit_parameter_component_slot)
 
 
 class TestEx4Manifest14(TestManifest):
@@ -405,7 +405,7 @@ class TestEx5Manifest14(TestManifest):
 
     def test_validate(self):
         self.assertEqual(4, len(self.decoded.suit_manifest.SUIT_Unseverable_Members.suit_validate[0].suit_validate.union))
-        self.assertEqual(15, self.decoded.suit_manifest.SUIT_Unseverable_Members.suit_validate[0].suit_validate.union[1].SUIT_Condition.suit_condition_image_match.SUIT_Rep_Policy)
+        self.assertEqual(15, self.decoded.suit_manifest.SUIT_Unseverable_Members.suit_validate[0].suit_validate.union[1].SUIT_Condition_m.suit_condition_image_match_m_l.SUIT_Rep_Policy_m)
 
 
 class TestEx5InvManifest14(TestManifest):
@@ -488,24 +488,24 @@ class TestEx1Manifest20(TestEx1Manifest16):
         self.manifest_digest = bytes.fromhex("ef14b7091e8adae8aa3bb6fca1d64fb37e19dcf8b35714cfdddc5968c80ff50e")
 
     def test_structure(self):
-        self.assertEqual("COSE_Sign1_Tagged", self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].union_choice)
-        self.assertEqual(-7, self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].COSE_Sign1_Tagged.Headers.protected.header_map_bstr.Generic_Headers.uint1union[0].int)
+        self.assertEqual("COSE_Sign1_Tagged_m", self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].union_choice)
+        self.assertEqual(-7, self.decoded.suit_authentication_wrapper.SUIT_Authentication_Block_bstr[0].COSE_Sign1_Tagged_m.Headers_m.protected.header_map_bstr.Generic_Headers.uint1union[0].int)
         self.assertEqual(self.manifest_digest, self.decoded.suit_authentication_wrapper.SUIT_Digest_bstr.suit_digest_bytes)
         self.assertEqual(1, self.decoded.suit_manifest.suit_manifest_sequence_number)
-        self.assertEqual(bytes.fromhex("fa6b4a53d5ad5fdfbe9de663e4d41ffe"), self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands.suit_directive_override_parameters.map[0].suit_parameter_vendor_identifier.RFC4122_UUID)
-        self.assertEqual(bytes.fromhex("1492af1425695e48bf429b2d51f2ab45"), self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands.suit_directive_override_parameters.map[1].suit_parameter_class_identifier)
-        self.assertEqual(bytes.fromhex("00112233445566778899aabbccddeeff0123456789abcdeffedcba9876543210"), self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands.suit_directive_override_parameters.map[2].suit_parameter_image_digest.suit_digest_bytes)
-        self.assertEqual('cose_alg_sha_256', self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands.suit_directive_override_parameters.map[2].suit_parameter_image_digest.suit_digest_algorithm_id.union_choice)
-        self.assertEqual(34768, self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands.suit_directive_override_parameters.map[3].suit_parameter_image_size)
-        self.assertEqual(4, len(self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands.suit_directive_override_parameters.map))
-        self.assertEqual(15, self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[1].SUIT_Condition.suit_condition_vendor_identifier.SUIT_Rep_Policy)
-        self.assertEqual(15, self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[2].SUIT_Condition.suit_condition_class_identifier.SUIT_Rep_Policy)
+        self.assertEqual(bytes.fromhex("fa6b4a53d5ad5fdfbe9de663e4d41ffe"), self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands_m.suit_directive_override_parameters_m_l.map[0].suit_parameter_vendor_identifier.RFC4122_UUID_m)
+        self.assertEqual(bytes.fromhex("1492af1425695e48bf429b2d51f2ab45"), self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands_m.suit_directive_override_parameters_m_l.map[1].suit_parameter_class_identifier)
+        self.assertEqual(bytes.fromhex("00112233445566778899aabbccddeeff0123456789abcdeffedcba9876543210"), self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands_m.suit_directive_override_parameters_m_l.map[2].suit_parameter_image_digest.suit_digest_bytes)
+        self.assertEqual('cose_alg_sha_256_m', self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands_m.suit_directive_override_parameters_m_l.map[2].suit_parameter_image_digest.suit_digest_algorithm_id.union_choice)
+        self.assertEqual(34768, self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands_m.suit_directive_override_parameters_m_l.map[3].suit_parameter_image_size)
+        self.assertEqual(4, len(self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands_m.suit_directive_override_parameters_m_l.map))
+        self.assertEqual(15, self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[1].SUIT_Condition_m.suit_condition_vendor_identifier_m_l.SUIT_Rep_Policy_m)
+        self.assertEqual(15, self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[2].SUIT_Condition_m.suit_condition_class_identifier_m_l.SUIT_Rep_Policy_m)
         self.assertEqual(3, len(self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union))
         self.assertEqual(2, len(self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0]))
-        self.assertEqual(2, len(self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands))
-        self.assertEqual(1, len(self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands.suit_directive_override_parameters))
-        self.assertEqual(4, len(self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands.suit_directive_override_parameters.map))
-        self.assertEqual(2, len(self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands.suit_directive_override_parameters.map[0]))
+        self.assertEqual(2, len(self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands_m))
+        self.assertEqual(1, len(self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands_m.suit_directive_override_parameters_m_l))
+        self.assertEqual(4, len(self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands_m.suit_directive_override_parameters_m_l.map))
+        self.assertEqual(2, len(self.decoded.suit_manifest.suit_common.suit_shared_sequence[0].suit_shared_sequence.union[0].SUIT_Shared_Commands_m.suit_directive_override_parameters_m_l.map[0]))
 
 
 class TestEx1InvManifest20(TestEx1InvManifest16):


### PR DESCRIPTION
in generated code

See changes in zcbor.py. The rest of the changes are renaming tests.

Fixes #294 and #295