### PR TITLE
zcbor_decode: Add validation that data follows canonical CBOR rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If using zcbor with Zephyr, use the [Kconfig options](https://github.com/zephyrp
 
 Name                      | Description
 ------------------------- | -----------
-`ZCBOR_CANONICAL`         | When encoding lists and maps, do not use indefinite length encoding. Enabling `ZCBOR_CANONICAL` increases code size and makes the encoding library more often use state backups.
+`ZCBOR_CANONICAL`         | Assume canonical encoding (AKA "deterministically encoded CBOR"). When encoding lists and maps, do not use indefinite length encoding. Enabling `ZCBOR_CANONICAL` increases code size and makes the encoding library more often use state backups. When decoding, ensure that the incoming data conforms to canonical encoding, i.e. no indefinite length encoding, and always using minimal length encoding (e.g. not using 16 bits to encode a value < 256). Note: the map ordering constraint in canonical encoding is not checked.
 `ZCBOR_VERBOSE`           | Print messages on encoding/decoding errors (`zcbor_print()`), and also a trace message (`zcbor_trace()`) for each decoded value, and in each generated function (when using code generation). Requires `printk` as found in Zephyr.
 `ZCBOR_ASSERTS`           | Enable asserts (`zcbor_assert()`). When they fail, the assert statements instruct the current function to return a `ZCBOR_ERR_ASSERTION` error. If `ZCBOR_VERBOSE` is enabled, a message is printed.
 `ZCBOR_STOP_ON_ERROR`     | Enable the `stop_on_error` functionality. This makes all functions abort their execution if called when an error has already happened.

--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -282,6 +282,7 @@ do { \
 #define ZCBOR_ERR_ELEMS_NOT_PROCESSED 18
 #define ZCBOR_ERR_NOT_AT_END 19
 #define ZCBOR_ERR_MAP_FLAGS_NOT_AVAILABLE 20
+#define ZCBOR_ERR_INVALID_VALUE_ENCODING 21 ///! When ZCBOR_CANONICAL is defined, and the incoming data is not encoded with minimal length.
 #define ZCBOR_ERR_UNKNOWN 31
 
 /** The largest possible elem_count. */

--- a/tests/decode/test9_manifest14/testcase.yaml
+++ b/tests/decode/test9_manifest14/testcase.yaml
@@ -2,7 +2,7 @@ tests:
   zcbor.decode.test9_manifest14:
     platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
     tags: zcbor decode manifest14 test9
-  zcbor.cbor_decode.test9_manifest16:
+  zcbor.cbor_decode.test9_manifest16.canonical:
     platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
-    tags: zcbor decode manifest16 test9
-    extra_args: MANIFEST=manifest16
+    tags: zcbor decode manifest16 test9 canonical
+    extra_args: MANIFEST=manifest16 CANONICAL=ON

--- a/tests/unit/test1_unit_tests/src/main.c
+++ b/tests/unit/test1_unit_tests/src/main.c
@@ -1023,12 +1023,14 @@ ZTEST(zcbor_unit_tests, test_any_skip)
 	size_t exp_elem_count = 10;
 
 	zassert_true(zcbor_uint32_put(state_e, 10), NULL);
-	zassert_true(zcbor_any_skip(state_d, NULL));
+	bool ret = zcbor_any_skip(state_d, NULL);
+	zassert_true(ret, "err: %d\n", zcbor_peek_error(state_d));
 	zassert_equal(state_d->payload, state_e->payload, NULL);
 	zassert_equal(state_d->elem_count, --exp_elem_count, NULL);
 
 	zassert_true(zcbor_int64_put(state_e, -10000000000000), NULL);
-	zassert_true(zcbor_any_skip(state_d, NULL));
+	ret = zcbor_any_skip(state_d, NULL);
+	zassert_true(ret, "err: %d\n", zcbor_peek_error(state_d));
 	zassert_equal(state_d->payload, state_e->payload, NULL);
 	zassert_equal(state_d->elem_count, --exp_elem_count, NULL);
 
@@ -1060,7 +1062,8 @@ ZTEST(zcbor_unit_tests, test_any_skip)
 	zassert_true(zcbor_bool_put(state_e, true), NULL);
 	zassert_true(zcbor_float64_put(state_e, 3.14), NULL);
 	zassert_true(zcbor_list_end_encode(state_e, 6), NULL);
-	zassert_true(zcbor_any_skip(state_d, NULL));
+	ret = zcbor_any_skip(state_d, NULL);
+	zassert_true(ret, "err: %d\n", zcbor_peek_error(state_d));
 	zassert_equal(state_d->payload, state_e->payload, NULL);
 	zassert_equal(state_d->elem_count, --exp_elem_count, NULL);
 

--- a/tests/unit/test1_unit_tests/testcase.yaml
+++ b/tests/unit/test1_unit_tests/testcase.yaml
@@ -7,3 +7,5 @@ tests:
   zcbor.unit.test1: {}
   zcbor.unit.test1.map_smart_search:
     extra_args: MAP_SMART_SEARCH=ON
+  zcbor.unit.test1.canonical:
+    extra_args: CANONICAL=ON

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -2586,11 +2586,12 @@ Generated with a --default-max-qty of {self.default_max_qty}"""
                     type_names[type_name] = type_def[0]
                     out_types.append(type_def)
                 else:
-                    assert (
-                        ''.join(type_names[type_name]) == ''.join(type_def[0])), \
-                        "Two elements share the type name %s, but their implementations are not " \
-                        + "identical. Please change one or both names. One of them is %s" \
-                        % (type_name, pformat(mtype.type_def()))
+                    assert (''.join(type_names[type_name]) == ''.join(type_def[0])), f"""
+Two elements share the type name {type_name}, but their implementations are not identical.
+Please change one or both names. They are
+{linesep.join(type_names[type_name])}
+and
+{linesep.join(type_def[0])}"""
         return out_types
 
     # Return a list of encoder/decoder functions for all defined types, with duplicate


### PR DESCRIPTION
When ZCBOR_CANONICAL is enabled.