### PR TITLE
zcbor_encode: Change zcbor_tag_encode to take a pointer argument

### DIFF
--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -108,8 +108,12 @@ static inline bool zcbor_tstr_encode_ptr(zcbor_state_t *state, const char *ptr, 
 #define zcbor_tstr_put_arr(state, string) \
 	zcbor_tstr_encode_ptr(state, string, sizeof(string))
 
-/** Encode a tag. Must be called before encoding the value being tagged. */
-bool zcbor_tag_encode(zcbor_state_t *state, uint32_t tag);
+/** Encode a tag. Must be called before encoding the value being tagged.
+ *  Note that zcbor_tag_put() is the new zcbor_tag_encode(), and
+ *  zcbor_tag_encode()'s argument was changed to be a pointer.
+*/
+bool zcbor_tag_put(zcbor_state_t *state, uint32_t tag);
+bool zcbor_tag_encode(zcbor_state_t *state, uint32_t *tag);
 
 /** Encode a simple value. */
 bool zcbor_simple_encode(zcbor_state_t *state, uint8_t *input);

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -661,7 +661,7 @@ bool zcbor_float16_bytes_put(zcbor_state_t *state, uint16_t input)
 }
 
 
-bool zcbor_tag_encode(zcbor_state_t *state, uint32_t tag)
+bool zcbor_tag_put(zcbor_state_t *state, uint32_t tag)
 {
 	if (!value_encode(state, ZCBOR_MAJOR_TYPE_TAG, &tag, sizeof(tag))) {
 		ZCBOR_FAIL();
@@ -669,6 +669,12 @@ bool zcbor_tag_encode(zcbor_state_t *state, uint32_t tag)
 	state->elem_count--;
 
 	return true;
+}
+
+
+bool zcbor_tag_encode(zcbor_state_t *state, uint32_t *tag)
+{
+	return zcbor_tag_put(state, *tag);
 }
 
 

--- a/tests/unit/test1_unit_tests/src/main.c
+++ b/tests/unit/test1_unit_tests/src/main.c
@@ -247,7 +247,8 @@ ZTEST(zcbor_unit_tests, test_stop_on_error)
 	zassert_false(zcbor_size_encode(state_e, &(size_t){9}), NULL);
 	zassert_false(zcbor_bstr_put_lit(state_e, "Hello"), NULL);
 	zassert_false(zcbor_tstr_put_lit(state_e, "World"), NULL);
-	zassert_false(zcbor_tag_encode(state_e, 9), NULL);
+	zassert_false(zcbor_tag_put(state_e, 9), NULL);
+	zassert_false(zcbor_tag_encode(state_e, &(uint32_t){10}));
 	zassert_false(zcbor_bool_put(state_e, true), NULL);
 	zassert_false(zcbor_bool_encode(state_e, &(bool){false}), NULL);
 	zassert_false(zcbor_float32_put(state_e, 10.5), NULL);
@@ -286,8 +287,8 @@ ZTEST(zcbor_unit_tests, test_stop_on_error)
 	zassert_true(zcbor_size_encode(state_e, &(size_t){9}), NULL);
 	zassert_true(zcbor_bstr_put_lit(state_e, "Hello"), NULL);
 	zassert_true(zcbor_tstr_put_lit(state_e, "World"), NULL);
-	zassert_true(zcbor_tag_encode(state_e, 9), NULL);
-	zassert_true(zcbor_tag_encode(state_e, 10), NULL);
+	zassert_true(zcbor_tag_put(state_e, 9), NULL);
+	zassert_true(zcbor_tag_encode(state_e, &(uint32_t){10}));
 	zassert_true(zcbor_bool_put(state_e, true), NULL);
 	zassert_true(zcbor_bool_encode(state_e, &(bool){false}), NULL);
 	zassert_true(zcbor_float32_put(state_e, 10.5), NULL);
@@ -1020,9 +1021,9 @@ ZTEST(zcbor_unit_tests, test_any_skip)
 	zassert_equal(state_d->payload, state_e->payload, NULL);
 	zassert_equal(state_d->elem_count, --exp_elem_count, NULL);
 
-	zassert_true(zcbor_tag_encode(state_e, 1), NULL);
-	zassert_true(zcbor_tag_encode(state_e, 200), NULL);
-	zassert_true(zcbor_tag_encode(state_e, 3000), NULL);
+	zassert_true(zcbor_tag_put(state_e, 1), NULL);
+	zassert_true(zcbor_tag_put(state_e, 200), NULL);
+	zassert_true(zcbor_tag_put(state_e, 3000), NULL);
 	zassert_true(zcbor_map_start_encode(state_e, 6), NULL);
 	zassert_true(zcbor_uint32_put(state_e, 10), NULL);
 	zassert_true(zcbor_int64_put(state_e, -10000000000000), NULL);

--- a/tests/unit/test2_cpp/src/main.cpp
+++ b/tests/unit/test2_cpp/src/main.cpp
@@ -44,8 +44,8 @@ int main(void)
 	zcbor_size_encode(state_e, &nine);
 	zcbor_bstr_put_lit(state_e, "Hello");
 	zcbor_tstr_put_lit(state_e, "World");
-	zcbor_tag_encode(state_e, 9);
-	zcbor_tag_encode(state_e, 10);
+	zcbor_tag_put(state_e, 9);
+	zcbor_tag_put(state_e, 10);
 	zcbor_bool_put(state_e, true);
 	zcbor_bool_encode(state_e, &false_);
 	zcbor_float32_put(state_e, 10.5);

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -2349,7 +2349,7 @@ class CodeGenerator(CddlXcoder):
         return self.xcode_single_func_prim()
 
     def xcode_tags(self):
-        return [f"zcbor_tag_{self.mode if (self.mode == 'encode') else 'expect'}(state, {tag})"
+        return [f"zcbor_tag_{'put' if (self.mode == 'encode') else 'expect'}(state, {tag})"
                 for tag in self.tags]
 
     # Appends ULL or LL if a value exceeding 32-bits is used


### PR DESCRIPTION
Add zcbor_tag_put() which takes a value argument.