### PR TITLE
zcbor.py: Fix decoding of unions with aliased values.

### DIFF
--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -2143,7 +2143,7 @@ class CodeGenerator(CddlXcoder):
         assert self.type not in ["LIST", "MAP"], "Must have wrapper function for list or map."
 
         if self.type == "OTHER":
-            return self.my_types[self.value].single_func(access, union_int)
+            return self.my_types[self.value].single_func(access, union_int if self.my_types[self.value].type in ('UINT', 'NINT') else None)
 
         func_name = self.single_func_prim_name(union_int, ptr_result=ptr_result)
         if func_name is None:


### PR DESCRIPTION
* Fix an issue decoding unions where the value is a type alias for things like `nil`.


I hit this issue when prototyping some usage of ZCBOR for ZMK. In particular, I had started with a union type like:

```
core_request = {
    (0: get_lock_state) /
    (1: unlock_request) /
    (2: lock_request)
}

get_lock_state = nil
unlock_request = nil
lock_request = nil
```

Without the change in this PR, this gets generated as:

```
static bool decode_core_request(
		zcbor_state_t *state, struct core_request *result)
{
	zcbor_log("%s\r\n", __func__);

	bool tmp_result = (((zcbor_map_start_decode(state) && ((((((zcbor_uint_decode(state, &(*result).union_choice, sizeof((*result).union_choice)))) && ((((((*result).union_choice == union_get_lock_state_m_c) && (((1)
	&& 1)))
	|| (((*result).union_choice == union_unlock_request_m_c) && (((1)
	&& 1)))
	|| (((*result).union_choice == union_lock_request_m_c) && (((1)
	&& 1)))) || (zcbor_error(state, ZCBOR_ERR_WRONG_VALUE), false)))))) || (zcbor_list_map_end_force_decode(state), false)) && zcbor_map_end_decode(state))));

	if (!tmp_result) {
		zcbor_trace_file(state);
		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
	} else {
		zcbor_log("%s success\r\n", __func__);
	}

	return tmp_result;
}
```

It never bothers dropping the expected 0xF6 value for null in the CBOR message.

If you replace the value in the CDDL with `nil` directly, current `main` does the right thing:

```
core_request = {
    (0: nil) /
    (1: unlock_request) /
    (2: lock_request)
}

get_lock_state = nil
unlock_request = nil
lock_request = nil
```

generates:

```
static bool decode_core_request(
		zcbor_state_t *state, struct core_request *result)
{
	zcbor_log("%s\r\n", __func__);

	bool tmp_result = (((zcbor_map_start_decode(state) && ((((((zcbor_uint_decode(state, &(*result).union_choice, sizeof((*result).union_choice)))) && ((((((*result).union_choice == union_uint0nil_c) && (((1)
	&& (zcbor_nil_expect(state, NULL)))))
	|| (((*result).union_choice == union_unlock_request_m_c) && (((1)
	&& 1)))
	|| (((*result).union_choice == union_lock_request_m_c) && (((1)
	&& 1)))) || (zcbor_error(state, ZCBOR_ERR_WRONG_VALUE), false)))))) || (zcbor_list_map_end_force_decode(state), false)) && zcbor_map_end_decode(state))));

	if (!tmp_result) {
		zcbor_trace_file(state);
		zcbor_log("%s error: %s\r\n", __func__, zcbor_error_str(zcbor_peek_error(state)));
	} else {
		zcbor_log("%s success\r\n", __func__);
	}

	return tmp_result;
}
```

You can see the added `zcbor_nil_expect`.

I tracked this down to the call in `single_func_prim` when we have an `OTHER` value. When this happens, it forwards on the `DROP` value for `union_int`, but that's *different* from the handling in `repeated_xcode` which *only* passes down the `union_int` for the specific types that need it.

This one line change seems to fix my specific use case, but I'm definitely not super familiar with the code, so there may be a better fix than this, for sure. With the code change, the generated code properly calls `zcbor_nil_expect` in all the branches even with type aliases used.