### PR TITLE
zcbor.py: Don't use zcbor_present_encode()

### DIFF
--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -259,15 +259,6 @@ bool zcbor_multi_encode_minmax(size_t min_encode, size_t max_encode, const size_
 		zcbor_encoder_t encoder, zcbor_state_t *state, const void *input,
 		size_t input_len);
 
-/** Runs @p encoder on @p state and @p input if @p present is true.
- *
- * Calls @ref zcbor_multi_encode under the hood.
- */
-bool zcbor_present_encode(const bool *present,
-		zcbor_encoder_t encoder,
-		zcbor_state_t *state,
-		const void *input);
-
 /** See @ref zcbor_new_state() */
 void zcbor_new_encode_state(zcbor_state_t *state_array, size_t n_states,
 		uint8_t *payload, size_t payload_len, size_t elem_count);

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -706,15 +706,6 @@ bool zcbor_multi_encode(size_t num_encode,
 }
 
 
-bool zcbor_present_encode(const bool *present,
-		zcbor_encoder_t encoder,
-		zcbor_state_t *state,
-		const void *input)
-{
-	return zcbor_multi_encode(!!*present, encoder, state, input, 0);
-}
-
-
 void zcbor_new_encode_state(zcbor_state_t *state_array, size_t n_states,
 		uint8_t *payload, size_t payload_len, size_t elem_count)
 {

--- a/tests/unit/test1_unit_tests/src/main.c
+++ b/tests/unit/test1_unit_tests/src/main.c
@@ -264,7 +264,6 @@ ZTEST(zcbor_unit_tests, test_stop_on_error)
 	zassert_false(zcbor_list_end_encode(state_e, 1), NULL);
 	zassert_false(zcbor_multi_encode(1, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)14, 0), NULL);
 	zassert_false(zcbor_multi_encode_minmax(1, 1, &(size_t){1}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)15, 0), NULL);
-	zassert_false(zcbor_present_encode(&(bool){true}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)16), NULL);
 
 
 	zassert_mem_equal(&state_backup, state_e, sizeof(state_backup), NULL);
@@ -305,7 +304,6 @@ ZTEST(zcbor_unit_tests, test_stop_on_error)
 	zassert_true(zcbor_list_end_encode(state_e, 1), NULL);
 	zassert_true(zcbor_multi_encode(1, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)14, 0), NULL);
 	zassert_true(zcbor_multi_encode_minmax(1, 1, &(size_t){1}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)15, 0), NULL);
-	zassert_true(zcbor_present_encode(&(bool){true}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)16), NULL);
 
 	ZCBOR_STATE_D(state_d, 3, payload, sizeof(payload), 30);
 	state_d->constant_state->stop_on_error = true;
@@ -347,8 +345,7 @@ ZTEST(zcbor_unit_tests, test_stop_on_error)
 	zassert_false(zcbor_map_end_decode(state_d), NULL);
 	zassert_false(zcbor_list_end_decode(state_d), NULL);
 	zassert_false(zcbor_multi_decode(1, 1, &(size_t){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)14, 0), NULL);
-	zassert_false(zcbor_int32_expect(state_d, 15), NULL);
-	zassert_false(zcbor_present_decode(&(bool){true}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)16), NULL);
+	zassert_false(zcbor_present_decode(&(bool){true}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)15), NULL);
 
 	zassert_mem_equal(&state_backup, state_d, sizeof(state_backup), NULL);
 	zassert_mem_equal(&constant_state_backup, state_d->constant_state, sizeof(constant_state_backup), NULL);
@@ -389,8 +386,7 @@ ZTEST(zcbor_unit_tests, test_stop_on_error)
 	zassert_true(zcbor_map_end_decode(state_d), NULL);
 	zassert_true(zcbor_list_end_decode(state_d), NULL);
 	zassert_true(zcbor_multi_decode(1, 1, &(size_t){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)14, 0), NULL);
-	zassert_true(zcbor_int32_expect(state_d, 15), NULL);
-	zassert_true(zcbor_present_decode(&(bool){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)16), NULL);
+	zassert_true(zcbor_present_decode(&(bool){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)15), NULL);
 
 	/* Everything has been decoded. */
 	zassert_equal(state_e->payload, state_d->payload, NULL);

--- a/tests/unit/test2_cpp/src/main.cpp
+++ b/tests/unit/test2_cpp/src/main.cpp
@@ -61,8 +61,7 @@ int main(void)
 	zcbor_map_end_encode(state_e, 0);
 	zcbor_list_end_encode(state_e, 1);
 	zcbor_multi_encode(1, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)14, 0);
-	zcbor_multi_encode_minmax(1, 1, &one, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)15, 0);
-	bool ret = zcbor_present_encode(&one_b, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)16);
+	bool ret = zcbor_multi_encode_minmax(1, 1, &one, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)15, 0);
 
 	if (!ret) {
 		printk("Encode error: %d\r\n", zcbor_peek_error(state_e));
@@ -99,8 +98,7 @@ int main(void)
 	zcbor_map_end_decode(state_d);
 	zcbor_list_end_decode(state_d);
 	zcbor_multi_decode(1, 1, &one, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)14, 0);
-	zcbor_int32_expect(state_d, 15);
-	ret = zcbor_present_decode(&one_b, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)16);
+	ret = zcbor_present_decode(&one_b, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)15);
 
 	if (!ret) {
 		printk("Decode error: %d\r\n", zcbor_peek_error(state_d));


### PR DESCRIPTION
and only use zcbor_present_decode() in complex cases. This saves footprint.
Then remove zcbor_present_encode().