### PR TITLE
zcbor_decode: Add _pexpect() functions

### DIFF
--- a/include/zcbor_decode.h
+++ b/include/zcbor_decode.h
@@ -77,7 +77,7 @@ bool zcbor_float32_64_decode(zcbor_state_t *state, double *result); /* IEEE754 f
 bool zcbor_float64_decode(zcbor_state_t *state, double *result); /* IEEE754 float64 */
 bool zcbor_float_decode(zcbor_state_t *state, double *result); /* IEEE754 float16, float32, or float64 */
 
-/** The following applies to all _expect() functions listed directly below.
+/** The following applies to all _expect() and _pexpect() functions listed directly below.
  *
  * @param[inout] state     The current state of the decoding.
  * @param[in]    expected  The expected value.
@@ -106,6 +106,24 @@ bool zcbor_float32_expect(zcbor_state_t *state, float expected); /* IEEE754 floa
 bool zcbor_float32_64_expect(zcbor_state_t *state, double expected); /* IEEE754 float32 or float64 */
 bool zcbor_float64_expect(zcbor_state_t *state, double expected); /* IEEE754 float64 */
 bool zcbor_float_expect(zcbor_state_t *state, double expected); /* IEEE754 float16, float32, or float64 */
+
+/** Like the _expect() functions but the value is passed through a pointer.
+ * (for use as a zcbor_decoder_t function) */
+bool zcbor_int32_pexpect(zcbor_state_t *state, int32_t *expected); /* pint/nint */
+bool zcbor_int64_pexpect(zcbor_state_t *state, int64_t *expected); /* pint/nint */
+bool zcbor_uint32_pexpect(zcbor_state_t *state, uint32_t *expected); /* pint */
+bool zcbor_uint64_pexpect(zcbor_state_t *state, uint64_t *expected); /* pint */
+bool zcbor_size_pexpect(zcbor_state_t *state, size_t *expected); /* pint */
+bool zcbor_tag_pexpect(zcbor_state_t *state, uint32_t *expected); /* CBOR tag */
+bool zcbor_simple_pexpect(zcbor_state_t *state, uint8_t *expected); /* CBOR simple value */
+bool zcbor_bool_pexpect(zcbor_state_t *state, bool *expected); /* boolean CBOR simple value */
+bool zcbor_float16_pexpect(zcbor_state_t *state, float *expected); /* IEEE754 float16 */
+bool zcbor_float16_bytes_pexpect(zcbor_state_t *state, uint16_t *expected); /* IEEE754 float16 raw bytes */
+bool zcbor_float16_32_pexpect(zcbor_state_t *state, float *expected); /* IEEE754 float16 or float32 */
+bool zcbor_float32_pexpect(zcbor_state_t *state, float *expected); /* IEEE754 float32 */
+bool zcbor_float32_64_pexpect(zcbor_state_t *state, double *expected); /* IEEE754 float32 or float64 */
+bool zcbor_float64_pexpect(zcbor_state_t *state, double *expected); /* IEEE754 float64 */
+bool zcbor_float_pexpect(zcbor_state_t *state, double *expected); /* IEEE754 float16, float32, or float64 */
 
 /** Consume and expect a pint/nint with a certain value, within a union.
  *
@@ -198,6 +216,8 @@ bool zcbor_any_skip(zcbor_state_t *state, void *unused);
  *                           The result pointer is moved @p result_len bytes for
  *                           each call to @p decoder, i.e. @p result refers to
  *                           an array of result variables.
+ *                           Should not be an _expect() function, use
+ *                           _pexpect() instead.
  * @param[out] result        Where to place the decoded values. Must be an array
  *                           of at least @p max_decode elements.
  * @param[in]  result_len    The length of each result variable. Must be the

--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -268,6 +268,12 @@ bool zcbor_int32_expect(zcbor_state_t *state, int32_t expected)
 }
 
 
+bool zcbor_int32_pexpect(zcbor_state_t *state, int32_t *expected)
+{
+	return zcbor_int32_expect(state, *expected);
+}
+
+
 bool zcbor_int64_expect(zcbor_state_t *state, int64_t expected)
 {
 	int64_t actual;
@@ -281,6 +287,12 @@ bool zcbor_int64_expect(zcbor_state_t *state, int64_t expected)
 		ERR_RESTORE(ZCBOR_ERR_WRONG_VALUE);
 	}
 	return true;
+}
+
+
+bool zcbor_int64_pexpect(zcbor_state_t *state, int64_t *expected)
+{
+	return zcbor_int64_expect(state, *expected);
 }
 
 
@@ -304,6 +316,12 @@ bool zcbor_uint32_expect(zcbor_state_t *state, uint32_t expected)
 }
 
 
+bool zcbor_uint32_pexpect(zcbor_state_t *state, uint32_t *expected)
+{
+	return zcbor_uint32_expect(state, *expected);
+}
+
+
 bool zcbor_uint64_expect(zcbor_state_t *state, uint64_t expected)
 {
 	uint64_t actual;
@@ -319,10 +337,22 @@ bool zcbor_uint64_expect(zcbor_state_t *state, uint64_t expected)
 }
 
 
+bool zcbor_uint64_pexpect(zcbor_state_t *state, uint64_t *expected)
+{
+	return zcbor_uint64_expect(state, *expected);
+}
+
+
 #ifdef ZCBOR_SUPPORTS_SIZE_T
 bool zcbor_size_expect(zcbor_state_t *state, size_t expected)
 {
 	return zcbor_uint64_expect(state, expected);
+}
+
+
+bool zcbor_size_pexpect(zcbor_state_t *state, size_t *expected)
+{
+	return zcbor_size_expect(state, *expected);
 }
 #endif
 
@@ -712,6 +742,12 @@ bool zcbor_simple_expect(zcbor_state_t *state, uint8_t expected)
 }
 
 
+bool zcbor_simple_pexpect(zcbor_state_t *state, uint8_t *expected)
+{
+	return zcbor_simple_expect(state, *expected);
+}
+
+
 bool zcbor_nil_expect(zcbor_state_t *state, void *unused)
 {
 	(void)unused;
@@ -750,6 +786,12 @@ bool zcbor_bool_expect(zcbor_state_t *state, bool expected)
 }
 
 
+bool zcbor_bool_pexpect(zcbor_state_t *state, bool *expected)
+{
+	return zcbor_bool_expect(state, *expected);
+}
+
+
 static bool float_check(zcbor_state_t *state, uint8_t additional_val)
 {
 	INITIAL_CHECKS_WITH_TYPE(ZCBOR_MAJOR_TYPE_SIMPLE);
@@ -785,6 +827,12 @@ bool zcbor_float16_bytes_expect(zcbor_state_t *state, uint16_t expected)
 }
 
 
+bool zcbor_float16_bytes_pexpect(zcbor_state_t *state, uint16_t *expected)
+{
+	return zcbor_float16_bytes_expect(state, *expected);
+}
+
+
 bool zcbor_float16_decode(zcbor_state_t *state, float *result)
 {
 	uint16_t value16;
@@ -809,6 +857,12 @@ bool zcbor_float16_expect(zcbor_state_t *state, float expected)
 		ERR_RESTORE(ZCBOR_ERR_WRONG_VALUE);
 	}
 	return true;
+}
+
+
+bool zcbor_float16_pexpect(zcbor_state_t *state, float *expected)
+{
+	return zcbor_float16_expect(state, *expected);
 }
 
 
@@ -838,6 +892,12 @@ bool zcbor_float32_expect(zcbor_state_t *state, float expected)
 }
 
 
+bool zcbor_float32_pexpect(zcbor_state_t *state, float *expected)
+{
+	return zcbor_float32_expect(state, *expected);
+}
+
+
 bool zcbor_float16_32_decode(zcbor_state_t *state, float *result)
 {
 	if (zcbor_float16_decode(state, result)) {
@@ -859,6 +919,12 @@ bool zcbor_float16_32_expect(zcbor_state_t *state, float expected)
 	}
 
 	return true;
+}
+
+
+bool zcbor_float16_32_pexpect(zcbor_state_t *state, float *expected)
+{
+	return zcbor_float16_32_expect(state, *expected);
 }
 
 
@@ -888,6 +954,12 @@ bool zcbor_float64_expect(zcbor_state_t *state, double expected)
 }
 
 
+bool zcbor_float64_pexpect(zcbor_state_t *state, double *expected)
+{
+	return zcbor_float64_expect(state, *expected);
+}
+
+
 bool zcbor_float32_64_decode(zcbor_state_t *state, double *result)
 {
 	float float_result;
@@ -911,6 +983,12 @@ bool zcbor_float32_64_expect(zcbor_state_t *state, double expected)
 	}
 
 	return true;
+}
+
+
+bool zcbor_float32_64_pexpect(zcbor_state_t *state, double *expected)
+{
+	return zcbor_float32_64_expect(state, *expected);
 }
 
 
@@ -941,6 +1019,12 @@ bool zcbor_float_expect(zcbor_state_t *state, double expected)
 	}
 
 	return true;
+}
+
+
+bool zcbor_float_pexpect(zcbor_state_t *state, double *expected)
+{
+	return zcbor_float_expect(state, *expected);
 }
 
 
@@ -1043,6 +1127,12 @@ bool zcbor_tag_expect(zcbor_state_t *state, uint32_t expected)
 		ERR_RESTORE(ZCBOR_ERR_WRONG_VALUE);
 	}
 	return true;
+}
+
+
+bool zcbor_tag_pexpect(zcbor_state_t *state, uint32_t *expected)
+{
+	return zcbor_tag_expect(state, *expected);
 }
 
 

--- a/tests/cases/corner_cases.cddl
+++ b/tests/cases/corner_cases.cddl
@@ -247,3 +247,10 @@ InvalidIdentifiers = [
 	? Ø: 2,
 	? "{[a-z]}",
 ]
+
+Uint64List = [
+	* uint64: uint .size 8,
+	? nint64: nint .size 8,
+	? uint64_lit: 0x0123456789abcdef,
+	* nint64_lit: -0x0123456789abcdef,
+]

--- a/tests/decode/test5_corner_cases/CMakeLists.txt
+++ b/tests/decode/test5_corner_cases/CMakeLists.txt
@@ -52,6 +52,7 @@ set(py_command
     Intmax1
     Intmax2
     InvalidIdentifiers
+    Uint64List
   --decode
   --git-sha-header
   --short-names

--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -2073,4 +2073,34 @@ ZTEST(cbor_decode_test5, test_invalid_identifiers)
 }
 
 
+ZTEST(cbor_decode_test5, test_uint64_list)
+{
+	uint8_t uint64_list_payload1[] = {LIST(8),
+		0x10,
+		0x18, 0x20,
+		0x19, 0x12, 0x34,
+		0x1a, 0x12, 0x34, 0x56, 0x78,
+		0x1b, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
+		0x3b, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
+		0x1b, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+		0x3b, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xee,
+		END
+	};
+
+	struct Uint64List result;
+	size_t num_decode;
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Uint64List(uint64_list_payload1,
+		sizeof(uint64_list_payload1), &result, &num_decode), NULL);
+	zassert_equal(sizeof(uint64_list_payload1), num_decode, NULL);
+
+	zassert_equal(5, result.uint64_count, NULL);
+	zassert_equal(0x10, result.uint64[0], NULL);
+	zassert_equal(0x20, result.uint64[1], NULL);
+	zassert_equal(0x1234, result.uint64[2], NULL);
+	zassert_equal(0x12345678, result.uint64[3], NULL);
+	zassert_equal(0x123456789abcdef0, result.uint64[4], NULL);
+}
+
+
 ZTEST_SUITE(cbor_decode_test5, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
and make sure multi_(en|de)code always uses functions with pointer arguments. This is to avoid problems with register alignment or other issues in the calling conventions of pointer arguments vs. other arguments. E.g. on cortex-m a uint64 as the 2nd argument will be aligned to registers R2 and R3 instead of R1, while a uint32 or a pointer will use R1.

Add test that fails on the previous implementation and is fixed by this change.