### PR TITLE
 zcbor_encode, zcbor_decode: fix double promotion warnings

### DIFF
--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -769,7 +769,7 @@ bool zcbor_float16_bytes_expect(zcbor_state_t *state, uint16_t result)
 #define F16_EXPO_MSK 0x1F /* Bitmask for the exponent (right shifted by F16_EXPO_OFFS). */
 #define F16_MANTISSA_MSK 0x3FF /* Bitmask for the mantissa. */
 #define F16_MIN_EXPO 24 /* Negative exponent of the non-zero float16 value closest to 0 (2^-24) */
-#define F16_MIN (1.0 / (1 << F16_MIN_EXPO)) /* The non-zero float16 value closest to 0 (2^-24) */
+#define F16_MIN (1.0f / (1 << F16_MIN_EXPO)) /* The non-zero float16 value closest to 0 (2^-24) */
 #define F16_BIAS 15 /* The exponent bias of normalized float16 values. */
 
 /* Float32: */
@@ -793,7 +793,7 @@ bool zcbor_float16_decode(zcbor_state_t *state, float *result)
 
 	if ((expo == 0) && (mantissa != 0)) {
 		/* Subnormal float16 - convert to normalized float32 */
-		*result = ((float)mantissa * (float)F16_MIN) * (sign ? -1 : 1);
+		*result = ((float)mantissa * F16_MIN) * (sign ? -1 : 1);
 	} else {
 		/* Normalized / zero / Infinity / NaN */
 		uint32_t new_expo = (expo == 0 /* zero */) ? 0

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -568,8 +568,8 @@ bool zcbor_float16_encode(zcbor_state_t *state, const float *input)
 #define F16_MAX 65520 /* Lowest float32 value that rounds up to float16 infinity.
 		       * (65519.996 rounds to 65504) */
 #define F16_MIN_EXPO 24 /* Negative exponent of the non-zero float16 value closest to 0 (2^-24) */
-#define F16_MIN (1.0 / (1 << F16_MIN_EXPO)) /* The non-zero float16 value closest to 0 (2^-24) */
-#define F16_MIN_NORM (1.0 / (1 << 14)) /* The normalized float16 value closest to 0 (2^-14) */
+#define F16_MIN (1.0f / (1 << F16_MIN_EXPO)) /* The non-zero float16 value closest to 0 (2^-24) */
+#define F16_MIN_NORM (1.0f / (1 << 14)) /* The normalized float16 value closest to 0 (2^-14) */
 #define F16_BIAS 15 /* The exponent bias of normalized float16 values. */
 
 /* Float32: */

--- a/tests/decode/test2_suit/CMakeLists.txt
+++ b/tests/decode/test2_suit/CMakeLists.txt
@@ -38,5 +38,5 @@ target_link_libraries(app PRIVATE manifest2)
 
 if (NOT VERBOSE)
   # VERBOSE means including printk which doesn't build with these options.
-  target_compile_options(manifest2 PRIVATE -Wpedantic -Wconversion)
+  target_compile_options(manifest2 PRIVATE -Wpedantic -Wconversion -Wdouble-promotion)
 endif()

--- a/tests/decode/test5_corner_cases/CMakeLists.txt
+++ b/tests/decode/test5_corner_cases/CMakeLists.txt
@@ -78,5 +78,5 @@ endif()
 
 if (NOT VERBOSE AND CONFIG_MINIMAL_LIBC)
   # VERBOSE means including printk which doesn't build with these options.
-  target_compile_options(corner_cases PRIVATE -Wpedantic -Wconversion)
+  target_compile_options(corner_cases PRIVATE -Wpedantic -Wconversion -Wdouble-promotion)
 endif()

--- a/tests/unit/test1_unit_tests/CMakeLists.txt
+++ b/tests/unit/test1_unit_tests/CMakeLists.txt
@@ -25,5 +25,5 @@ zephyr_compile_definitions(ZCBOR_STOP_ON_ERROR)
 
 if (NOT VERBOSE AND CONFIG_MINIMAL_LIBC)
   # VERBOSE means including printk which doesn't build with these options.
-  target_compile_options(zcbor PRIVATE -Wpedantic -Wconversion -Wall -Wextra)
+  target_compile_options(zcbor PRIVATE -Wpedantic -Wconversion -Wall -Wextra -Wdouble-promotion)
 endif()


### PR DESCRIPTION
C implicit promotion rules will want to make floats into doubles very easily. Fix the constants that were defined as doubles.

Related PR: https://github.com/zephyrproject-rtos/zephyr/pull/57154