### PR TITLE
Fix conversion of UINT8_MAX etc.

### DIFF
--- a/samples/pet/src/pet_decode.c
+++ b/samples/pet/src/pet_decode.c
@@ -32,7 +32,7 @@ static bool decode_Pet(
 	&& ((zcbor_bstr_decode(state, (&(*result).birthday)))
 	&& ((((((*result).birthday.len >= 8)
 	&& ((*result).birthday.len <= 8)) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false))) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false)))
-	&& ((((zcbor_int_decode(state, &(*result).species_choice, sizeof((*result).species_choice)))) && ((((((*result).species_choice == Pet_species_cat_c) && ((1)))
+	&& ((((zcbor_uint_decode(state, &(*result).species_choice, sizeof((*result).species_choice)))) && ((((((*result).species_choice == Pet_species_cat_c) && ((1)))
 	|| (((*result).species_choice == Pet_species_dog_c) && ((1)))
 	|| (((*result).species_choice == Pet_species_other_c) && ((1)))) || (zcbor_error(state, ZCBOR_ERR_WRONG_VALUE), false)))))) || (zcbor_list_map_end_force_decode(state), false)) && zcbor_list_end_decode(state))));
 

--- a/tests/cases/corner_cases.cddl
+++ b/tests/cases/corner_cases.cddl
@@ -242,6 +242,12 @@ Intmax2 = [
 	UINT_64: 0..18446744073709551615,
 ]
 
+Intmax3 = [
+	(254 / 255),
+	int .le 65535,
+	{-128 => bstr .size 127},
+]
+
 InvalidIdentifiers = [
 	? "1one",
 	? Ø: 2,

--- a/tests/decode/test5_corner_cases/CMakeLists.txt
+++ b/tests/decode/test5_corner_cases/CMakeLists.txt
@@ -51,6 +51,7 @@ set(py_command
     UnionInt2
     Intmax1
     Intmax2
+    Intmax3
     InvalidIdentifiers
     Uint64List
     BstrSize

--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -8,6 +8,7 @@
 #include <math.h>
 #include <corner_cases.h>
 #include <zcbor_decode.h>
+#include <zcbor_print.h>
 
 #define CONCAT_BYTE(a,b) a ## b
 
@@ -2019,7 +2020,27 @@ ZTEST(cbor_decode_test5, test_intmax)
 		0x1B, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 		END
 	};
+	uint8_t intmax3_payload1[] = {LIST(3),
+		0x18, 254,
+		0x19, 0xFF, 0xFE,
+		MAP(1),
+			0x38, 127,
+			0x58, 127,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		END
+		END
+	};
+
+
 	struct Intmax2 result2;
+	struct Intmax3 result3;
 	size_t num_decode;
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Intmax1(intmax1_payload1,
@@ -2049,6 +2070,14 @@ ZTEST(cbor_decode_test5, test_intmax)
 	zassert_equal(result2.UINT_32, UINT32_MAX, NULL);
 	zassert_equal(result2.INT_64, INT64_MAX, NULL);
 	zassert_equal(result2.UINT_64, UINT64_MAX, NULL);
+
+	int res = cbor_decode_Intmax3(intmax3_payload1,
+		sizeof(intmax3_payload1), &result3, &num_decode);
+	zassert_equal(ZCBOR_SUCCESS, res, "%s\n", zcbor_error_str(res));
+	zassert_equal(sizeof(intmax3_payload1), num_decode, NULL);
+	zassert_equal(result3.union_choice, Intmax3_union_uint254_c, NULL);
+	zassert_equal(result3.Int, 65534, NULL);
+	zassert_equal(result3.nintbstr.len, 127, NULL);
 }
 
 


### PR DESCRIPTION
The conversion happened prematurely, and caused errors when the value
was compared to ints. Refactor so the conversion happens at the latest
possible point. Add test.

Fixes #387