### PR TITLE
Add support for searching for elements in a map.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Backups are needed for _encoding_ if there are any lists or maps *and* you are u
 ```c
 /** Initialize a decoding state (could include an array of backup states).
  *  After calling this, decode_state[0] is ready to be used with the decoding APIs. */
-ZCBOR_STATE_D(decode_state, n, payload, payload_len, elem_count);
+ZCBOR_STATE_D(decode_state, n, payload, payload_len, elem_count, n_flags);
 
 /** Initialize an encoding state (could include an array of backup states).
  *  After calling this, encode_state[0] is ready to be used with the encoding APIs. */
@@ -97,6 +97,7 @@ Name                      | Description
 `ZCBOR_ASSERTS`           | Enable asserts (`zcbor_assert()`). When they fail, the assert statements instruct the current function to return a `ZCBOR_ERR_ASSERTION` error. If `ZCBOR_VERBOSE` is enabled, a message is printed.
 `ZCBOR_STOP_ON_ERROR`     | Enable the `stop_on_error` functionality. This makes all functions abort their execution if called when an error has already happened.
 `ZCBOR_BIG_ENDIAN`        | All decoded values are returned as big-endian. The default is little-endian.
+`ZCBOR_MAP_SMART_SEARCH`  | Applies to decoding of unordered maps. When enabled, a flag is kept for each element in an array, ensuring it is not processed twice. If disabled, a count is kept for map as a whole. Enabling increases code size and memory usage, and requires the state variable to possess the memory necessary for the flags.
 
 
 Python script and module

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,8 +10,6 @@ Any new bugs, requests, or missing features should be reported as [Github issues
 Not all features outlined in the CDDL specs [RFC8610](https://datatracker.ietf.org/doc/html/rfc8610), [RFC9090](https://datatracker.ietf.org/doc/html/rfc9090), and [RFC9165](https://datatracker.ietf.org/doc/html/rfc9165) are supported by zcbor.
 The following is a list of limitations and missing features:
 
- * Map elements in data must appear in the same order as they appear in the CDDL.
- * C API doesn't support searching through a map.
  * Using `&()` to turn groups into choices (unions). `&()` is supported when used with `.bits`.
  * Representation Types (`#x.y`), except for tags (`#6.y(foo)`) which are supported.
  * Unwrapping (`~`)

--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -110,6 +110,7 @@ do { \
 
 struct zcbor_state_constant;
 
+/** The zcbor_state_t structure is used for both encoding and decoding. */
 typedef struct {
 union {
 	uint8_t *payload_mut;
@@ -126,12 +127,16 @@ union {
 	uint8_t const *payload_end; /**< The end of the payload. This will be
 	                                 checked against payload before
 	                                 processing each element. */
-	bool indefinite_length_array; /**< Is set to true if the decoder is currently
-	                                   decoding the contents of an indefinite-
-	                                   length array. */
 	bool payload_moved; /**< Is set to true while the state is stored as a backup
 	                         if @ref zcbor_update_state is called, since that function
 	                         updates the payload_end of all backed-up states. */
+
+/* This is the "decode state", the part of zcbor_state_t that is only used by zcbor_decode.c. */
+struct {
+	bool indefinite_length_array; /**< Is set to true if the decoder is currently
+	                                   decoding the contents of an indefinite-
+	                                   length array. */
+} decode_state;
 	struct zcbor_state_constant *constant_state; /**< The part of the state that is
 	                                                  not backed up and duplicated. */
 } zcbor_state_t;
@@ -230,6 +235,7 @@ do { \
 #define ZCBOR_FLAG_RESTORE 1UL ///! Restore from the backup. Overwrite the current state with the state from the backup.
 #define ZCBOR_FLAG_CONSUME 2UL ///! Consume the backup. Remove the backup from the stack of backups.
 #define ZCBOR_FLAG_KEEP_PAYLOAD 4UL ///! Keep the pre-restore payload after restoring.
+#define ZCBOR_FLAG_KEEP_DECODE_STATE 8UL ///! Keep the pre-restore decode state (everything only used for decoding)
 
 #define ZCBOR_SUCCESS 0
 #define ZCBOR_ERR_NO_BACKUP_MEM 1
@@ -246,6 +252,7 @@ do { \
 #define ZCBOR_ERR_WRONG_RANGE 12
 #define ZCBOR_ERR_ITERATIONS 13
 #define ZCBOR_ERR_ASSERTION 14
+#define ZCBOR_ERR_PAYLOAD_OUTDATED 15 ///! Because of a call to @ref zcbor_update_state
 #define ZCBOR_ERR_UNKNOWN 31
 
 /** The largest possible elem_count. */

--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -27,7 +27,7 @@ void main(void)
 	}
 
 	/* Create zcbor state variable for decoding. */
-	ZCBOR_STATE_D(decoding_state, 0, cbor_payload, sizeof(cbor_payload), 1);
+	ZCBOR_STATE_D(decoding_state, 0, cbor_payload, sizeof(cbor_payload), 1, 0);
 
 	/* Decode the text string into the cbor_payload buffer */
 	success = zcbor_tstr_decode(decoding_state, &decoded_string);

--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -621,7 +621,7 @@ static bool list_map_start_decode(zcbor_state_t *state,
 		FAIL_RESTORE();
 	}
 
-	state->indefinite_length_array = indefinite_length_array;
+	state->decode_state.indefinite_length_array = indefinite_length_array;
 
 	return true;
 }
@@ -637,7 +637,7 @@ bool zcbor_map_start_decode(zcbor_state_t *state)
 {
 	bool ret = list_map_start_decode(state, ZCBOR_MAJOR_TYPE_MAP);
 
-	if (ret && !state->indefinite_length_array) {
+	if (ret && !state->decode_state.indefinite_length_array) {
 		if (state->elem_count >= (ZCBOR_MAX_ELEM_COUNT / 2)) {
 			/* The new elem_count is too large. */
 			ERR_RESTORE(ZCBOR_ERR_INT_SIZE);
@@ -650,8 +650,8 @@ bool zcbor_map_start_decode(zcbor_state_t *state)
 
 bool zcbor_array_at_end(zcbor_state_t *state)
 {
-	return ((!state->indefinite_length_array && (state->elem_count == 0))
-		|| (state->indefinite_length_array
+	return ((!state->decode_state.indefinite_length_array && (state->elem_count == 0))
+		|| (state->decode_state.indefinite_length_array
 			&& (state->payload < state->payload_end)
 			&& (*state->payload == 0xFF)));
 }
@@ -671,12 +671,12 @@ static bool list_map_end_decode(zcbor_state_t *state)
 {
 	size_t max_elem_count = 0;
 
-	if (state->indefinite_length_array) {
+	if (state->decode_state.indefinite_length_array) {
 		if (!array_end_expect(state)) {
 			ZCBOR_FAIL();
 		}
 		max_elem_count = ZCBOR_MAX_ELEM_COUNT;
-		state->indefinite_length_array = false;
+		state->decode_state.indefinite_length_array = false;
 	}
 	if (!zcbor_process_backup(state,
 			ZCBOR_FLAG_RESTORE | ZCBOR_FLAG_CONSUME | ZCBOR_FLAG_KEEP_PAYLOAD,
@@ -1084,7 +1084,7 @@ bool zcbor_any_skip(zcbor_state_t *state, void *result)
 				value = ZCBOR_LARGE_ELEM_COUNT;
 			}
 			state_copy.elem_count = (size_t)value;
-			state_copy.indefinite_length_array = indefinite_length_array;
+			state_copy.decode_state.indefinite_length_array = indefinite_length_array;
 			while (!zcbor_array_at_end(&state_copy)) {
 				if (!zcbor_any_skip(&state_copy, NULL)) {
 					ZCBOR_FAIL();

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -659,5 +659,5 @@ bool zcbor_multi_encode(const size_t num_encode, zcbor_encoder_t encoder,
 void zcbor_new_encode_state(zcbor_state_t *state_array, size_t n_states,
 		uint8_t *payload, size_t payload_len, size_t elem_count)
 {
-	zcbor_new_state(state_array, n_states, payload, payload_len, elem_count);
+	zcbor_new_state(state_array, n_states, payload, payload_len, elem_count, NULL, 0);
 }

--- a/tests/cmake/test_template.cmake
+++ b/tests/cmake/test_template.cmake
@@ -20,6 +20,10 @@ if (CONFIG_BIG_ENDIAN OR BIG_ENDIAN)
   zephyr_compile_definitions(ZCBOR_BIG_ENDIAN)
 endif()
 
+if (MAP_SMART_SEARCH)
+  zephyr_compile_definitions(ZCBOR_MAP_SMART_SEARCH)
+endif()
+
 zephyr_compile_options(-Werror)
 
 if (CONFIG_64BIT)

--- a/tests/decode/test3_simple/src/main.c
+++ b/tests/decode/test3_simple/src/main.c
@@ -483,9 +483,9 @@ ZTEST(cbor_decode_test3, test_serial1)
 {
 	struct Upload upload;
 	size_t decode_len;
-	bool ret = cbor_decode_Upload(serial_rec_input1,
+	int ret = cbor_decode_Upload(serial_rec_input1,
 			sizeof(serial_rec_input1), &upload, &decode_len);
-	zassert_equal(ZCBOR_SUCCESS, ret, "decoding failed.");
+	zassert_equal(ZCBOR_SUCCESS, ret, "decoding failed: %d.", ret);
 	zassert_equal(sizeof(serial_rec_input1), decode_len, NULL);
 
 	zassert_equal(5, upload.members_count,
@@ -507,9 +507,9 @@ ZTEST(cbor_decode_test3, test_serial2)
 {
 	struct Upload upload;
 	size_t decode_len;
-	bool ret = cbor_decode_Upload(serial_rec_input2,
+	int ret = cbor_decode_Upload(serial_rec_input2,
 			sizeof(serial_rec_input2), &upload, &decode_len);
-	zassert_equal(ZCBOR_SUCCESS, ret, "decoding failed.");
+	zassert_equal(ZCBOR_SUCCESS, ret, "decoding failed: %d.", ret);
 	zassert_equal(sizeof(serial_rec_input2), decode_len, NULL);
 
 	zassert_equal(5, upload.members_count,

--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -882,7 +882,7 @@ ZTEST(cbor_decode_test5, test_empty_map)
 	const uint8_t payload4[] = {MAP(0), END MAP(0), END MAP(0), END};
 	size_t num_decode;
 
-	ZCBOR_STATE_D(state, 0, payload4, sizeof(payload4), 3);
+	ZCBOR_STATE_D(state, 0, payload4, sizeof(payload4), 3, 0);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_EmptyMap(payload1, sizeof(payload1), NULL, NULL), NULL);
 #ifdef TEST_INDEFINITE_LENGTH_ARRAYS

--- a/tests/unit/test1_unit_tests/testcase.yaml
+++ b/tests/unit/test1_unit_tests/testcase.yaml
@@ -1,4 +1,9 @@
+common:
+  platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+  tags: zcbor unit
+  timeout: 120  # Because of test_size64
+
 tests:
-  zcbor.unit.test1:
-    platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
-    tags: zcbor unit
+  zcbor.unit.test1: {}
+  zcbor.unit.test1.map_smart_search:
+    extra_args: MAP_SMART_SEARCH=ON

--- a/tests/unit/test2_cpp/src/main.cpp
+++ b/tests/unit/test2_cpp/src/main.cpp
@@ -26,7 +26,7 @@ int main(void)
 	struct zcbor_string dummy_string;
 
 	ZCBOR_STATE_E(state_e, 3, payload, sizeof(payload), 0);
-	ZCBOR_STATE_D(state_d, 3, payload, sizeof(payload), 30);
+	ZCBOR_STATE_D(state_d, 3, payload, sizeof(payload), 30, 0);
 
 	state_e->constant_state->stop_on_error = true;
 	state_d->constant_state->stop_on_error = true;

--- a/tests/unit/test3_float16/src/main.c
+++ b/tests/unit/test3_float16/src/main.c
@@ -57,7 +57,7 @@ ZTEST(zcbor_unit_tests3, test_float16_decode)
 		*(uint16_t *)&payload[1] = i_be;
 
 		float out;
-		ZCBOR_STATE_D(state_d, 0, payload, sizeof(payload), 1);
+		ZCBOR_STATE_D(state_d, 0, payload, sizeof(payload), 1, 0);
 		ZCBOR_STATE_E(state_e, 0, payload, sizeof(payload), 0);
 
 		zassert_true(zcbor_float16_decode(state_d, &out), NULL);


### PR DESCRIPTION
C library: Add support for searching for elements in a map.

Map elements should per the spec be assumed to appear in arbitrary order.

This PR brings some new functions to zcbor_decode, called
zcbor_unordered_map_*().
These functions can be used to search for keys within a map.
The existing map decoding functions work like before.

This PR adds some optional functionality when it comes to keeping track
of which elements in a map have been found. The new functionality can
be enabled with ZCBOR_MAP_SEARCH_FLAGS.