### PR TITLE
zcbor.py: Fix a bug where some decoding function were not called

### DIFF
--- a/tests/cases/corner_cases.cddl
+++ b/tests/cases/corner_cases.cddl
@@ -265,3 +265,18 @@ BstrSize = {
     bstr12,
 }
 bstr12 = ("s" : bstr .size 12)
+
+; found in https://github.com/NordicSemiconductor/zcbor/pull/398
+MapUnionPrimAlias = {
+	(0: 0) /
+	(1: int) /
+	(2: nil) /
+	(3: m_nil) /
+	(4: mm_nil) /
+	(5: m_int) /
+	(6: m_6)
+}
+m_nil = nil
+mm_nil = m_nil
+m_int = int
+m_6 = 6

--- a/tests/decode/test5_corner_cases/CMakeLists.txt
+++ b/tests/decode/test5_corner_cases/CMakeLists.txt
@@ -55,6 +55,7 @@ set(py_command
     InvalidIdentifiers
     Uint64List
     BstrSize
+    MapUnionPrimAlias
   --decode
   --git-sha-header
   --short-names

--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -2151,4 +2151,56 @@ ZTEST(cbor_decode_test5, test_bstr_size)
 }
 
 
+/** Regression test for a bug where some decoding functions were not called
+ *  because of the union_int optimization */
+ZTEST(cbor_decode_test5, test_map_union_prim_alias)
+{
+	uint8_t map_union_prim_alias_payload0[] = {MAP(1), 0, 0, END};
+	uint8_t map_union_prim_alias_payload1[] = {MAP(1), 1, 1, END};
+	uint8_t map_union_prim_alias_payload2[] = {MAP(1), 2, 0xf6, END};
+	uint8_t map_union_prim_alias_payload3[] = {MAP(1), 3, 0xf6, END};
+	uint8_t map_union_prim_alias_payload4[] = {MAP(1), 4, 0xf6, END};
+	uint8_t map_union_prim_alias_payload5[] = {MAP(1), 5, 5, END};
+	uint8_t map_union_prim_alias_payload6[] = {MAP(1), 6, 6, END};
+
+	struct MapUnionPrimAlias result;
+	size_t num_decode;
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_MapUnionPrimAlias(map_union_prim_alias_payload0,
+		sizeof(map_union_prim_alias_payload0), &result, &num_decode), NULL);
+	zassert_equal(sizeof(map_union_prim_alias_payload0), num_decode, NULL);
+	zassert_equal(union_uint0_c, result.union_choice);
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_MapUnionPrimAlias(map_union_prim_alias_payload1,
+		sizeof(map_union_prim_alias_payload1), &result, &num_decode), NULL);
+	zassert_equal(sizeof(map_union_prim_alias_payload1), num_decode, NULL);
+	zassert_equal(union_uint1int_c, result.union_choice);
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_MapUnionPrimAlias(map_union_prim_alias_payload2,
+		sizeof(map_union_prim_alias_payload2), &result, &num_decode), NULL);
+	zassert_equal(sizeof(map_union_prim_alias_payload2), num_decode, NULL);
+	zassert_equal(union_uint2nil_c, result.union_choice);
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_MapUnionPrimAlias(map_union_prim_alias_payload3,
+		sizeof(map_union_prim_alias_payload3), &result, &num_decode), NULL);
+	zassert_equal(sizeof(map_union_prim_alias_payload3), num_decode, NULL);
+	zassert_equal(union_m_nil_m_c, result.union_choice);
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_MapUnionPrimAlias(map_union_prim_alias_payload4,
+		sizeof(map_union_prim_alias_payload4), &result, &num_decode), NULL);
+	zassert_equal(sizeof(map_union_prim_alias_payload4), num_decode, NULL);
+	zassert_equal(union_mm_nil_m_c, result.union_choice);
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_MapUnionPrimAlias(map_union_prim_alias_payload5,
+		sizeof(map_union_prim_alias_payload5), &result, &num_decode), NULL);
+	zassert_equal(sizeof(map_union_prim_alias_payload5), num_decode, NULL);
+	zassert_equal(union_m_int_m_c, result.union_choice);
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_MapUnionPrimAlias(map_union_prim_alias_payload6,
+		sizeof(map_union_prim_alias_payload6), &result, &num_decode), NULL);
+	zassert_equal(sizeof(map_union_prim_alias_payload6), num_decode, NULL);
+	zassert_equal(union_m_6_m_c, result.union_choice);
+}
+
+
 ZTEST_SUITE(cbor_decode_test5, NULL, NULL, NULL, NULL, NULL);

--- a/tests/encode/test3_corner_cases/CMakeLists.txt
+++ b/tests/encode/test3_corner_cases/CMakeLists.txt
@@ -45,6 +45,7 @@ set(py_command
   Intmax1
   Intmax2
   InvalidIdentifiers
+  MapUnionPrimAlias
   -e
   ${bit_arg}
   --short-names

--- a/tests/encode/test3_corner_cases/src/main.c
+++ b/tests/encode/test3_corner_cases/src/main.c
@@ -1551,4 +1551,66 @@ ZTEST(cbor_encode_test3, test_invalid_identifiers)
 }
 
 
+/** Regression test for a bug where some decoding functions were not called
+ *  because of the union_int optimization */
+ZTEST(cbor_encode_test3, test_map_union_prim_alias)
+{
+	uint8_t exp_map_union_prim_alias_payload0[] = {MAP(1), 0, 0, END};
+	uint8_t exp_map_union_prim_alias_payload1[] = {MAP(1), 1, 1, END};
+	uint8_t exp_map_union_prim_alias_payload2[] = {MAP(1), 2, 0xf6, END};
+	uint8_t exp_map_union_prim_alias_payload3[] = {MAP(1), 3, 0xf6, END};
+	uint8_t exp_map_union_prim_alias_payload4[] = {MAP(1), 4, 0xf6, END};
+	uint8_t exp_map_union_prim_alias_payload5[] = {MAP(1), 5, 5, END};
+	uint8_t exp_map_union_prim_alias_payload6[] = {MAP(1), 6, 6, END};
+	uint8_t payload[10];
+
+	struct MapUnionPrimAlias input;
+	size_t num_encode;
+
+	input.union_choice = union_uint0_c;
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_MapUnionPrimAlias(payload,
+		sizeof(payload), &input, &num_encode), NULL);
+	zassert_equal(num_encode, sizeof(exp_map_union_prim_alias_payload0));
+	zassert_mem_equal(exp_map_union_prim_alias_payload0, payload, num_encode);
+
+	input.union_choice = union_uint1int_c;
+	input.uint1int = 1;
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_MapUnionPrimAlias(payload,
+		sizeof(payload), &input, &num_encode), NULL);
+	zassert_equal(num_encode, sizeof(exp_map_union_prim_alias_payload1));
+	zassert_mem_equal(exp_map_union_prim_alias_payload1, payload, num_encode);
+
+	input.union_choice = union_uint2nil_c;
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_MapUnionPrimAlias(payload,
+		sizeof(payload), &input, &num_encode), NULL);
+	zassert_equal(num_encode, sizeof(exp_map_union_prim_alias_payload2));
+	zassert_mem_equal(exp_map_union_prim_alias_payload2, payload, num_encode);
+
+	input.union_choice = union_m_nil_m_c;
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_MapUnionPrimAlias(payload,
+		sizeof(payload), &input, &num_encode), NULL);
+	zassert_equal(num_encode, sizeof(exp_map_union_prim_alias_payload3));
+	zassert_mem_equal(exp_map_union_prim_alias_payload3, payload, num_encode);
+
+	input.union_choice = union_mm_nil_m_c;
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_MapUnionPrimAlias(payload,
+		sizeof(payload), &input, &num_encode), NULL);
+	zassert_equal(num_encode, sizeof(exp_map_union_prim_alias_payload4));
+	zassert_mem_equal(exp_map_union_prim_alias_payload4, payload, num_encode);
+
+	input.union_choice = union_m_int_m_c;
+	input.m_int_m = 5;
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_MapUnionPrimAlias(payload,
+		sizeof(payload), &input, &num_encode), NULL);
+	zassert_equal(num_encode, sizeof(exp_map_union_prim_alias_payload5));
+	zassert_mem_equal(exp_map_union_prim_alias_payload5, payload, num_encode);
+
+	input.union_choice = union_m_6_m_c;
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_MapUnionPrimAlias(payload,
+		sizeof(payload), &input, &num_encode), NULL);
+	zassert_equal(num_encode, sizeof(exp_map_union_prim_alias_payload6));
+	zassert_mem_equal(exp_map_union_prim_alias_payload6, payload, num_encode);
+}
+
+
 ZTEST_SUITE(cbor_encode_test3, NULL, NULL, NULL, NULL, NULL);

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -2405,11 +2405,12 @@ class CodeGenerator(CddlXcoder):
     # Return the full code needed to encode/decode this element, including children,
     # key and cbor, excluding repetitions.
     def repeated_xcode(self, union_int=None):
+        val_union_int = union_int if not self.key else None  # In maps, only pass union_int to key.
         range_checks = self.range_checks(self.val_access())
         xcoder = {
             "INT": self.xcode_single_func_prim,
-            "UINT": lambda: self.xcode_single_func_prim(union_int),
-            "NINT": lambda: self.xcode_single_func_prim(union_int),
+            "UINT": lambda: self.xcode_single_func_prim(val_union_int),
+            "NINT": lambda: self.xcode_single_func_prim(val_union_int),
             "FLOAT": self.xcode_single_func_prim,
             "BSTR": self.xcode_bstr,
             "TSTR": self.xcode_single_func_prim,
@@ -2419,9 +2420,9 @@ class CodeGenerator(CddlXcoder):
             "ANY": self.xcode_single_func_prim,
             "LIST": self.xcode_list,
             "MAP": self.xcode_list,
-            "GROUP": lambda: self.xcode_group(union_int),
+            "GROUP": lambda: self.xcode_group(val_union_int),
             "UNION": self.xcode_union,
-            "OTHER": lambda: self.xcode_single_func_prim(union_int),
+            "OTHER": lambda: self.xcode_single_func_prim(val_union_int),
         }[self.type]
         xcoders = []
         if self.key:


### PR DESCRIPTION
This is a bug in the union_int optimization. In maps, the optimization refers to the key, but was propagated to the value as well, so that in some cases, if the key was optimized away, the value was erroneously optimized away as well.

Thanks to Pete Johanson for finding and debugging this issue!

Fixes #398