### PR TITLE
zcbor.py: Change name of generated choice enum members to add a '_c'

### DIFF
--- a/samples/pet/include/pet_types.h
+++ b/samples/pet/include/pet_types.h
@@ -34,9 +34,9 @@ struct Pet {
 	size_t names_count;
 	struct zcbor_string birthday;
 	enum {
-		Pet_species_cat = 1,
-		Pet_species_dog = 2,
-		Pet_species_other = 3,
+		Pet_species_cat_c = 1,
+		Pet_species_dog_c = 2,
+		Pet_species_other_c = 3,
 	} species_choice;
 };
 

--- a/samples/pet/src/main.c
+++ b/samples/pet/src/main.c
@@ -21,13 +21,13 @@ static void print_pet(const struct Pet *pet)
 		printf("%02x", pet->birthday.value[i]);
 	}
 	switch (pet->species_choice) {
-	case Pet_species_cat:
+	case Pet_species_cat_c:
 		printf("\nSpecies: Cat\n\n");
 		return;
-	case Pet_species_dog:
+	case Pet_species_dog_c:
 		printf("\nSpecies: Dog\n\n");
 		return;
-	case Pet_species_other:
+	case Pet_species_other_c:
 		printf("\nSpecies: Other\n\n");
 		return;
 	}
@@ -101,7 +101,7 @@ static void get_pet3(void)
 	encoded_pet.names_count = 2;
 	encoded_pet.birthday.value = timestamp3;
 	encoded_pet.birthday.len = sizeof(timestamp3);
-	encoded_pet.species_choice = Pet_species_other;
+	encoded_pet.species_choice = Pet_species_other_c;
 
 	err = cbor_encode_Pet(pet3, sizeof(pet3), &encoded_pet, NULL);
 

--- a/samples/pet/src/pet_decode.c
+++ b/samples/pet/src/pet_decode.c
@@ -31,9 +31,9 @@ static bool decode_Pet(
 	&& ((zcbor_bstr_decode(state, (&(*result).birthday)))
 	&& ((((((*result).birthday.len >= 8)
 	&& ((*result).birthday.len <= 8)) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false))) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false)))
-	&& ((((zcbor_int_decode(state, &(*result).species_choice, sizeof((*result).species_choice)))) && ((((((*result).species_choice == Pet_species_cat) && ((1)))
-	|| (((*result).species_choice == Pet_species_dog) && ((1)))
-	|| (((*result).species_choice == Pet_species_other) && ((1)))) || (zcbor_error(state, ZCBOR_ERR_WRONG_VALUE), false)))))) || (zcbor_list_map_end_force_decode(state), false)) && zcbor_list_end_decode(state))));
+	&& ((((zcbor_int_decode(state, &(*result).species_choice, sizeof((*result).species_choice)))) && ((((((*result).species_choice == Pet_species_cat_c) && ((1)))
+	|| (((*result).species_choice == Pet_species_dog_c) && ((1)))
+	|| (((*result).species_choice == Pet_species_other_c) && ((1)))) || (zcbor_error(state, ZCBOR_ERR_WRONG_VALUE), false)))))) || (zcbor_list_map_end_force_decode(state), false)) && zcbor_list_end_decode(state))));
 
 	if (!tmp_result)
 		zcbor_trace();

--- a/samples/pet/src/pet_encode.c
+++ b/samples/pet/src/pet_encode.c
@@ -31,9 +31,9 @@ static bool encode_Pet(
 	&& (((((((*input).birthday.len >= 8)
 	&& ((*input).birthday.len <= 8)) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false))) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false))
 	&& (zcbor_bstr_encode(state, (&(*input).birthday))))
-	&& ((((*input).species_choice == Pet_species_cat) ? ((zcbor_uint32_put(state, (1))))
-	: (((*input).species_choice == Pet_species_dog) ? ((zcbor_uint32_put(state, (2))))
-	: (((*input).species_choice == Pet_species_other) ? ((zcbor_uint32_put(state, (3))))
+	&& ((((*input).species_choice == Pet_species_cat_c) ? ((zcbor_uint32_put(state, (1))))
+	: (((*input).species_choice == Pet_species_dog_c) ? ((zcbor_uint32_put(state, (2))))
+	: (((*input).species_choice == Pet_species_other_c) ? ((zcbor_uint32_put(state, (3))))
 	: false))))) || (zcbor_list_map_end_force_encode(state), false)) && zcbor_list_end_encode(state, 3))));
 
 	if (!tmp_result)

--- a/tests/decode/test1_suit_old_formats/src/main.c
+++ b/tests/decode/test1_suit_old_formats/src/main.c
@@ -216,7 +216,7 @@ ZTEST(cbor_decode_test, test_3)
 		      .SUIT_Outer_Wrapper_suit_manifest_cbor
 		      .SUIT_Manifest_suit_install_present,
 		      "Expected install present");
-	zassert_equal(SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr,
+	zassert_equal(SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_c,
 		      outerwrapper4
 		      .SUIT_Outer_Wrapper_suit_manifest_cbor
 		      .SUIT_Manifest_suit_install
@@ -231,7 +231,7 @@ ZTEST(cbor_decode_test, test_3)
 		      .SUIT_Severable_Command_Sequence3_SUIT_Command_Sequence_bstr_cbor
 		      .SUIT_Command_Sequence_SUIT_Command_m_count,
 		      "Expected x commands.");
-	zassert_equal(SUIT_Command_union_SUIT_Directive_m,
+	zassert_equal(SUIT_Command_union_SUIT_Directive_m_c,
 		      outerwrapper4
 		      .SUIT_Outer_Wrapper_suit_manifest_cbor
 		      .SUIT_Manifest_suit_install
@@ -240,7 +240,7 @@ ZTEST(cbor_decode_test, test_3)
 		      .SUIT_Command_Sequence_SUIT_Command_m[0]
 		      .SUIT_Command_union_choice,
 		      "Expected directive");
-	zassert_equal(SUIT_Directive_Set_Component_Index,
+	zassert_equal(SUIT_Directive_Set_Component_Index_c,
 		      outerwrapper4
 		      .SUIT_Outer_Wrapper_suit_manifest_cbor
 		      .SUIT_Manifest_suit_install
@@ -250,7 +250,7 @@ ZTEST(cbor_decode_test, test_3)
 		      .SUIT_Command_union_SUIT_Directive_m
 		      .SUIT_Directive_choice,
 		      "Expected Component_Index");
-	zassert_equal(SUIT_Directive_Set_Component_Index_uint,
+	zassert_equal(SUIT_Directive_Set_Component_Index_uint_c,
 		      outerwrapper4
 		      .SUIT_Outer_Wrapper_suit_manifest_cbor
 		      .SUIT_Manifest_suit_install
@@ -260,7 +260,7 @@ ZTEST(cbor_decode_test, test_3)
 		      .SUIT_Command_union_SUIT_Directive_m
 		      .SUIT_Directive_Set_Component_Index_choice,
 		      NULL);
-	zassert_equal(SUIT_Command_union_SUIT_Directive_m,
+	zassert_equal(SUIT_Command_union_SUIT_Directive_m_c,
 		      outerwrapper4
 		      .SUIT_Outer_Wrapper_suit_manifest_cbor
 		      .SUIT_Manifest_suit_install
@@ -269,7 +269,7 @@ ZTEST(cbor_decode_test, test_3)
 		      .SUIT_Command_Sequence_SUIT_Command_m[1]
 		      .SUIT_Command_union_choice,
 		      "Expected directive");
-	zassert_equal(SUIT_Directive_Set_Parameters,
+	zassert_equal(SUIT_Directive_Set_Parameters_c,
 		      outerwrapper4
 		      .SUIT_Outer_Wrapper_suit_manifest_cbor
 		      .SUIT_Manifest_suit_install
@@ -289,7 +289,7 @@ ZTEST(cbor_decode_test, test_3)
 		      .SUIT_Command_union_SUIT_Directive_m
 		      .SUIT_Directive_Set_Parameters_SUIT_Parameters_m_count,
 		      "Expected 1 parameter");
-zassert_equal(SUIT_Parameters_SUIT_Parameter_URI_List,
+zassert_equal(SUIT_Parameters_SUIT_Parameter_URI_List_c,
 		      outerwrapper4
 		      .SUIT_Outer_Wrapper_suit_manifest_cbor
 		      .SUIT_Manifest_suit_install
@@ -343,7 +343,7 @@ zassert_equal(SUIT_Parameters_SUIT_Parameter_URI_List,
 		      .SUIT_Prioritized_URI_uri.value,
 		      sizeof(expected_uri) - 1,
 		      "Expected example.com uri");
-	zassert_equal(SUIT_Command_union_SUIT_Directive_m,
+	zassert_equal(SUIT_Command_union_SUIT_Directive_m_c,
 		      outerwrapper4
 		      .SUIT_Outer_Wrapper_suit_manifest_cbor
 		      .SUIT_Manifest_suit_install
@@ -352,7 +352,7 @@ zassert_equal(SUIT_Parameters_SUIT_Parameter_URI_List,
 		      .SUIT_Command_Sequence_SUIT_Command_m[2]
 		      .SUIT_Command_union_choice,
 		      "Expected directive");
-	zassert_equal(SUIT_Directive_Fetch,
+	zassert_equal(SUIT_Directive_Fetch_c,
 		      outerwrapper4
 		      .SUIT_Outer_Wrapper_suit_manifest_cbor
 		      .SUIT_Manifest_suit_install

--- a/tests/decode/test2_suit/src/main.c
+++ b/tests/decode/test2_suit/src/main.c
@@ -53,7 +53,7 @@ ZTEST(cbor_decode_test2, test_5)
 						&outerwrapper1, &decode_len);
 	zassert_equal(ZCBOR_SUCCESS, res, "top-level decoding failed.");
 	zassert_equal(sizeof(test_vector1), decode_len, NULL);
-	zassert_equal(SUIT_Manifest_Wrapped_suit_manifest, outerwrapper1
+	zassert_equal(SUIT_Manifest_Wrapped_suit_manifest_c, outerwrapper1
 			.SUIT_Outer_Wrapper_SUIT_Manifest_Wrapped_m
 			.SUIT_Manifest_Wrapped_choice,
 			"wrong manifest variant");
@@ -157,7 +157,7 @@ ZTEST(cbor_decode_test2, test_5)
 			.SUIT_Command_Sequence_SUIT_Command_m_count,
 			"Should be one command (was %d).", sequence
 			.SUIT_Command_Sequence_SUIT_Command_m_count);
-	zassert_equal(SUIT_Command_SUIT_Directive_m, sequence
+	zassert_equal(SUIT_Command_SUIT_Directive_m_c, sequence
 			.SUIT_Command_Sequence_SUIT_Command_m[0]
 			.SUIT_Command_choice,
 			"Should be a directive.");

--- a/tests/decode/test3_simple/src/main.c
+++ b/tests/decode/test3_simple/src/main.c
@@ -447,7 +447,7 @@ ZTEST(cbor_decode_test3, test_pet)
 	zassert_mem_equal("bar", pet.names[1].value, 3, "Expect first name 'bar'");
 	zassert_equal(8, pet.birthday.len, "Expect len 8 birthday");
 	zassert_mem_equal(exp_birthday, pet.birthday.value, 8, "Expect birthday");
-	zassert_equal(Pet_species_dog, pet.species_choice, "Expect dog");
+	zassert_equal(Pet_species_dog_c, pet.species_choice, "Expect dog");
 }
 
 
@@ -490,16 +490,16 @@ ZTEST(cbor_decode_test3, test_serial1)
 
 	zassert_equal(5, upload.members_count,
 		"expect 5 members");
-	zassert_equal(Member_data, upload.members[0].members
+	zassert_equal(Member_data_c, upload.members[0].members
 		.Member_choice, "expect data 1st");
-	zassert_equal(Member_image, upload.members[1].members
+	zassert_equal(Member_image_c, upload.members[1].members
 		.Member_choice, "expect image 2nd");
-	zassert_equal(Member_len, upload.members[2].members
+	zassert_equal(Member_len_c, upload.members[2].members
 		.Member_choice, "was %d\r\n", upload.members[2].members
 		.Member_choice);
-	zassert_equal(Member_off, upload.members[3].members
+	zassert_equal(Member_off_c, upload.members[3].members
 		.Member_choice, "expect off 4th");
-	zassert_equal(Member_sha, upload.members[4].members
+	zassert_equal(Member_sha_c, upload.members[4].members
 		.Member_choice, "expect sha 5th");
 }
 
@@ -514,15 +514,15 @@ ZTEST(cbor_decode_test3, test_serial2)
 
 	zassert_equal(5, upload.members_count,
 		"expect 5 members");
-	zassert_equal(Member_data, upload.members[0].members
+	zassert_equal(Member_data_c, upload.members[0].members
 		.Member_choice, "expect data 1st");
-	zassert_equal(Member_image, upload.members[1].members
+	zassert_equal(Member_image_c, upload.members[1].members
 		.Member_choice, "expect image 2nd");
-	zassert_equal(Member_len, upload.members[2].members
+	zassert_equal(Member_len_c, upload.members[2].members
 		.Member_choice, "expect len 3rd");
-	zassert_equal(Member_off, upload.members[3].members
+	zassert_equal(Member_off_c, upload.members[3].members
 		.Member_choice, "expect off 4th");
-	zassert_equal(Member_sha, upload.members[4].members
+	zassert_equal(Member_sha_c, upload.members[4].members
 		.Member_choice, "expect sha 5th");
 }
 

--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -268,13 +268,13 @@ ZTEST(cbor_decode_test5, test_tagged_union)
 		sizeof(payload_tagged_union1), &result, &decode_len), "%d\r\n");
 
 	zassert_equal(sizeof(payload_tagged_union1), decode_len, NULL);
-	zassert_equal(TaggedUnion_bool, result.TaggedUnion_choice, NULL);
+	zassert_equal(TaggedUnion_bool_c, result.TaggedUnion_choice, NULL);
 	zassert_true(result.Bool, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_TaggedUnion(payload_tagged_union2,
 		sizeof(payload_tagged_union2), &result, &decode_len), NULL);
 
-	zassert_equal(TaggedUnion_uint, result.TaggedUnion_choice, NULL);
+	zassert_equal(TaggedUnion_uint_c, result.TaggedUnion_choice, NULL);
 	zassert_equal(0x10, result.uint, NULL);
 
 	zassert_equal(ZCBOR_ERR_WRONG_TYPE, cbor_decode_TaggedUnion(payload_tagged_union3_inv,
@@ -706,24 +706,24 @@ ZTEST(cbor_decode_test5, test_union)
 	struct Union_r union_r;
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Union(payload_union1, sizeof(payload_union1),
 				&union_r, NULL), NULL);
-	zassert_equal(Union_Group_m, union_r.Union_choice, NULL);
+	zassert_equal(Union_Group_m_c, union_r.Union_choice, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Union(payload_union2, sizeof(payload_union2),
 				&union_r, NULL), NULL);
-	zassert_equal(Union_MultiGroup_m, union_r.Union_choice, NULL);
+	zassert_equal(Union_MultiGroup_m_c, union_r.Union_choice, NULL);
 	zassert_equal(1, union_r.MultiGroup_m.MultiGroup_count, "was %d\r\n", union_r.MultiGroup_m.MultiGroup_count);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Union(payload_union3, sizeof(payload_union3),
 				&union_r, NULL), NULL);
-	zassert_equal(Union_uint3_l, union_r.Union_choice, NULL);
+	zassert_equal(Union_uint3_l_c, union_r.Union_choice, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Union(payload_union4, sizeof(payload_union4),
 				&union_r, NULL), NULL);
-	zassert_equal(Union_hello_tstr, union_r.Union_choice, NULL);
+	zassert_equal(Union_hello_tstr_c, union_r.Union_choice, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Union(payload_union6, sizeof(payload_union6),
 				&union_r, &decode_len), NULL);
-	zassert_equal(Union_MultiGroup_m, union_r.Union_choice, NULL);
+	zassert_equal(Union_MultiGroup_m_c, union_r.Union_choice, NULL);
 	zassert_equal(6, union_r.MultiGroup_m.MultiGroup_count, NULL);
 	zassert_equal(12, decode_len, NULL);
 
@@ -815,13 +815,13 @@ ZTEST(cbor_decode_test5, test_map)
 
 	struct Map map;
 
-	zassert_equal(union_nintuint, -8,
+	zassert_equal(union_nintuint_c, -8,
 		"The union_int optimization seems to not be working.\r\n");
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Map(payload_map1, sizeof(payload_map1),
 			&map, NULL), NULL);
 	zassert_false(map.listkey, NULL);
-	zassert_equal(union_uint7uint, map.union_choice, NULL);
+	zassert_equal(union_uint7uint_c, map.union_choice, NULL);
 	zassert_equal(1, map.uint7uint, NULL);
 	zassert_equal(2, map.twotothree_count, NULL);
 	zassert_equal(5, map.twotothree[0].twotothree.len, NULL);
@@ -835,7 +835,7 @@ ZTEST(cbor_decode_test5, test_map)
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Map(payload_map3, sizeof(payload_map3),
 			&map, NULL), NULL);
 	zassert_true(map.listkey, NULL);
-	zassert_equal(union_uint7uint, map.union_choice, NULL);
+	zassert_equal(union_uint7uint_c, map.union_choice, NULL);
 	zassert_equal(1, map.uint7uint, NULL);
 	zassert_equal(3, map.twotothree_count, NULL);
 	zassert_equal(5, map.twotothree[0].twotothree.len, NULL);
@@ -855,7 +855,7 @@ ZTEST(cbor_decode_test5, test_map)
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Map(payload_map5, sizeof(payload_map5),
 			&map, NULL), NULL);
 	zassert_false(map.listkey, NULL);
-	zassert_equal(union_nintuint, map.union_choice, NULL);
+	zassert_equal(union_nintuint_c, map.union_choice, NULL);
 	zassert_equal(1, map.nintuint, NULL);
 	zassert_equal(2, map.twotothree_count, NULL);
 }
@@ -1338,18 +1338,18 @@ ZTEST(cbor_decode_test5, test_unabstracted)
 					sizeof(payload_unabstracted0),
 					&result_unabstracted, &out_len), NULL);
 	zassert_equal(result_unabstracted.unabstractedunion1_choice,
-			Unabstracted_unabstractedunion1_choice1, NULL);
+			Unabstracted_unabstractedunion1_choice1_c, NULL);
 	zassert_equal(result_unabstracted.unabstractedunion2_choice,
-			Unabstracted_unabstractedunion2_uint3, NULL);
+			Unabstracted_unabstractedunion2_uint3_c, NULL);
 	zassert_equal(sizeof(payload_unabstracted0), out_len, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Unabstracted(payload_unabstracted1,
 					sizeof(payload_unabstracted1),
 					&result_unabstracted, &out_len), NULL);
 	zassert_equal(result_unabstracted.unabstractedunion1_choice,
-			Unabstracted_unabstractedunion1_choice2, NULL);
+			Unabstracted_unabstractedunion1_choice2_c, NULL);
 	zassert_equal(result_unabstracted.unabstractedunion2_choice,
-			Unabstracted_unabstractedunion2_choice4, NULL);
+			Unabstracted_unabstractedunion2_choice4_c, NULL);
 	zassert_equal(sizeof(payload_unabstracted1), out_len, NULL);
 
 	int ret = cbor_decode_Unabstracted(payload_unabstracted2_inv,
@@ -1924,46 +1924,46 @@ ZTEST(cbor_decode_test5, test_union_int)
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_UnionInt1(union_int_payload1,
 		sizeof(union_int_payload1), &result1, &num_decode), NULL);
 	zassert_equal(sizeof(union_int_payload1), num_decode, NULL);
-	zassert_equal(result1.union_choice, UnionInt1_union_uint1_l, NULL);
+	zassert_equal(result1.union_choice, UnionInt1_union_uint1_l_c, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_UnionInt2(union_int_payload1,
 		sizeof(union_int_payload1), &result2, &num_decode), NULL);
 	zassert_equal(sizeof(union_int_payload1), num_decode, NULL);
-	zassert_equal(result2.union_choice, union_uint5_l, NULL);
+	zassert_equal(result2.union_choice, union_uint5_l_c, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_UnionInt1(union_int_payload2,
 		sizeof(union_int_payload2), &result1, &num_decode), NULL);
 	zassert_equal(sizeof(union_int_payload2), num_decode, NULL);
-	zassert_equal(result1.union_choice, UnionInt1_union_uint2_l, NULL);
+	zassert_equal(result1.union_choice, UnionInt1_union_uint2_l_c, NULL);
 	zassert_equal(result1.bstr.len, 16, NULL);
 	zassert_mem_equal(result1.bstr.value, "This is thousand", 16, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_UnionInt2(union_int_payload2,
 		sizeof(union_int_payload2), &result2, &num_decode), NULL);
 	zassert_equal(sizeof(union_int_payload2), num_decode, NULL);
-	zassert_equal(result2.union_choice, union_uint1000_l, NULL);
+	zassert_equal(result2.union_choice, union_uint1000_l_c, NULL);
 	zassert_equal(result2.bstr.len, 16, NULL);
 	zassert_mem_equal(result2.bstr.value, "This is thousand", 16, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_UnionInt1(union_int_payload3,
 		sizeof(union_int_payload3), &result1, &num_decode), NULL);
 	zassert_equal(sizeof(union_int_payload3), num_decode, NULL);
-	zassert_equal(result1.union_choice, UnionInt1_union_uint3_l, NULL);
-	zassert_equal(result1.number_m.number_choice, number_int, NULL);
+	zassert_equal(result1.union_choice, UnionInt1_union_uint3_l_c, NULL);
+	zassert_equal(result1.number_m.number_choice, number_int_c, NULL);
 	zassert_equal(result1.number_m.Int, 1, NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_UnionInt2(union_int_payload3,
 		sizeof(union_int_payload3), &result2, &num_decode), NULL);
 	zassert_equal(sizeof(union_int_payload3), num_decode, NULL);
-	zassert_equal(result2.union_choice, union_nint_l, NULL);
-	zassert_equal(result2.number_m.number_choice, number_int, NULL);
+	zassert_equal(result2.union_choice, union_nint_l_c, NULL);
+	zassert_equal(result2.number_m.number_choice, number_int_c, NULL);
 	zassert_equal(result2.number_m.Int, 1, NULL);
 
 	int err = cbor_decode_UnionInt2(union_int_payload6,
 		sizeof(union_int_payload6), &result2, &num_decode);
 	zassert_equal(ZCBOR_SUCCESS, err, "%d\r\n", err);
 	zassert_equal(sizeof(union_int_payload6), num_decode, NULL);
-	zassert_equal(result2.union_choice, UnionInt2_union_Structure_One_m, NULL);
+	zassert_equal(result2.union_choice, UnionInt2_union_Structure_One_m_c, NULL);
 	zassert_equal(result2.Structure_One_m.some_array.len, 2, NULL);
 	zassert_mem_equal(result2.Structure_One_m.some_array.value, "hi", 2, NULL);
 

--- a/tests/decode/test9_manifest14/src/main.c
+++ b/tests/decode/test9_manifest14/src/main.c
@@ -41,7 +41,7 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_auth)
 	zassert_equal(sizeof(example0), out_len, NULL);
 
 	digest = &envelope.SUIT_Envelope_suit_authentication_wrapper_cbor.SUIT_Authentication_SUIT_Digest_bstr_cbor;
-	zassert_equal(suit_cose_hash_algs_cose_alg_sha_256_m,
+	zassert_equal(suit_cose_hash_algs_cose_alg_sha_256_m_c,
 		digest->SUIT_Digest_suit_digest_algorithm_id.suit_cose_hash_algs_choice, NULL);
 	zassert_equal(sizeof(exp_digest),
 		digest->SUIT_Digest_suit_digest_bytes.len, NULL);
@@ -49,10 +49,10 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_auth)
 		digest->SUIT_Digest_suit_digest_bytes.value,
 		digest->SUIT_Digest_suit_digest_bytes.len, NULL);
 	zassert_equal(1, envelope.SUIT_Envelope_suit_authentication_wrapper_cbor.SUIT_Authentication_Block_bstr_count, NULL);
-	zassert_equal(SUIT_Authentication_Block_COSE_Sign1_Tagged_m,
+	zassert_equal(SUIT_Authentication_Block_COSE_Sign1_Tagged_m_c,
 		envelope.SUIT_Envelope_suit_authentication_wrapper_cbor.SUIT_Authentication_Block_bstr[0].SUIT_Authentication_Block_bstr_cbor.SUIT_Authentication_Block_choice, NULL);
 	cose_sign1 = &envelope.SUIT_Envelope_suit_authentication_wrapper_cbor.SUIT_Authentication_Block_bstr[0].SUIT_Authentication_Block_bstr_cbor.SUIT_Authentication_Block_COSE_Sign1_Tagged_m;
-	zassert_equal(empty_or_serialized_map_header_map_bstr,
+	zassert_equal(empty_or_serialized_map_header_map_bstr_c,
 		cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_choice, NULL);
 	zassert_equal(0, cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_header_map_bstr_cbor.header_map_label_count, NULL);
 	zassert_true(cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_header_map_bstr_cbor.header_map_Generic_Headers_m.Generic_Headers_uint1union_present, NULL);
@@ -61,14 +61,14 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_auth)
 	zassert_false(cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_header_map_bstr_cbor.header_map_Generic_Headers_m.Generic_Headers_uint4bstr_present, NULL);
 	zassert_false(cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_header_map_bstr_cbor.header_map_Generic_Headers_m.Generic_Headers_uint5bstr_present, NULL);
 	zassert_false(cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_header_map_bstr_cbor.header_map_Generic_Headers_m.Generic_Headers_uint6bstr_present, NULL);
-	zassert_equal(Generic_Headers_uint1union_int,
+	zassert_equal(Generic_Headers_uint1union_int_c,
 		cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_header_map_bstr_cbor.header_map_Generic_Headers_m.Generic_Headers_uint1union.Generic_Headers_uint1union_choice, NULL);
 	zassert_equal(-7,
 		cose_sign1->COSE_Sign1_Headers_m.Headers_protected.empty_or_serialized_map_header_map_bstr_cbor.header_map_Generic_Headers_m.Generic_Headers_uint1union.Generic_Headers_uint1union_int, NULL);
 	zassert_equal(sizeof(exp_signature), cose_sign1->COSE_Sign1_signature.len, NULL);
 	zassert_mem_equal(exp_signature, cose_sign1->COSE_Sign1_signature.value,
 		cose_sign1->COSE_Sign1_signature.len, NULL);
-	zassert_equal(COSE_Sign1_payload_nil, cose_sign1->COSE_Sign1_payload_choice, NULL);
+	zassert_equal(COSE_Sign1_payload_nil_c, cose_sign1->COSE_Sign1_payload_choice, NULL);
 }
 
 
@@ -97,10 +97,10 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_common_sequence)
 		0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10,
 	};
 	uint32_t exp_rep_policy = (
-		(1 << suit_reporting_bits_suit_send_record_success)
-		| (1 << suit_reporting_bits_suit_send_record_failure)
-		| (1 << suit_reporting_bits_suit_send_sysinfo_success)
-		| (1 << suit_reporting_bits_suit_send_sysinfo_failure));
+		(1 << suit_reporting_bits_suit_send_record_success_c)
+		| (1 << suit_reporting_bits_suit_send_record_failure_c)
+		| (1 << suit_reporting_bits_suit_send_sysinfo_success_c)
+		| (1 << suit_reporting_bits_suit_send_sysinfo_failure_c));
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Envelope_Tagged(example0, sizeof(example0), &envelope, &out_len), NULL);
 	zassert_equal(sizeof(example0), out_len, NULL);
@@ -121,15 +121,15 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_common_sequence)
 		manifest.SUIT_Manifest_suit_common_cbor.SUIT_Common_suit_common_sequence.SUIT_Common_suit_common_sequence.len,
 		out_len, NULL);
 	zassert_equal(3, common_sequence.SUIT_Common_Sequence_union_count, NULL);
-	zassert_equal(SUIT_Common_Sequence_union_SUIT_Common_Commands_m, common_sequence.SUIT_Common_Sequence_union[0].SUIT_Common_Sequence_union_choice, NULL);
-	zassert_equal(SUIT_Common_Commands_suit_directive_override_parameters_m_l, common_sequence.SUIT_Common_Sequence_union[0].SUIT_Common_Sequence_union_SUIT_Common_Commands_m.SUIT_Common_Commands_choice, NULL);
+	zassert_equal(SUIT_Common_Sequence_union_SUIT_Common_Commands_m_c, common_sequence.SUIT_Common_Sequence_union[0].SUIT_Common_Sequence_union_choice, NULL);
+	zassert_equal(SUIT_Common_Commands_suit_directive_override_parameters_m_l_c, common_sequence.SUIT_Common_Sequence_union[0].SUIT_Common_Sequence_union_SUIT_Common_Commands_m.SUIT_Common_Commands_choice, NULL);
 	zassert_equal(4, common_sequence.SUIT_Common_Sequence_union[0].SUIT_Common_Sequence_union_SUIT_Common_Commands_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m_count, NULL);
 	parameter = &common_sequence.SUIT_Common_Sequence_union[0].SUIT_Common_Sequence_union_SUIT_Common_Commands_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m[0].suit_directive_override_parameters_m_l_map_SUIT_Parameters_m;
 	zassert_equal(
-		SUIT_Parameters_suit_parameter_vendor_identifier,
+		SUIT_Parameters_suit_parameter_vendor_identifier_c,
 		parameter->SUIT_Parameters_choice, NULL);
 	zassert_equal(
-		SUIT_Parameters_suit_parameter_vendor_identifier_RFC4122_UUID_m,
+		SUIT_Parameters_suit_parameter_vendor_identifier_RFC4122_UUID_m_c,
 		parameter->SUIT_Parameters_suit_parameter_vendor_identifier_choice, NULL);
 	zassert_equal(
 		parameter->SUIT_Parameters_suit_parameter_vendor_identifier_RFC4122_UUID_m.len,
@@ -140,7 +140,7 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_common_sequence)
 
 	parameter = &common_sequence.SUIT_Common_Sequence_union[0].SUIT_Common_Sequence_union_SUIT_Common_Commands_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m[1].suit_directive_override_parameters_m_l_map_SUIT_Parameters_m;
 	zassert_equal(
-		SUIT_Parameters_suit_parameter_class_identifier,
+		SUIT_Parameters_suit_parameter_class_identifier_c,
 		parameter->SUIT_Parameters_choice, NULL);
 	zassert_equal(
 		parameter->SUIT_Parameters_suit_parameter_class_identifier.len,
@@ -151,12 +151,12 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_common_sequence)
 
 	parameter = &common_sequence.SUIT_Common_Sequence_union[0].SUIT_Common_Sequence_union_SUIT_Common_Commands_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m[2].suit_directive_override_parameters_m_l_map_SUIT_Parameters_m;
 	zassert_equal(
-		SUIT_Parameters_suit_parameter_image_digest,
+		SUIT_Parameters_suit_parameter_image_digest_c,
 		parameter->SUIT_Parameters_choice, NULL);
 	zassert_equal(
 		parameter->SUIT_Parameters_suit_parameter_image_digest_cbor.SUIT_Digest_suit_digest_bytes.len,
 		sizeof(exp_digest), NULL);
-	zassert_equal(suit_cose_hash_algs_cose_alg_sha_256_m,
+	zassert_equal(suit_cose_hash_algs_cose_alg_sha_256_m_c,
 		parameter->SUIT_Parameters_suit_parameter_image_digest_cbor.SUIT_Digest_suit_digest_algorithm_id.suit_cose_hash_algs_choice, NULL);
 	zassert_mem_equal(exp_digest,
 		parameter->SUIT_Parameters_suit_parameter_image_digest_cbor.SUIT_Digest_suit_digest_bytes.value,
@@ -164,22 +164,22 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_common_sequence)
 
 	parameter = &common_sequence.SUIT_Common_Sequence_union[0].SUIT_Common_Sequence_union_SUIT_Common_Commands_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m[3].suit_directive_override_parameters_m_l_map_SUIT_Parameters_m;
 	zassert_equal(
-		SUIT_Parameters_suit_parameter_image_size,
+		SUIT_Parameters_suit_parameter_image_size_c,
 		parameter->SUIT_Parameters_choice, NULL);
 	zassert_equal(34768, parameter->SUIT_Parameters_suit_parameter_image_size, NULL);
 
-	zassert_equal(SUIT_Common_Sequence_union_SUIT_Condition_m, common_sequence.SUIT_Common_Sequence_union[1].SUIT_Common_Sequence_union_choice, NULL);
+	zassert_equal(SUIT_Common_Sequence_union_SUIT_Condition_m_c, common_sequence.SUIT_Common_Sequence_union[1].SUIT_Common_Sequence_union_choice, NULL);
 	condition = &common_sequence.SUIT_Common_Sequence_union[1].SUIT_Common_Sequence_union_SUIT_Condition_m;
-	zassert_equal(SUIT_Condition_suit_condition_vendor_identifier_m_l,
+	zassert_equal(SUIT_Condition_suit_condition_vendor_identifier_m_l_c,
 		condition->SUIT_Condition_choice, NULL);
 	zassert_equal(exp_rep_policy,
 		condition->SUIT_Condition_suit_condition_vendor_identifier_m_l_SUIT_Rep_Policy_m, NULL);
 	zassert_equal(exp_rep_policy,
 		condition->SUIT_Condition_suit_condition_class_identifier_m_l_SUIT_Rep_Policy_m, NULL);
 
-	zassert_equal(SUIT_Common_Sequence_union_SUIT_Condition_m, common_sequence.SUIT_Common_Sequence_union[2].SUIT_Common_Sequence_union_choice, NULL);
+	zassert_equal(SUIT_Common_Sequence_union_SUIT_Condition_m_c, common_sequence.SUIT_Common_Sequence_union[2].SUIT_Common_Sequence_union_choice, NULL);
 	condition = &common_sequence.SUIT_Common_Sequence_union[2].SUIT_Common_Sequence_union_SUIT_Condition_m;
-	zassert_equal(SUIT_Condition_suit_condition_class_identifier_m_l,
+	zassert_equal(SUIT_Condition_suit_condition_class_identifier_m_l_c,
 		condition->SUIT_Condition_choice, NULL);
 	zassert_equal(exp_rep_policy,
 		condition->SUIT_Condition_suit_condition_class_identifier_m_l_SUIT_Rep_Policy_m, NULL);
@@ -213,10 +213,10 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_common_sequence_as_command_sequence)
 		0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10,
 	};
 	uint32_t exp_rep_policy = (
-		(1 << suit_reporting_bits_suit_send_record_success)
-		| (1 << suit_reporting_bits_suit_send_record_failure)
-		| (1 << suit_reporting_bits_suit_send_sysinfo_success)
-		| (1 << suit_reporting_bits_suit_send_sysinfo_failure));
+		(1 << suit_reporting_bits_suit_send_record_success_c)
+		| (1 << suit_reporting_bits_suit_send_record_failure_c)
+		| (1 << suit_reporting_bits_suit_send_sysinfo_success_c)
+		| (1 << suit_reporting_bits_suit_send_sysinfo_failure_c));
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Envelope_Tagged(example0, sizeof(example0), &envelope, &out_len), NULL);
 	zassert_equal(sizeof(example0), out_len, NULL);
@@ -240,16 +240,16 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_common_sequence_as_command_sequence)
 		manifest.SUIT_Manifest_suit_common_cbor.SUIT_Common_suit_common_sequence.SUIT_Common_suit_common_sequence.len,
 		out_len, NULL);
 	zassert_equal(3, command_sequence.SUIT_Command_Sequence_union_count, NULL);
-	zassert_equal(SUIT_Command_Sequence_union_SUIT_Directive_m, command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_choice, NULL);
-	zassert_equal(SUIT_Directive_suit_directive_override_parameters_m_l, command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_SUIT_Directive_m.SUIT_Directive_choice, NULL);
+	zassert_equal(SUIT_Command_Sequence_union_SUIT_Directive_m_c, command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_choice, NULL);
+	zassert_equal(SUIT_Directive_suit_directive_override_parameters_m_l_c, command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_SUIT_Directive_m.SUIT_Directive_choice, NULL);
 	zassert_equal(4, command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_SUIT_Directive_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m_count, NULL);
 
 	parameter = &command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_SUIT_Directive_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m[0].suit_directive_override_parameters_m_l_map_SUIT_Parameters_m;
 	zassert_equal(
-		SUIT_Parameters_suit_parameter_vendor_identifier,
+		SUIT_Parameters_suit_parameter_vendor_identifier_c,
 		parameter->SUIT_Parameters_choice, NULL);
 	zassert_equal(
-		SUIT_Parameters_suit_parameter_vendor_identifier_RFC4122_UUID_m,
+		SUIT_Parameters_suit_parameter_vendor_identifier_RFC4122_UUID_m_c,
 		parameter->SUIT_Parameters_suit_parameter_vendor_identifier_choice, NULL);
 	zassert_equal(
 		parameter->SUIT_Parameters_suit_parameter_vendor_identifier_RFC4122_UUID_m.len,
@@ -260,7 +260,7 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_common_sequence_as_command_sequence)
 
 	parameter = &command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_SUIT_Directive_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m[1].suit_directive_override_parameters_m_l_map_SUIT_Parameters_m;
 	zassert_equal(
-		SUIT_Parameters_suit_parameter_class_identifier,
+		SUIT_Parameters_suit_parameter_class_identifier_c,
 		parameter->SUIT_Parameters_choice, NULL);
 	zassert_equal(
 		parameter->SUIT_Parameters_suit_parameter_class_identifier.len,
@@ -271,12 +271,12 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_common_sequence_as_command_sequence)
 
 	parameter = &command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_SUIT_Directive_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m[2].suit_directive_override_parameters_m_l_map_SUIT_Parameters_m;
 	zassert_equal(
-		SUIT_Parameters_suit_parameter_image_digest,
+		SUIT_Parameters_suit_parameter_image_digest_c,
 		parameter->SUIT_Parameters_choice, NULL);
 	zassert_equal(
 		parameter->SUIT_Parameters_suit_parameter_image_digest_cbor.SUIT_Digest_suit_digest_bytes.len,
 		sizeof(exp_digest), NULL);
-	zassert_equal(suit_cose_hash_algs_cose_alg_sha_256_m,
+	zassert_equal(suit_cose_hash_algs_cose_alg_sha_256_m_c,
 		parameter->SUIT_Parameters_suit_parameter_image_digest_cbor.SUIT_Digest_suit_digest_algorithm_id.suit_cose_hash_algs_choice, NULL);
 	zassert_mem_equal(exp_digest,
 		parameter->SUIT_Parameters_suit_parameter_image_digest_cbor.SUIT_Digest_suit_digest_bytes.value,
@@ -284,22 +284,22 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_common_sequence_as_command_sequence)
 
 	parameter = &command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_SUIT_Directive_m.suit_directive_override_parameters_m_l_map_SUIT_Parameters_m[3].suit_directive_override_parameters_m_l_map_SUIT_Parameters_m;
 	zassert_equal(
-		SUIT_Parameters_suit_parameter_image_size,
+		SUIT_Parameters_suit_parameter_image_size_c,
 		parameter->SUIT_Parameters_choice, NULL);
 	zassert_equal(34768, parameter->SUIT_Parameters_suit_parameter_image_size, NULL);
 
-	zassert_equal(SUIT_Command_Sequence_union_SUIT_Condition_m, command_sequence.SUIT_Command_Sequence_union[1].SUIT_Command_Sequence_union_choice, NULL);
+	zassert_equal(SUIT_Command_Sequence_union_SUIT_Condition_m_c, command_sequence.SUIT_Command_Sequence_union[1].SUIT_Command_Sequence_union_choice, NULL);
 	condition = &command_sequence.SUIT_Command_Sequence_union[1].SUIT_Command_Sequence_union_SUIT_Condition_m;
-	zassert_equal(SUIT_Condition_suit_condition_vendor_identifier_m_l,
+	zassert_equal(SUIT_Condition_suit_condition_vendor_identifier_m_l_c,
 		condition->SUIT_Condition_choice, NULL);
 	zassert_equal(exp_rep_policy,
 		condition->SUIT_Condition_suit_condition_vendor_identifier_m_l_SUIT_Rep_Policy_m, NULL);
 	zassert_equal(exp_rep_policy,
 		condition->SUIT_Condition_suit_condition_class_identifier_m_l_SUIT_Rep_Policy_m, NULL);
 
-	zassert_equal(SUIT_Command_Sequence_union_SUIT_Condition_m, command_sequence.SUIT_Command_Sequence_union[2].SUIT_Command_Sequence_union_choice, NULL);
+	zassert_equal(SUIT_Command_Sequence_union_SUIT_Condition_m_c, command_sequence.SUIT_Command_Sequence_union[2].SUIT_Command_Sequence_union_choice, NULL);
 	condition = &command_sequence.SUIT_Command_Sequence_union[2].SUIT_Command_Sequence_union_SUIT_Condition_m;
-	zassert_equal(SUIT_Condition_suit_condition_class_identifier_m_l,
+	zassert_equal(SUIT_Condition_suit_condition_class_identifier_m_l_c,
 		condition->SUIT_Condition_choice, NULL);
 	zassert_equal(exp_rep_policy,
 		condition->SUIT_Condition_suit_condition_class_identifier_m_l_SUIT_Rep_Policy_m, NULL);
@@ -314,11 +314,11 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_validate_run)
 	struct SUIT_Directive_r *directive;
 	size_t out_len;
 	uint32_t exp_rep_policy1 = (
-		(1 << suit_reporting_bits_suit_send_record_success)
-		| (1 << suit_reporting_bits_suit_send_record_failure)
-		| (1 << suit_reporting_bits_suit_send_sysinfo_success)
-		| (1 << suit_reporting_bits_suit_send_sysinfo_failure));
-	uint32_t exp_rep_policy2 = (1 << suit_reporting_bits_suit_send_record_failure);
+		(1 << suit_reporting_bits_suit_send_record_success_c)
+		| (1 << suit_reporting_bits_suit_send_record_failure_c)
+		| (1 << suit_reporting_bits_suit_send_sysinfo_success_c)
+		| (1 << suit_reporting_bits_suit_send_sysinfo_failure_c));
+	uint32_t exp_rep_policy2 = (1 << suit_reporting_bits_suit_send_record_failure_c);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SUIT_Envelope_Tagged(example0, sizeof(example0), &envelope, &out_len), NULL);
 	zassert_equal(sizeof(example0), out_len, NULL);
@@ -337,9 +337,9 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_validate_run)
 		manifest.SUIT_Manifest_SUIT_Unseverable_Members_m.SUIT_Unseverable_Members_suit_validate.SUIT_Unseverable_Members_suit_validate.len,
 		out_len, NULL);
 	zassert_equal(1, command_sequence.SUIT_Command_Sequence_union_count, NULL);
-	zassert_equal(SUIT_Command_Sequence_union_SUIT_Condition_m, command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_choice, NULL);
+	zassert_equal(SUIT_Command_Sequence_union_SUIT_Condition_m_c, command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_choice, NULL);
 	condition = &command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_SUIT_Condition_m;
-	zassert_equal(SUIT_Condition_suit_condition_image_match_m_l,
+	zassert_equal(SUIT_Condition_suit_condition_image_match_m_l_c,
 		condition->SUIT_Condition_choice, NULL);
 	zassert_equal(exp_rep_policy1,
 		condition->SUIT_Condition_suit_condition_image_match_m_l_SUIT_Rep_Policy_m, NULL);
@@ -352,9 +352,9 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_validate_run)
 		manifest.SUIT_Manifest_SUIT_Unseverable_Members_m.SUIT_Unseverable_Members_suit_run.SUIT_Unseverable_Members_suit_run.len,
 		out_len, NULL);
 	zassert_equal(1, command_sequence.SUIT_Command_Sequence_union_count, NULL);
-	zassert_equal(SUIT_Command_Sequence_union_SUIT_Directive_m, command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_choice, NULL);
+	zassert_equal(SUIT_Command_Sequence_union_SUIT_Directive_m_c, command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_choice, NULL);
 	directive = &command_sequence.SUIT_Command_Sequence_union[0].SUIT_Command_Sequence_union_SUIT_Directive_m;
-	zassert_equal(SUIT_Directive_suit_directive_run_m_l,
+	zassert_equal(SUIT_Directive_suit_directive_run_m_l_c,
 		directive->SUIT_Directive_choice, NULL);
 	zassert_equal(exp_rep_policy2,
 		directive->SUIT_Directive_suit_directive_run_m_l_SUIT_Rep_Policy_m, NULL);

--- a/tests/encode/test1_suit/src/main.c
+++ b/tests/encode/test1_suit/src/main.c
@@ -272,14 +272,14 @@ void test_command_sequence(struct zcbor_string *sequence_str,
 		directive_present = sequence1
 			.SUIT_Command_Sequence_union[i]
 			.SUIT_Command_Sequence_union_choice
-			== SUIT_Command_Sequence_union_SUIT_Directive_m;
+			== SUIT_Command_Sequence_union_SUIT_Directive_m_c;
 
 		run_seq = &directive
 			->SUIT_Directive_suit_directive_run_sequence_m_l_SUIT_Command_Sequence_bstr;
 		run_seq_present = directive_present
 			&& directive
 			->SUIT_Directive_choice
-			== SUIT_Directive_suit_directive_run_sequence_m_l;
+			== SUIT_Directive_suit_directive_run_sequence_m_l_c;
 		test_command_sequence(run_seq, run_seq_present, "run_seq");
 
 		for (uint32_t j = 0; j < directive
@@ -291,7 +291,7 @@ void test_command_sequence(struct zcbor_string *sequence_str,
 				.SUIT_Directive_Try_Each_Argument_SUIT_Command_Sequence_bstr[j];
 			try_each1_present = directive_present
 				&& directive->SUIT_Directive_choice
-				== SUIT_Directive_suit_directive_try_each_m_l;
+				== SUIT_Directive_suit_directive_try_each_m_l_c;
 			test_command_sequence(try_each1, try_each1_present, "try_each1");
 		}
 
@@ -300,11 +300,11 @@ void test_command_sequence(struct zcbor_string *sequence_str,
 			.SUIT_Directive_Try_Each_Argument_union_SUIT_Command_Sequence_bstr;
 		try_each2_present = directive_present
 			&& directive->SUIT_Directive_choice
-			== SUIT_Directive_suit_directive_try_each_m_l
+			== SUIT_Directive_suit_directive_try_each_m_l_c
 			&& directive
 			->SUIT_Directive_suit_directive_try_each_m_l_SUIT_Directive_Try_Each_Argument_m
 			.SUIT_Directive_Try_Each_Argument_union_choice
-			== SUIT_Directive_Try_Each_Argument_union_SUIT_Command_Sequence_bstr;
+			== SUIT_Directive_Try_Each_Argument_union_SUIT_Command_Sequence_bstr_c;
 		test_command_sequence(try_each2, try_each2_present, "try_each2");
 
 	}
@@ -390,7 +390,7 @@ void test_manifest(const uint8_t *input, uint32_t len)
 		&& manifest
 		->SUIT_Manifest_suit_dependency_resolution
 		.SUIT_Manifest_suit_dependency_resolution_choice ==
-		SUIT_Manifest_suit_dependency_resolution_SUIT_Command_Sequence_bstr;
+		SUIT_Manifest_suit_dependency_resolution_SUIT_Command_Sequence_bstr_c;
 	test_command_sequence(dependency2, dependency2_present, "dependency2");
 
 	fetch2 = &manifest
@@ -401,7 +401,7 @@ void test_manifest(const uint8_t *input, uint32_t len)
 		&& manifest
 		->SUIT_Manifest_suit_payload_fetch
 		.SUIT_Manifest_suit_payload_fetch_choice ==
-		SUIT_Manifest_suit_payload_fetch_SUIT_Command_Sequence_bstr;
+		SUIT_Manifest_suit_payload_fetch_SUIT_Command_Sequence_bstr_c;
 	test_command_sequence(fetch2, fetch2_present, "fetch2");
 
 	install2 = &manifest
@@ -412,7 +412,7 @@ void test_manifest(const uint8_t *input, uint32_t len)
 		&& manifest
 		->SUIT_Manifest_suit_install
 		.SUIT_Manifest_suit_install_choice ==
-		SUIT_Manifest_suit_install_SUIT_Command_Sequence_bstr;
+		SUIT_Manifest_suit_install_SUIT_Command_Sequence_bstr_c;
 	test_command_sequence(install2, install2_present, "install2");
 
 	validate = &manifest

--- a/tests/encode/test2_simple/src/main.c
+++ b/tests/encode/test2_simple/src/main.c
@@ -41,7 +41,7 @@ ZTEST(cbor_encode_test2, test_pet)
 		.names = {{.value = "foo", .len = 3}, {.value = "bar", .len = 3}},
 		.names_count = 2,
 		.birthday = {.value = (uint8_t[]){1,2,3,4,5,6,7,8}, .len = 8},
-		.species_choice = Pet_species_dog
+		.species_choice = Pet_species_dog_c
 	};
 	uint8_t exp_output[] = {
 		LIST(3),

--- a/tests/encode/test3_corner_cases/src/main.c
+++ b/tests/encode/test3_corner_cases/src/main.c
@@ -125,7 +125,7 @@ ZTEST(cbor_encode_test3, test_tagged_union)
 	uint8_t output[5];
 
 	struct TaggedUnion_r input;
-	input.TaggedUnion_choice = TaggedUnion_bool;
+	input.TaggedUnion_choice = TaggedUnion_bool_c;
 	input.Bool = true;
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_TaggedUnion(output,
@@ -134,7 +134,7 @@ ZTEST(cbor_encode_test3, test_tagged_union)
 	zassert_equal(sizeof(exp_payload_tagged_union1), encode_len, NULL);
 	zassert_mem_equal(exp_payload_tagged_union1, output, sizeof(exp_payload_tagged_union1), NULL);
 
-	input.TaggedUnion_choice = TaggedUnion_uint;
+	input.TaggedUnion_choice = TaggedUnion_uint_c;
 	input.uint = 0x10;
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_TaggedUnion(output,
@@ -514,12 +514,12 @@ ZTEST(cbor_encode_test3, test_union)
 		0x03, 0x23, 0x03, 0x23, 0x03, 0x23
 	};
 
-	struct Union_r union1 = {.Union_choice = Union_Group_m};
-	struct Union_r union2 = {.Union_choice = Union_MultiGroup_m, .MultiGroup_m.MultiGroup_count = 1};
-	struct Union_r union3 = {.Union_choice = Union_uint3_l};
-	struct Union_r union4 = {.Union_choice = Union_hello_tstr};
-	struct Union_r union5 = {.Union_choice = Union_MultiGroup_m, .MultiGroup_m.MultiGroup_count = 6};
-	struct Union_r union6_inv = {.Union_choice = Union_MultiGroup_m, .MultiGroup_m.MultiGroup_count = 7};
+	struct Union_r union1 = {.Union_choice = Union_Group_m_c};
+	struct Union_r union2 = {.Union_choice = Union_MultiGroup_m_c, .MultiGroup_m.MultiGroup_count = 1};
+	struct Union_r union3 = {.Union_choice = Union_uint3_l_c};
+	struct Union_r union4 = {.Union_choice = Union_hello_tstr_c};
+	struct Union_r union5 = {.Union_choice = Union_MultiGroup_m_c, .MultiGroup_m.MultiGroup_count = 6};
+	struct Union_r union6_inv = {.Union_choice = Union_MultiGroup_m_c, .MultiGroup_m.MultiGroup_count = 7};
 
 	uint8_t output[15];
 	size_t out_len;
@@ -615,7 +615,7 @@ ZTEST(cbor_encode_test3, test_map)
 	};
 
 	struct Map map1 = {
-		.union_choice = union_uint7uint,
+		.union_choice = union_uint7uint_c,
 		.uint7uint = 1,
 		.twotothree_count = 2,
 		.twotothree = {
@@ -625,7 +625,7 @@ ZTEST(cbor_encode_test3, test_map)
 	};
 	struct Map map2 = {
 		.listkey = true,
-		.union_choice = union_uint7uint,
+		.union_choice = union_uint7uint_c,
 		.uint7uint = 1,
 		.twotothree_count = 3,
 		.twotothree = {
@@ -635,7 +635,7 @@ ZTEST(cbor_encode_test3, test_map)
 		}
 	};
 	struct Map map3 = {
-		.union_choice = union_nintuint,
+		.union_choice = union_nintuint_c,
 		.nintuint = 1,
 		.twotothree_count = 2,
 		.twotothree = {
@@ -1074,12 +1074,12 @@ ZTEST(cbor_encode_test3, test_unabstracted)
 	uint8_t exp_payload_unabstracted0[] = {LIST(2), 0x01, 0x03, END};
 	uint8_t exp_payload_unabstracted1[] = {LIST(2), 0x02, 0x04, END};
 	struct Unabstracted result_unabstracted0 = {
-		.unabstractedunion1_choice = Unabstracted_unabstractedunion1_choice1,
-		.unabstractedunion2_choice = Unabstracted_unabstractedunion2_uint3,
+		.unabstractedunion1_choice = Unabstracted_unabstractedunion1_choice1_c,
+		.unabstractedunion2_choice = Unabstracted_unabstractedunion2_uint3_c,
 	};
 	struct Unabstracted result_unabstracted1 = {
-		.unabstractedunion1_choice = Unabstracted_unabstractedunion1_choice2,
-		.unabstractedunion2_choice = Unabstracted_unabstractedunion2_choice4,
+		.unabstractedunion1_choice = Unabstracted_unabstractedunion1_choice2_c,
+		.unabstractedunion2_choice = Unabstracted_unabstractedunion2_choice4_c,
 	};
 	uint8_t output[4];
 	size_t out_len;
@@ -1423,13 +1423,13 @@ ZTEST(cbor_encode_test3, test_union_int)
 	size_t num_encode;
 	uint8_t output[60];
 
-	input.union_choice = union_uint5_l;
+	input.union_choice = union_uint5_l_c;
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_UnionInt2(output, sizeof(output),
 			&input, &num_encode), NULL);
 	zassert_equal(sizeof(exp_union_int_payload1), num_encode, NULL);
 	zassert_mem_equal(exp_union_int_payload1, output, num_encode, NULL);
 
-	input.union_choice = union_uint1000_l;
+	input.union_choice = union_uint1000_l_c;
 	input.bstr.len = 16;
 	input.bstr.value = (uint8_t *)&"This is thousand";
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_UnionInt2(output, sizeof(output),
@@ -1437,15 +1437,15 @@ ZTEST(cbor_encode_test3, test_union_int)
 	zassert_equal(sizeof(exp_union_int_payload2), num_encode, NULL);
 	zassert_mem_equal(exp_union_int_payload2, output, num_encode, NULL);
 
-	input.union_choice = union_nint_l;
-	input.number_m.number_choice = number_int;
+	input.union_choice = union_nint_l_c;
+	input.number_m.number_choice = number_int_c;
 	input.number_m.Int = 1;
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_UnionInt2(output, sizeof(output),
 			&input, &num_encode), NULL);
 	zassert_equal(sizeof(exp_union_int_payload3), num_encode, NULL);
 	zassert_mem_equal(exp_union_int_payload3, output, num_encode, NULL);
 
-	input.union_choice = UnionInt2_union_Structure_One_m;
+	input.union_choice = UnionInt2_union_Structure_One_m_c;
 	input.Structure_One_m.some_array.value = (uint8_t *)&"hi";
 	input.Structure_One_m.some_array.len = 2;
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_UnionInt2(output, sizeof(output),

--- a/tests/encode/test4_senml/src/main.c
+++ b/tests/encode/test4_senml/src/main.c
@@ -44,7 +44,7 @@ ZTEST(cbor_encode_test4, test_senml)
 			.record_t_present = 1,
 			.record_union = {
 				.union_vb = true,
-				.record_union_choice = union_vb,
+				.record_union_choice = union_vb_c,
 			},
 			.record_union_present = 1,
 			.record_key_value_pair_m_count = 0,

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -1250,12 +1250,12 @@ class CddlXcoder(CddlParser):
         return self.var_name() + "_choice"
 
     # Name of the enum entry for this element.
-    def enum_var_name(self, int_val=False):
-        if not int_val:
-            retval = self.var_name(with_prefix=True)
-        else:
-            retval = f"{self.var_name(with_prefix=True)} = {self.int_val()}"
-        return retval
+    def enum_var_name(self):
+        return self.var_name(with_prefix=True) + "_c"
+
+    # Enum entry for this element.
+    def enum_var(self, int_val=False):
+        return f"{self.enum_var_name()} = {self.int_val()}" if int_val else self.enum_var_name()
 
     # Full "path" of the "choice" variable for this element.
     def choice_var_access(self):
@@ -1778,7 +1778,7 @@ class CodeGenerator(CddlXcoder):
     # Declaration of the "choice" variable for this element.
     def anonymous_choice_var(self):
         var = self.enclose(
-            "enum", [val.enum_var_name(self.all_children_int_disambiguated())
+            "enum", [val.enum_var(self.all_children_int_disambiguated())
                      + "," for val in self.value])
         return var
 


### PR DESCRIPTION
This is to make them different from the data elements they refer to, since in C++ they occupy the same namespace, causing compilation errors.

Most of the patch is changing samples and tests to match the new naming.

Fixes #314 and https://github.com/zephyrproject-rtos/zephyr/issues/54092