### PR TITLE
zcbor_encode, zcbor_decode: Move inline functions from header files

### DIFF
--- a/include/zcbor_decode.h
+++ b/include/zcbor_decode.h
@@ -80,18 +80,8 @@ bool zcbor_tstr_expect(zcbor_state_t *state, struct zcbor_string *result);
  * @param[in]    string  The value to expect. A pointer to the string.
  * @param[in]    len     The length of the string pointed to by @p string.
  */
-static inline bool zcbor_bstr_expect_ptr(zcbor_state_t *state, char const *ptr, size_t len)
-{
-	struct zcbor_string zs = { .value = (const uint8_t *)ptr, .len = len };
-
-	return zcbor_bstr_expect(state, &zs);
-}
-static inline bool zcbor_tstr_expect_ptr(zcbor_state_t *state, char const *ptr, size_t len)
-{
-	struct zcbor_string zs = { .value = (const uint8_t *)ptr, .len = len };
-
-	return zcbor_tstr_expect(state, &zs);
-}
+bool zcbor_bstr_expect_ptr(zcbor_state_t *state, char const *ptr, size_t len);
+bool zcbor_tstr_expect_ptr(zcbor_state_t *state, char const *ptr, size_t len);
 
 
 /** Consume and expect a bstr/tstr with the value of the provided string literal.

--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -62,18 +62,8 @@ bool zcbor_tstr_encode(zcbor_state_t *state, const struct zcbor_string *input);
  * @param[in]    string  The value to encode. A pointer to the string
  * @param[in]    len     The length of the string pointed to by @p string.
  */
-static inline bool zcbor_bstr_encode_ptr(zcbor_state_t *state, const char *ptr, size_t len)
-{
-	const struct zcbor_string zs = { .value = (const uint8_t *)ptr, .len = len };
-
-	return zcbor_bstr_encode(state, &zs);
-}
-static inline bool zcbor_tstr_encode_ptr(zcbor_state_t *state, const char *ptr, size_t len)
-{
-	const struct zcbor_string zs = { .value = (const uint8_t *)ptr, .len = len };
-
-	return zcbor_tstr_encode(state, &zs);
-}
+bool zcbor_bstr_encode_ptr(zcbor_state_t *state, const char *ptr, size_t len);
+bool zcbor_tstr_encode_ptr(zcbor_state_t *state, const char *ptr, size_t len);
 
 /** Encode a string literal as a bstr/tstr.
  *

--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -550,6 +550,21 @@ bool zcbor_tstr_expect(zcbor_state_t *state, struct zcbor_string *result)
 	return str_expect(state, result, ZCBOR_MAJOR_TYPE_TSTR);
 }
 
+bool zcbor_bstr_expect_ptr(zcbor_state_t *state, char const *ptr, size_t len)
+{
+	struct zcbor_string zs = { .value = (const uint8_t *)ptr, .len = len };
+
+	return zcbor_bstr_expect(state, &zs);
+}
+
+bool zcbor_tstr_expect_ptr(zcbor_state_t *state, char const *ptr, size_t len)
+{
+	struct zcbor_string zs = { .value = (const uint8_t *)ptr, .len = len };
+
+	return zcbor_tstr_expect(state, &zs);
+}
+
+
 
 static bool list_map_start_decode(zcbor_state_t *state,
 		zcbor_major_type_t exp_major_type)

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -352,6 +352,22 @@ bool zcbor_tstr_encode(zcbor_state_t *state, const struct zcbor_string *input)
 }
 
 
+bool zcbor_bstr_encode_ptr(zcbor_state_t *state, const char *ptr, size_t len)
+{
+	const struct zcbor_string zs = { .value = (const uint8_t *)ptr, .len = len };
+
+	return zcbor_bstr_encode(state, &zs);
+}
+
+
+bool zcbor_tstr_encode_ptr(zcbor_state_t *state, const char *ptr, size_t len)
+{
+	const struct zcbor_string zs = { .value = (const uint8_t *)ptr, .len = len };
+
+	return zcbor_tstr_encode(state, &zs);
+}
+
+
 static bool list_map_start_encode(zcbor_state_t *state, size_t max_num,
 		zcbor_major_type_t major_type)
 {


### PR DESCRIPTION
to c files.