### PR TITLE
Change all uint_fast32_t usage to use size_t instead

### DIFF
--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -107,11 +107,11 @@ union {
 	                             processed. */
 };
 	uint8_t const *payload_bak; /**< Temporary backup of payload. */
-	uint_fast32_t elem_count; /**< The current element is part of a LIST or a MAP,
-	                               and this keeps count of how many elements are
-	                               expected. This will be checked before processing
-	                               and decremented if the element is correctly
-	                               processed. */
+	size_t elem_count; /**< The current element is part of a LIST or a MAP,
+	                        and this keeps count of how many elements are
+	                        expected. This will be checked before processing
+	                        and decremented if the element is correctly
+	                        processed. */
 	uint8_t const *payload_end; /**< The end of the payload. This will be
 	                                 checked against payload before
 	                                 processing each element. */
@@ -127,8 +127,8 @@ union {
 
 struct zcbor_state_constant {
 	zcbor_state_t *backup_list;
-	uint_fast32_t current_backup;
-	uint_fast32_t num_backups;
+	size_t current_backup;
+	size_t num_backups;
 	int error;
 #ifdef ZCBOR_STOP_ON_ERROR
 	bool stop_on_error;
@@ -236,7 +236,7 @@ do { \
 #ifdef UINT_FAST32_MAX
 #define ZCBOR_MAX_ELEM_COUNT UINT_FAST32_MAX
 #else
-#define ZCBOR_MAX_ELEM_COUNT ((uint_fast32_t)(-1L))
+#define ZCBOR_MAX_ELEM_COUNT ((size_t)(-1L))
 #endif
 
 /** Initial value for elem_count for when it just needs to be large. */
@@ -244,13 +244,13 @@ do { \
 
 
 /** Take a backup of the current state. Overwrite the current elem_count. */
-bool zcbor_new_backup(zcbor_state_t *state, uint_fast32_t new_elem_count);
+bool zcbor_new_backup(zcbor_state_t *state, size_t new_elem_count);
 
 /** Consult the most recent backup. In doing so, check whether elem_count is
  *  less than or equal to max_elem_count.
  *  Also, take action based on the flags (See ZCBOR_FLAG_*).
  */
-bool zcbor_process_backup(zcbor_state_t *state, uint32_t flags, uint_fast32_t max_elem_count);
+bool zcbor_process_backup(zcbor_state_t *state, uint32_t flags, size_t max_elem_count);
 
 /** Convenience function for starting encoding/decoding of a union.
  *
@@ -281,8 +281,8 @@ bool zcbor_union_end_code(zcbor_state_t *state);
  *  payload, payload_len, and elem_count are used to initialize the first state.
  *  in the array, which is the state that can be passed to cbor functions.
  */
-void zcbor_new_state(zcbor_state_t *state_array, uint_fast32_t n_states,
-		const uint8_t *payload, size_t payload_len, uint_fast32_t elem_count);
+void zcbor_new_state(zcbor_state_t *state_array, size_t n_states,
+		const uint8_t *payload, size_t payload_len, size_t elem_count);
 
 #ifdef ZCBOR_STOP_ON_ERROR
 /** Check stored error and fail if present, but only if stop_on_error is true. */
@@ -366,7 +366,7 @@ void zcbor_update_state(zcbor_state_t *state,
  *                  found, or if any fragment value is NULL.
  */
 bool zcbor_validate_string_fragments(struct zcbor_string_fragment *fragments,
-		uint_fast32_t num_fragments);
+		size_t num_fragments);
 
 /** Assemble the fragments into a single string.
  *
@@ -385,7 +385,7 @@ bool zcbor_validate_string_fragments(struct zcbor_string_fragment *fragments,
  *                  The buffer might still be written to.
  */
 bool zcbor_splice_string_fragments(struct zcbor_string_fragment *fragments,
-		uint_fast32_t num_fragments, uint8_t *result, size_t *result_len);
+		size_t num_fragments, uint8_t *result, size_t *result_len);
 
 /** Compare two struct zcbor_string instances.
  *

--- a/include/zcbor_decode.h
+++ b/include/zcbor_decode.h
@@ -310,9 +310,9 @@ bool zcbor_list_map_end_force_decode(zcbor_state_t *state);
  * @retval false  If @p decoder failed before having decoded @p min_decode
  *                values.
  */
-bool zcbor_multi_decode(uint_fast32_t min_decode, uint_fast32_t max_decode, uint_fast32_t *num_decode,
+bool zcbor_multi_decode(size_t min_decode, size_t max_decode, size_t *num_decode,
 		zcbor_decoder_t decoder, zcbor_state_t *state, void *result,
-		uint_fast32_t result_len);
+		size_t result_len);
 
 /** Attempt to decode a value that might not be present in the data.
  *
@@ -325,14 +325,14 @@ bool zcbor_multi_decode(uint_fast32_t min_decode, uint_fast32_t max_decode, uint
  *
  * @return Should always return true.
  */
-bool zcbor_present_decode(uint_fast32_t *present,
+bool zcbor_present_decode(bool *present,
 		zcbor_decoder_t decoder,
 		zcbor_state_t *state,
 		void *result);
 
 /** See @ref zcbor_new_state() */
-void zcbor_new_decode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
-		const uint8_t *payload, size_t payload_len, uint_fast32_t elem_count);
+void zcbor_new_decode_state(zcbor_state_t *state_array, size_t n_states,
+		const uint8_t *payload, size_t payload_len, size_t elem_count);
 
 /** Convenience macro for declaring and initializing a state with backups.
  *

--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -173,8 +173,8 @@ bool zcbor_bstr_end_encode(zcbor_state_t *state, struct zcbor_string *result);
  *                        call.
  *                        Only used when ZCBOR_CANONICAL is defined.
  */
-bool zcbor_list_start_encode(zcbor_state_t *state, uint_fast32_t max_num);
-bool zcbor_map_start_encode(zcbor_state_t *state, uint_fast32_t max_num);
+bool zcbor_list_start_encode(zcbor_state_t *state, size_t max_num);
+bool zcbor_map_start_encode(zcbor_state_t *state, size_t max_num);
 
 /** Encode the end of a list/map. Do some checks and deallocate backup.
  *
@@ -193,8 +193,8 @@ bool zcbor_map_start_encode(zcbor_state_t *state, uint_fast32_t max_num);
  *                        @ref zcbor_list_start_encode call.
  *                        Only used when ZCBOR_CANONICAL is defined.
  */
-bool zcbor_list_end_encode(zcbor_state_t *state, uint_fast32_t max_num);
-bool zcbor_map_end_encode(zcbor_state_t *state, uint_fast32_t max_num);
+bool zcbor_list_end_encode(zcbor_state_t *state, size_t max_num);
+bool zcbor_map_end_encode(zcbor_state_t *state, size_t max_num);
 bool zcbor_list_map_end_force_encode(zcbor_state_t *state);
 
 /** Encode 0 or more elements with the same type and constraints.
@@ -245,32 +245,32 @@ bool zcbor_list_map_end_force_encode(zcbor_state_t *state);
  * @retval false  If @p encoder failed before having encoded @p min_encode
  *                values.
  */
-bool zcbor_multi_encode(uint_fast32_t num_encode,
+bool zcbor_multi_encode(size_t num_encode,
 		zcbor_encoder_t encoder,
 		zcbor_state_t *state,
 		const void *input,
-		uint_fast32_t result_len);
+		size_t result_len);
 
 /** Works like @ref zcbor_multi_encode
  *
  * But first checks that @p num_encode is between @p min_encode and @p max_encode.
  */
-bool zcbor_multi_encode_minmax(uint_fast32_t min_encode, uint_fast32_t max_encode, const uint_fast32_t *num_encode,
+bool zcbor_multi_encode_minmax(size_t min_encode, size_t max_encode, const size_t *num_encode,
 		zcbor_encoder_t encoder, zcbor_state_t *state, const void *input,
-		uint_fast32_t input_len);
+		size_t input_len);
 
 /** Runs @p encoder on @p state and @p input if @p present is true.
  *
  * Calls @ref zcbor_multi_encode under the hood.
  */
-bool zcbor_present_encode(const uint_fast32_t *present,
+bool zcbor_present_encode(const bool *present,
 		zcbor_encoder_t encoder,
 		zcbor_state_t *state,
 		const void *input);
 
 /** See @ref zcbor_new_state() */
-void zcbor_new_encode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
-		uint8_t *payload, size_t payload_len, uint_fast32_t elem_count);
+void zcbor_new_encode_state(zcbor_state_t *state_array, size_t n_states,
+		uint8_t *payload, size_t payload_len, size_t elem_count);
 
 /** Convenience macro for declaring and initializing a state with backups.
  *

--- a/samples/pet/include/pet_types.h
+++ b/samples/pet/include/pet_types.h
@@ -31,7 +31,7 @@ extern "C" {
 
 struct Pet {
 	struct zcbor_string names[3];
-	uint_fast32_t names_count;
+	size_t names_count;
 	struct zcbor_string birthday;
 	enum {
 		_Pet_species_cat = 1,

--- a/src/zcbor_common.c
+++ b/src/zcbor_common.c
@@ -16,7 +16,7 @@ _Static_assert((sizeof(size_t) == sizeof(void *)),
 _Static_assert((sizeof(zcbor_state_t) >= sizeof(struct zcbor_state_constant)),
 	"This code needs zcbor_state_t to be at least as large as zcbor_backups_t.");
 
-bool zcbor_new_backup(zcbor_state_t *state, uint_fast32_t new_elem_count)
+bool zcbor_new_backup(zcbor_state_t *state, size_t new_elem_count)
 {
 	ZCBOR_CHECK_ERROR();
 
@@ -31,7 +31,7 @@ bool zcbor_new_backup(zcbor_state_t *state, uint_fast32_t new_elem_count)
 
 	/* use the backup at current_backup - 1, since otherwise, the 0th
 	 * backup would be unused. */
-	uint_fast32_t i = (state->constant_state->current_backup) - 1;
+	size_t i = (state->constant_state->current_backup) - 1;
 
 	memcpy(&state->constant_state->backup_list[i], state,
 		sizeof(zcbor_state_t));
@@ -43,10 +43,10 @@ bool zcbor_new_backup(zcbor_state_t *state, uint_fast32_t new_elem_count)
 
 
 bool zcbor_process_backup(zcbor_state_t *state, uint32_t flags,
-		uint_fast32_t max_elem_count)
+		size_t max_elem_count)
 {
 	const uint8_t *payload = state->payload;
-	const uint_fast32_t elem_count = state->elem_count;
+	const size_t elem_count = state->elem_count;
 
 	ZCBOR_CHECK_ERROR();
 
@@ -58,7 +58,7 @@ bool zcbor_process_backup(zcbor_state_t *state, uint32_t flags,
 	if (flags & ZCBOR_FLAG_RESTORE) {
 		/* use the backup at current_backup - 1, since otherwise, the
 		 * 0th backup would be unused. */
-		uint_fast32_t i = state->constant_state->current_backup - 1;
+		size_t i = state->constant_state->current_backup - 1;
 
 		if (!(flags & ZCBOR_FLAG_TRANSFER_PAYLOAD)) {
 			if (state->constant_state->backup_list[i].payload_moved) {
@@ -123,8 +123,8 @@ bool zcbor_union_end_code(zcbor_state_t *state)
 	return true;
 }
 
-void zcbor_new_state(zcbor_state_t *state_array, uint_fast32_t n_states,
-		const uint8_t *payload, size_t payload_len, uint_fast32_t elem_count)
+void zcbor_new_state(zcbor_state_t *state_array, size_t n_states,
+		const uint8_t *payload, size_t payload_len, size_t elem_count)
 {
 	state_array[0].payload = payload;
 	state_array[0].payload_end = payload + payload_len;
@@ -162,7 +162,7 @@ void zcbor_update_state(zcbor_state_t *state,
 
 
 bool zcbor_validate_string_fragments(struct zcbor_string_fragment *fragments,
-		uint_fast32_t num_fragments)
+		size_t num_fragments)
 {
 	size_t total_len = 0;
 
@@ -170,7 +170,7 @@ bool zcbor_validate_string_fragments(struct zcbor_string_fragment *fragments,
 		return false;
 	}
 
-	for (uint_fast32_t i = 0; i < num_fragments; i++) {
+	for (size_t i = 0; i < num_fragments; i++) {
 		if (fragments[i].offset != total_len) {
 			return false;
 		}
@@ -191,7 +191,7 @@ bool zcbor_validate_string_fragments(struct zcbor_string_fragment *fragments,
 	}
 
 	if (num_fragments && (fragments[0].total_len == ZCBOR_STRING_FRAGMENT_UNKNOWN_LENGTH)) {
-		for (uint_fast32_t i = 0; i < num_fragments; i++) {
+		for (size_t i = 0; i < num_fragments; i++) {
 			fragments[i].total_len = total_len;
 		}
 	}
@@ -200,7 +200,7 @@ bool zcbor_validate_string_fragments(struct zcbor_string_fragment *fragments,
 }
 
 bool zcbor_splice_string_fragments(struct zcbor_string_fragment *fragments,
-		uint_fast32_t num_fragments, uint8_t *result, size_t *result_len)
+		size_t num_fragments, uint8_t *result, size_t *result_len)
 {
 	size_t total_len = 0;
 
@@ -208,7 +208,7 @@ bool zcbor_splice_string_fragments(struct zcbor_string_fragment *fragments,
 		return false;
 	}
 
-	for (uint_fast32_t i = 0; i < num_fragments; i++) {
+	for (size_t i = 0; i < num_fragments; i++) {
 		if ((total_len > *result_len)
 			|| (fragments[i].fragment.len > (*result_len - total_len))) {
 			return false;

--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -1072,18 +1072,18 @@ bool zcbor_tag_expect(zcbor_state_t *state, uint32_t result)
 }
 
 
-bool zcbor_multi_decode(uint_fast32_t min_decode,
-		uint_fast32_t max_decode,
-		uint_fast32_t *num_decode,
+bool zcbor_multi_decode(size_t min_decode,
+		size_t max_decode,
+		size_t *num_decode,
 		zcbor_decoder_t decoder,
 		zcbor_state_t *state,
 		void *result,
-		uint_fast32_t result_len)
+		size_t result_len)
 {
 	ZCBOR_CHECK_ERROR();
-	for (uint_fast32_t i = 0; i < max_decode; i++) {
+	for (size_t i = 0; i < max_decode; i++) {
 		uint8_t const *payload_bak = state->payload;
-		uint_fast32_t elem_count_bak = state->elem_count;
+		size_t elem_count_bak = state->elem_count;
 
 		if (!decoder(state,
 				(uint8_t *)result + i*result_len)) {
@@ -1101,23 +1101,23 @@ bool zcbor_multi_decode(uint_fast32_t min_decode,
 }
 
 
-bool zcbor_present_decode(uint_fast32_t *present,
+bool zcbor_present_decode(bool *present,
 		zcbor_decoder_t decoder,
 		zcbor_state_t *state,
 		void *result)
 {
-	uint_fast32_t num_decode;
+	size_t num_decode;
 	bool retval = zcbor_multi_decode(0, 1, &num_decode, decoder, state, result, 0);
 
 	zcbor_assert_state(retval, "zcbor_multi_decode should not fail with these parameters.\r\n");
 
-	*present = num_decode;
+	*present = !!num_decode;
 	return retval;
 }
 
 
-void zcbor_new_decode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
-		const uint8_t *payload, size_t payload_len, uint_fast32_t elem_count)
+void zcbor_new_decode_state(zcbor_state_t *state_array, size_t n_states,
+		const uint8_t *payload, size_t payload_len, size_t elem_count)
 {
 	zcbor_new_state(state_array, n_states, payload, payload_len, elem_count);
 }

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -15,7 +15,7 @@ _Static_assert((sizeof(size_t) == sizeof(void *)),
 	"This code needs size_t to be the same length as pointers.");
 
 
-static uint8_t log2ceil(uint_fast32_t val)
+static uint8_t log2ceil(size_t val)
 {
 	switch(val) {
 		case 1: return 0;
@@ -33,7 +33,7 @@ static uint8_t log2ceil(uint_fast32_t val)
 }
 
 
-static uint8_t get_additional(uint_fast32_t len, uint8_t value0)
+static uint8_t get_additional(size_t len, uint8_t value0)
 {
 	return len == 0 ? value0 : (uint8_t)(24 + log2ceil(len));
 }
@@ -52,16 +52,16 @@ static bool encode_header_byte(zcbor_state_t *state,
 }
 
 
-static uint_fast32_t get_encoded_len(const void *const result, uint_fast32_t result_len);
+static size_t get_encoded_len(const void *const result, size_t result_len);
 
 
 /** Encode a single value.
  */
 static bool value_encode_len(zcbor_state_t *state, zcbor_major_type_t major_type,
-		const void *const result, uint_fast32_t result_len)
+		const void *const result, size_t result_len)
 {
 	uint8_t *u8_result  = (uint8_t *)result;
-	uint_fast32_t encoded_len = get_encoded_len(result, result_len);
+	size_t encoded_len = get_encoded_len(result, result_len);
 
 	if ((state->payload + 1 + encoded_len) > state->payload_end) {
 		ZCBOR_ERR(ZCBOR_ERR_NO_PAYLOAD);
@@ -89,10 +89,10 @@ static bool value_encode_len(zcbor_state_t *state, zcbor_major_type_t major_type
 }
 
 
-static uint_fast32_t get_result_len(const void *const input, uint_fast32_t max_result_len)
+static size_t get_result_len(const void *const input, size_t max_result_len)
 {
 	uint8_t *u8_result  = (uint8_t *)input;
-	uint_fast32_t len = max_result_len;
+	size_t len = max_result_len;
 
 	for (; len > 0; len--) {
 #ifdef CONFIG_BIG_ENDIAN
@@ -109,8 +109,8 @@ static uint_fast32_t get_result_len(const void *const input, uint_fast32_t max_r
 }
 
 
-static const void *get_result(const void *const input, uint_fast32_t max_result_len,
-	uint_fast32_t result_len)
+static const void *get_result(const void *const input, size_t max_result_len,
+	size_t result_len)
 {
 #ifdef CONFIG_BIG_ENDIAN
 	return &((uint8_t *)input)[max_result_len - (result_len ? result_len : 1)];
@@ -122,7 +122,7 @@ static const void *get_result(const void *const input, uint_fast32_t max_result_
 }
 
 
-static uint_fast32_t get_encoded_len(const void *const result, uint_fast32_t result_len)
+static size_t get_encoded_len(const void *const result, size_t result_len)
 {
 	const uint8_t *u8_result  = (const uint8_t *)result;
 
@@ -134,11 +134,11 @@ static uint_fast32_t get_encoded_len(const void *const result, uint_fast32_t res
 
 
 static bool value_encode(zcbor_state_t *state, zcbor_major_type_t major_type,
-		const void *const input, uint_fast32_t max_result_len)
+		const void *const input, size_t max_result_len)
 {
 	zcbor_assert_state(max_result_len != 0, "0-length result not supported.\r\n");
 
-	uint_fast32_t result_len = get_result_len(input, max_result_len);
+	size_t result_len = get_result_len(input, max_result_len);
 	const void *const result = get_result(input, max_result_len, result_len);
 
 	return value_encode_len(state, major_type, result, result_len);
@@ -352,7 +352,7 @@ bool zcbor_tstr_encode(zcbor_state_t *state, const struct zcbor_string *input)
 }
 
 
-static bool list_map_start_encode(zcbor_state_t *state, uint_fast32_t max_num,
+static bool list_map_start_encode(zcbor_state_t *state, size_t max_num,
 		zcbor_major_type_t major_type)
 {
 #ifdef ZCBOR_CANONICAL
@@ -376,22 +376,22 @@ static bool list_map_start_encode(zcbor_state_t *state, uint_fast32_t max_num,
 }
 
 
-bool zcbor_list_start_encode(zcbor_state_t *state, uint_fast32_t max_num)
+bool zcbor_list_start_encode(zcbor_state_t *state, size_t max_num)
 {
 	return list_map_start_encode(state, max_num, ZCBOR_MAJOR_TYPE_LIST);
 }
 
 
-bool zcbor_map_start_encode(zcbor_state_t *state, uint_fast32_t max_num)
+bool zcbor_map_start_encode(zcbor_state_t *state, size_t max_num)
 {
 	return list_map_start_encode(state, max_num, ZCBOR_MAJOR_TYPE_MAP);
 }
 
 
 #ifdef ZCBOR_CANONICAL
-static uint_fast32_t get_encoded_len2(const void *const input, uint_fast32_t max_result_len)
+static size_t get_encoded_len2(const void *const input, size_t max_result_len)
 {
-	uint_fast32_t result_len = get_result_len(input, max_result_len);
+	size_t result_len = get_result_len(input, max_result_len);
 	const void *const result = get_result(input, max_result_len, result_len);
 
 	return get_encoded_len(result, result_len);
@@ -399,18 +399,18 @@ static uint_fast32_t get_encoded_len2(const void *const input, uint_fast32_t max
 #endif
 
 
-static bool list_map_end_encode(zcbor_state_t *state, uint_fast32_t max_num,
+static bool list_map_end_encode(zcbor_state_t *state, size_t max_num,
 			zcbor_major_type_t major_type)
 {
 #ifdef ZCBOR_CANONICAL
-	uint_fast32_t list_count = ((major_type == ZCBOR_MAJOR_TYPE_LIST) ?
+	size_t list_count = ((major_type == ZCBOR_MAJOR_TYPE_LIST) ?
 					state->elem_count
 					: (state->elem_count / 2));
 
 	const uint8_t *payload = state->payload;
 
-	uint_fast32_t max_header_len = get_encoded_len2(&max_num, 4);
-	uint_fast32_t header_len = get_encoded_len2(&list_count, 4);
+	size_t max_header_len = get_encoded_len2(&max_num, 4);
+	size_t header_len = get_encoded_len2(&list_count, 4);
 
 	if (!zcbor_process_backup(state, ZCBOR_FLAG_RESTORE | ZCBOR_FLAG_CONSUME, 0xFFFFFFFF)) {
 		ZCBOR_FAIL();
@@ -454,13 +454,13 @@ static bool list_map_end_encode(zcbor_state_t *state, uint_fast32_t max_num,
 }
 
 
-bool zcbor_list_end_encode(zcbor_state_t *state, uint_fast32_t max_num)
+bool zcbor_list_end_encode(zcbor_state_t *state, size_t max_num)
 {
 	return list_map_end_encode(state, max_num, ZCBOR_MAJOR_TYPE_LIST);
 }
 
 
-bool zcbor_map_end_encode(zcbor_state_t *state, uint_fast32_t max_num)
+bool zcbor_map_end_encode(zcbor_state_t *state, size_t max_num)
 {
 	return list_map_end_encode(state, max_num, ZCBOR_MAJOR_TYPE_MAP);
 }
@@ -672,13 +672,13 @@ bool zcbor_tag_encode(zcbor_state_t *state, uint32_t tag)
 }
 
 
-bool zcbor_multi_encode_minmax(uint_fast32_t min_encode,
-		uint_fast32_t max_encode,
-		const uint_fast32_t *num_encode,
+bool zcbor_multi_encode_minmax(size_t min_encode,
+		size_t max_encode,
+		const size_t *num_encode,
 		zcbor_encoder_t encoder,
 		zcbor_state_t *state,
 		const void *input,
-		uint_fast32_t result_len)
+		size_t result_len)
 {
 
 	if ((*num_encode >= min_encode) && (*num_encode <= max_encode)) {
@@ -689,14 +689,14 @@ bool zcbor_multi_encode_minmax(uint_fast32_t min_encode,
 }
 
 
-bool zcbor_multi_encode(uint_fast32_t num_encode,
+bool zcbor_multi_encode(size_t num_encode,
 		zcbor_encoder_t encoder,
 		zcbor_state_t *state,
 		const void *input,
-		uint_fast32_t result_len)
+		size_t result_len)
 {
 	ZCBOR_CHECK_ERROR();
-	for (uint_fast32_t i = 0; i < num_encode; i++) {
+	for (size_t i = 0; i < num_encode; i++) {
 		if (!encoder(state, (const uint8_t *)input + i*result_len)) {
 			ZCBOR_FAIL();
 		}
@@ -706,7 +706,7 @@ bool zcbor_multi_encode(uint_fast32_t num_encode,
 }
 
 
-bool zcbor_present_encode(const uint_fast32_t *present,
+bool zcbor_present_encode(const bool *present,
 		zcbor_encoder_t encoder,
 		zcbor_state_t *state,
 		const void *input)
@@ -715,8 +715,8 @@ bool zcbor_present_encode(const uint_fast32_t *present,
 }
 
 
-void zcbor_new_encode_state(zcbor_state_t *state_array, uint_fast32_t n_states,
-		uint8_t *payload, size_t payload_len, uint_fast32_t elem_count)
+void zcbor_new_encode_state(zcbor_state_t *state_array, size_t n_states,
+		uint8_t *payload, size_t payload_len, size_t elem_count)
 {
 	zcbor_new_state(state_array, n_states, payload, payload_len, elem_count);
 }

--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -835,7 +835,7 @@ ZTEST(cbor_decode_test5, test_empty_map)
 	const uint8_t payload2_inv[] = {MAP(1), END};
 	const uint8_t payload3_inv[] = {MAP(1), 0, END};
 	const uint8_t payload4[] = {MAP(0), END MAP(0), END MAP(0), END};
-	uint_fast32_t num_decode;
+	size_t num_decode;
 
 	ZCBOR_STATE_D(state, 0, payload4, sizeof(payload4), 3);
 
@@ -1260,7 +1260,7 @@ ZTEST(cbor_decode_test5, test_single)
 	uint8_t payload_single3[] = {9};
 	uint8_t payload_single4_inv[] = {10};
 	struct zcbor_string result_bstr;
-	uint_fast32_t result_int;
+	size_t result_int;
 	size_t out_len;
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SingleBstr(payload_single0, sizeof(payload_single0), &result_bstr, &out_len), NULL);

--- a/tests/encode/test3_corner_cases/src/main.c
+++ b/tests/encode/test3_corner_cases/src/main.c
@@ -1043,10 +1043,10 @@ ZTEST(cbor_encode_test3, test_single)
 		.value = "hello",
 		.len = 5
 	};
-	uint_fast32_t input_single1 = 52;
-	uint_fast32_t input_single2_ign = 53;
-	uint_fast32_t input_single3 = 9;
-	uint_fast32_t input_single4_inv = 10;
+	size_t input_single1 = 52;
+	size_t input_single2_ign = 53;
+	size_t input_single3 = 9;
+	size_t input_single4_inv = 10;
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_SingleBstr(output, sizeof(output), &input_single0, &out_len), NULL);
 	zassert_equal(sizeof(exp_payload_single0), out_len, NULL);

--- a/tests/unit/test1_unit_tests/src/main.c
+++ b/tests/unit/test1_unit_tests/src/main.c
@@ -263,8 +263,8 @@ ZTEST(zcbor_unit_tests, test_stop_on_error)
 	zassert_false(zcbor_map_end_encode(state_e, 0), NULL);
 	zassert_false(zcbor_list_end_encode(state_e, 1), NULL);
 	zassert_false(zcbor_multi_encode(1, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)14, 0), NULL);
-	zassert_false(zcbor_multi_encode_minmax(1, 1, &(uint_fast32_t){1}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)15, 0), NULL);
-	zassert_false(zcbor_present_encode(&(uint_fast32_t){1}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)16), NULL);
+	zassert_false(zcbor_multi_encode_minmax(1, 1, &(size_t){1}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)15, 0), NULL);
+	zassert_false(zcbor_present_encode(&(bool){true}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)16), NULL);
 
 
 	zassert_mem_equal(&state_backup, state_e, sizeof(state_backup), NULL);
@@ -304,8 +304,8 @@ ZTEST(zcbor_unit_tests, test_stop_on_error)
 	zassert_true(zcbor_map_end_encode(state_e, 0), NULL);
 	zassert_true(zcbor_list_end_encode(state_e, 1), NULL);
 	zassert_true(zcbor_multi_encode(1, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)14, 0), NULL);
-	zassert_true(zcbor_multi_encode_minmax(1, 1, &(uint_fast32_t){1}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)15, 0), NULL);
-	zassert_true(zcbor_present_encode(&(uint_fast32_t){1}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)16), NULL);
+	zassert_true(zcbor_multi_encode_minmax(1, 1, &(size_t){1}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)15, 0), NULL);
+	zassert_true(zcbor_present_encode(&(bool){true}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)16), NULL);
 
 	ZCBOR_STATE_D(state_d, 3, payload, sizeof(payload), 30);
 	state_d->constant_state->stop_on_error = true;
@@ -344,9 +344,9 @@ ZTEST(zcbor_unit_tests, test_stop_on_error)
 	zassert_false(zcbor_map_start_decode(state_d), NULL);
 	zassert_false(zcbor_map_end_decode(state_d), NULL);
 	zassert_false(zcbor_list_end_decode(state_d), NULL);
-	zassert_false(zcbor_multi_decode(1, 1, &(uint_fast32_t){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)14, 0), NULL);
+	zassert_false(zcbor_multi_decode(1, 1, &(size_t){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)14, 0), NULL);
 	zassert_false(zcbor_int32_expect(state_d, 15), NULL);
-	zassert_false(zcbor_present_decode(&(uint_fast32_t){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)16), NULL);
+	zassert_false(zcbor_present_decode(&(bool){true}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)16), NULL);
 
 	zassert_mem_equal(&state_backup, state_d, sizeof(state_backup), NULL);
 	zassert_mem_equal(&constant_state_backup, state_d->constant_state, sizeof(constant_state_backup), NULL);
@@ -382,9 +382,9 @@ ZTEST(zcbor_unit_tests, test_stop_on_error)
 	zassert_true(zcbor_map_start_decode(state_d), NULL);
 	zassert_true(zcbor_map_end_decode(state_d), NULL);
 	zassert_true(zcbor_list_end_decode(state_d), NULL);
-	zassert_true(zcbor_multi_decode(1, 1, &(uint_fast32_t){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)14, 0), NULL);
+	zassert_true(zcbor_multi_decode(1, 1, &(size_t){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)14, 0), NULL);
 	zassert_true(zcbor_int32_expect(state_d, 15), NULL);
-	zassert_true(zcbor_present_decode(&(uint_fast32_t){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)16), NULL);
+	zassert_true(zcbor_present_decode(&(bool){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)16), NULL);
 
 	/* Everything has been decoded. */
 	zassert_equal(state_e->payload, state_d->payload, NULL);

--- a/tests/unit/test2_cpp/src/main.cpp
+++ b/tests/unit/test2_cpp/src/main.cpp
@@ -21,7 +21,8 @@ int main(void)
 	bool false_ = false;
 	float eleven_six = 11.6;
 	double thirteen_eight = 13.8;
-	uint_fast32_t one = 1;
+	size_t one = 1;
+	bool one_b = 1;
 	struct zcbor_string dummy_string;
 
 	ZCBOR_STATE_E(state_e, 3, payload, sizeof(payload), 0);
@@ -61,7 +62,7 @@ int main(void)
 	zcbor_list_end_encode(state_e, 1);
 	zcbor_multi_encode(1, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)14, 0);
 	zcbor_multi_encode_minmax(1, 1, &one, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)15, 0);
-	bool ret = zcbor_present_encode(&one, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)16);
+	bool ret = zcbor_present_encode(&one_b, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)16);
 
 	if (!ret) {
 		printk("Encode error: %d\r\n", zcbor_peek_error(state_e));
@@ -99,7 +100,7 @@ int main(void)
 	zcbor_list_end_decode(state_d);
 	zcbor_multi_decode(1, 1, &one, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)14, 0);
 	zcbor_int32_expect(state_d, 15);
-	ret = zcbor_present_decode(&one, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)16);
+	ret = zcbor_present_decode(&one_b, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)16);
 
 	if (!ret) {
 		printk("Decode error: %d\r\n", zcbor_peek_error(state_d));

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -1747,11 +1747,11 @@ class CodeGenerator(CddlXcoder):
 
     # Declaration of the "present" variable for this element.
     def present_var(self):
-        return ["uint_fast32_t %s;" % self.present_var_name()]
+        return ["bool %s;" % self.present_var_name()]
 
     # Declaration of the "count" variable for this element.
     def count_var(self):
-        return ["uint_fast32_t %s;" % self.count_var_name()]
+        return ["size_t %s;" % self.count_var_name()]
 
     # Declaration of the "choice" variable for this element.
     def anonymous_choice_var(self):


### PR DESCRIPTION
Because it's more concise, more descriptive, since most of the uses are counts.

The "present" variable has been changed to bool instead.