### PR TITLE
zcbor_decode.c: Fix "'num_decode' may be used uninitialized"

### DIFF
--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -1470,7 +1470,7 @@ bool zcbor_present_decode(bool *present,
 		zcbor_state_t *state,
 		void *result)
 {
-	size_t num_decode;
+	size_t num_decode = 0;
 	bool retval = zcbor_multi_decode(0, 1, &num_decode, decoder, state, result, 0);
 
 	zcbor_assert_state(retval, "zcbor_multi_decode should not fail with these parameters.\r\n");


### PR DESCRIPTION
This can happen when ZCBOR_STOP_ON_ERROR is enabled.