### PR TITLE
Zephyr versions

### DIFF
--- a/.github/actions/prepare_and_run_tests/action.yaml
+++ b/.github/actions/prepare_and_run_tests/action.yaml
@@ -24,7 +24,12 @@ runs:
     - name: Clone zephyr
       shell: sh
       run: |
-        git clone --depth 1 https://github.com/zephyrproject-rtos/zephyr zephyr-clone
+        mkdir zephyr-clone
+        cd zephyr-clone
+        git init
+        git remote add origin https://github.com/zephyrproject-rtos/zephyr
+        git fetch origin $ZEPHYR_REV --depth=1
+        git reset --hard FETCH_HEAD
 
     - name: West init
       shell: sh

--- a/.github/actions/prepare_and_run_tests/action.yaml
+++ b/.github/actions/prepare_and_run_tests/action.yaml
@@ -46,9 +46,9 @@ runs:
       if: ${{ inputs.zephyr_toolchain == 'zephyr' }}
       shell: sh
       run: |
-        wget -nv https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION/zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-x86_64_minimal.tar.gz
+        wget -nv https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION/zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-x86_64_minimal.tar.xz
         wget -nv -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION/sha256.sum | shasum --check --ignore-missing
-        tar -xf zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-x86_64_minimal.tar.gz
+        tar -xf zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-x86_64_minimal.tar.xz
         mv zephyr-sdk-$ZEPHYR_SDK_VERSION zephyr-sdk
         west update cmsis
 
@@ -57,18 +57,18 @@ runs:
       shell: sh
       run: |
         sudo apt install qemu qemu-system-arm
-        wget -nv https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION/toolchain_linux-x86_64_arm-zephyr-eabi.tar.gz
+        wget -nv https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION/toolchain_linux-x86_64_arm-zephyr-eabi.tar.xz
         wget -nv -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION/sha256.sum | shasum --check --ignore-missing
-        tar -xf toolchain_linux-x86_64_arm-zephyr-eabi.tar.gz -C zephyr-sdk
+        tar -xf toolchain_linux-x86_64_arm-zephyr-eabi.tar.xz -C zephyr-sdk
 
     - name: Install Zephyr SDK (MIPS)
       if: ${{ inputs.zephyr_toolchain == 'zephyr' && contains(inputs.zephyr_toolchain_arch, 'mips') }}
       shell: sh
       run: |
         sudo apt install qemu qemu-system-mips
-        wget -nv https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION/toolchain_linux-x86_64_mips-zephyr-elf.tar.gz
+        wget -nv https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION/toolchain_linux-x86_64_mips-zephyr-elf.tar.xz
         wget -nv -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION/sha256.sum | shasum --check --ignore-missing
-        tar -xf toolchain_linux-x86_64_mips-zephyr-elf.tar.gz -C zephyr-sdk
+        tar -xf toolchain_linux-x86_64_mips-zephyr-elf.tar.xz -C zephyr-sdk
 
     - name: Run tests
       working-directory: tests

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -3,7 +3,7 @@ name: Run tests
 on: [pull_request]
 
 env:
-  ZEPHYR_SDK_VERSION: 0.15.2
+  ZEPHYR_SDK_VERSION: 0.16.0
 
 jobs:
   merge-test-1:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 env:
   ZEPHYR_SDK_VERSION: 0.16.0
+  ZEPHYR_REV: fec7881117836ab1c3ec035389a962cd06b476b0
 
 jobs:
   merge-test-1:


### PR DESCRIPTION
Update Zephyr SDK version, and fix Zephyr version to a specific commit, so that the CI doesn't suddenly break because of changes in Zephyr.