### PR TITLE
src: Abstract float16 conversion and move it to zcbor_common.c

### DIFF
--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -425,6 +425,22 @@ size_t zcbor_header_len(size_t num_elems);
  */
 bool zcbor_array_at_end(zcbor_state_t *state);
 
+/** Convert a float16 value to float32.
+ *
+ *  @param[in] input  The float16 value stored in a uint16_t.
+ *
+ *  @return  The resulting float32 value.
+ */
+float zcbor_float16_to_32(uint16_t input);
+
+/** Convert a float32 value to float16.
+ *
+ *  @param[in] input  The float32 value.
+ *
+ *  @return  The resulting float16 value as a uint16_t.
+ */
+uint16_t zcbor_float32_to_16(float input);
+
 
 #ifdef __cplusplus
 }

--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -778,22 +778,6 @@ bool zcbor_float16_bytes_expect(zcbor_state_t *state, uint16_t expected)
 }
 
 
-/* Float16: */
-#define F16_SIGN_OFFS 15 /* Bit offset of the sign bit. */
-#define F16_EXPO_OFFS 10 /* Bit offset of the exponent. */
-#define F16_EXPO_MSK 0x1F /* Bitmask for the exponent (right shifted by F16_EXPO_OFFS). */
-#define F16_MANTISSA_MSK 0x3FF /* Bitmask for the mantissa. */
-#define F16_MIN_EXPO 24 /* Negative exponent of the non-zero float16 value closest to 0 (2^-24) */
-#define F16_MIN (1.0f / (1 << F16_MIN_EXPO)) /* The non-zero float16 value closest to 0 (2^-24) */
-#define F16_BIAS 15 /* The exponent bias of normalized float16 values. */
-
-/* Float32: */
-#define F32_SIGN_OFFS 31 /* Bit offset of the sign bit. */
-#define F32_EXPO_OFFS 23 /* Bit offset of the exponent. */
-#define F32_EXPO_MSK 0xFF /* Bitmask for the exponent (right shifted by F32_EXPO_OFFS). */
-#define F32_BIAS 127 /* The exponent bias of normalized float32 values. */
-
-
 bool zcbor_float16_decode(zcbor_state_t *state, float *result)
 {
 	uint16_t value16;
@@ -802,23 +786,7 @@ bool zcbor_float16_decode(zcbor_state_t *state, float *result)
 		ZCBOR_FAIL();
 	}
 
-	uint32_t sign = value16 >> F16_SIGN_OFFS;
-	uint32_t expo = (value16 >> F16_EXPO_OFFS) & F16_EXPO_MSK;
-	uint32_t mantissa = value16 & F16_MANTISSA_MSK;
-
-	if ((expo == 0) && (mantissa != 0)) {
-		/* Subnormal float16 - convert to normalized float32 */
-		*result = ((float)mantissa * F16_MIN) * (sign ? -1 : 1);
-	} else {
-		/* Normalized / zero / Infinity / NaN */
-		uint32_t new_expo = (expo == 0 /* zero */) ? 0
-			: (expo == F16_EXPO_MSK /* inf/NaN */) ? F32_EXPO_MSK
-				: (expo + (F32_BIAS - F16_BIAS));
-		uint32_t value32 = (sign << F32_SIGN_OFFS) | (new_expo << F32_EXPO_OFFS)
-			| (mantissa << (F32_EXPO_OFFS - F16_EXPO_OFFS));
-		memcpy(result, &value32, sizeof(*result));
-	}
-
+	*result = zcbor_float16_to_32(value16);
 	return true;
 }
 

--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -576,87 +576,10 @@ bool zcbor_float16_encode(zcbor_state_t *state, const float *input)
 	return zcbor_float16_put(state, *input);
 }
 
-/* Float16: */
-#define F16_SIGN_OFFS 15 /* Bit offset of the sign bit. */
-#define F16_EXPO_OFFS 10 /* Bit offset of the exponent. */
-#define F16_EXPO_MSK 0x1F /* Bitmask for the exponent (right shifted by F16_EXPO_OFFS). */
-#define F16_MANTISSA_MSK 0x3FF /* Bitmask for the mantissa. */
-#define F16_MAX 65520 /* Lowest float32 value that rounds up to float16 infinity.
-		       * (65519.996 rounds to 65504) */
-#define F16_MIN_EXPO 24 /* Negative exponent of the non-zero float16 value closest to 0 (2^-24) */
-#define F16_MIN (1.0f / (1 << F16_MIN_EXPO)) /* The non-zero float16 value closest to 0 (2^-24) */
-#define F16_MIN_NORM (1.0f / (1 << 14)) /* The normalized float16 value closest to 0 (2^-14) */
-#define F16_BIAS 15 /* The exponent bias of normalized float16 values. */
-
-/* Float32: */
-#define F32_SIGN_OFFS 31 /* Bit offset of the sign bit. */
-#define F32_EXPO_OFFS 23 /* Bit offset of the exponent. */
-#define F32_EXPO_MSK 0xFF /* Bitmask for the exponent (right shifted by F32_EXPO_OFFS). */
-#define F32_MANTISSA_MSK 0x7FFFFF /* Bitmask for the mantissa. */
-#define F32_BIAS 127 /* The exponent bias of normalized float32 values. */
-
-/* Rounding: */
-#define SUBNORM_ROUND_MSK (F32_MANTISSA_MSK | (1 << F32_EXPO_OFFS)) /* mantissa + lsb of expo for
-								     * tiebreak. */
-#define SUBNORM_ROUND_BIT_MSK (1 << (F32_EXPO_OFFS - 1)) /* msb of mantissa (0x400000) */
-#define NORM_ROUND_MSK (F32_MANTISSA_MSK >> (F16_EXPO_OFFS - 1)) /* excess mantissa when going from
-								  * float32 to float16 + 1 extra bit
-								  * for tiebreak. */
-#define NORM_ROUND_BIT_MSK (1 << (F32_EXPO_OFFS - F16_EXPO_OFFS - 1)) /* bit 12 (0x1000) */
 
 bool zcbor_float16_put(zcbor_state_t *state, float input)
 {
-	uint32_t value32 = *(uint32_t *)&input;
-
-	uint32_t sign = value32 >> F32_SIGN_OFFS;
-	uint32_t expo = (value32 >> F32_EXPO_OFFS) & F32_EXPO_MSK;
-	uint32_t mantissa = value32 & F32_MANTISSA_MSK;
-
-	uint16_t value16 = (uint16_t)(sign << F16_SIGN_OFFS);
-
-	float abs_input;
-	*(uint32_t *)&abs_input = value32 & ~(1 << F32_SIGN_OFFS);
-
-	if (abs_input <= (F16_MIN / 2)) {
-		/* 0 or too small for float16. Round down to 0. value16 is already correct. */
-	} else if (abs_input < F16_MIN) {
-		/* Round up to 2^(-24) (F16_MIN), has other rounding rules than larger values. */
-		value16 |= 0x0001;
-	} else if (abs_input < F16_MIN_NORM) {
-		/* Subnormal float16 (normal float32) */
-		uint32_t adjusted_mantissa =
-			/* Adjust for the purposes of checking rounding. */
-			/* The lsb of expo is needed for the cases where expo is 103 (minimum). */
-			((value32 << (expo - (F32_BIAS - F16_MIN_EXPO))) & SUBNORM_ROUND_MSK);
-		uint16_t rounding_bit =
-			/* "Round to nearest, ties to even". */
-			/* 0x400000 means ties go down towards even. (0xC00000 means ties go up.) */
-			(adjusted_mantissa & SUBNORM_ROUND_BIT_MSK)
-				&& (adjusted_mantissa != SUBNORM_ROUND_BIT_MSK);
-		value16 |= ((uint16_t)(abs_input * (1 << 24)) + rounding_bit); /* expo is 0 */
-	} else if (abs_input < F16_MAX) {
-		/* Normal float16 (normal float32) */
-		uint16_t rounding_bit =
-			/* Bit 13 of the mantissa represents which way to round, except for the */
-			/* special case where bits 0-12 and 14 are 0. */
-			/* This is because of "Round to nearest, ties to even". */
-			/* 0x1000 means ties go down towards even. (0x3000 means ties go up.) */
-			((mantissa & NORM_ROUND_BIT_MSK)
-				&& ((mantissa & NORM_ROUND_MSK) != NORM_ROUND_BIT_MSK));
-		value16 |= (uint16_t)((expo - (F32_BIAS - F16_BIAS)) << F16_EXPO_OFFS);
-		value16 |= (uint16_t)(mantissa >> (F32_EXPO_OFFS - F16_EXPO_OFFS));
-		value16 += rounding_bit; /* Might propagate to exponent. */
-	} else if (expo != F32_EXPO_MSK || !mantissa) {
-		/* Infinite, or finite normal float32 too large for float16. Round up to inf. */
-		value16 |= (F16_EXPO_MSK << F16_EXPO_OFFS);
-	} else {
-		/* NaN */
-		/* Preserve msbit of mantissa. */
-		uint16_t new_mantissa = (uint16_t)(mantissa >> (F32_EXPO_OFFS - F16_EXPO_OFFS));
-		value16 |= (F16_EXPO_MSK << F16_EXPO_OFFS) | (new_mantissa ? new_mantissa : 1);
-	}
-
-	return zcbor_float16_bytes_put(state, value16);
+	return zcbor_float16_bytes_put(state, zcbor_float32_to_16(input));
 }
 
 


### PR DESCRIPTION
Create new functions zcbor_float16_to_32() and zcbor_float32_to_16() in zcbor_common.c and use these in the decoding/encoding functions.

Adapt float16 test to use the new functions directly for the lengthiest test.