### PR TITLE
zcbor_common.h: Add forward declaration for strnlen()

### DIFF
--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -483,6 +483,8 @@ static inline size_t zcbor_flags_to_states(size_t num_flags)
 #define ZCBOR_FLAG_STATES(n_flags) 0
 #endif
 
+size_t strnlen(const char *, size_t);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
For the case when it is not available, and the weak implementation in zcbor_common is used.