### PR TITLE
tests: Update mps2 board name

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -8,14 +8,14 @@ on:
 
 env:
   ZEPHYR_SDK_VERSION: 0.16.5
-  ZEPHYR_REV: v3.6.0
+  ZEPHYR_REV: 5046229bb94cd2683ec1022848991d387152a0d2
 
 jobs:
   merge-test-1:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        platform: ["native_posix", "native_posix_64", "mps2_an521"]
+        platform: ["native_posix", "native_posix_64", "mps2/an521/cpu0"]
         asserts: ["", "-x VERBOSE=ON -x ASSERTS=ON"]
     name: Merge tests 1 (${{ matrix.platform }}${{ matrix.asserts != '' && ' with asserts' || '' }})
     steps:
@@ -29,8 +29,8 @@ jobs:
       uses: ./.github/actions/prepare_and_run_tests
       with:
         twister_arguments: "--timestamps --platform ${{ matrix.platform }} ${{ matrix.asserts }} --exclude-tag release"
-        zephyr_toolchain: ${{ matrix.platform == 'mps2_an521' && 'zephyr' || 'host'}}
-        zephyr_toolchain_arch: ${{ matrix.platform == 'mps2_an521' && 'arm' || ''}}
+        zephyr_toolchain: ${{ matrix.platform == 'mps2/an521/cpu0' && 'zephyr' || 'host'}}
+        zephyr_toolchain_arch: ${{ matrix.platform == 'mps2/an521/cpu0' && 'arm' || ''}}
 
   merge-test-2:
     runs-on: ubuntu-22.04
@@ -207,7 +207,7 @@ jobs:
     - name: Prepare and run tests
       uses: ./.github/actions/prepare_and_run_tests
       with:
-        twister_arguments: "--timestamps --platform native_posix --platform native_posix_64 --platform mps2_an521 --platform qemu_malta_be ${{ matrix.asserts }}"
+        twister_arguments: "--timestamps --platform native_posix --platform native_posix_64 --platform mps2/an521/cpu0 --platform qemu_malta/qemu_malta/be ${{ matrix.asserts }}"
         zephyr_toolchain: zephyr
         zephyr_toolchain_arch: arm,mips
 

--- a/tests/be_test.sh
+++ b/tests/be_test.sh
@@ -9,4 +9,4 @@ if [[ -z "$ZEHPYR_BASE" ]]; then
         ZEPHYR_BASE=$(west topdir)/zephyr
 fi
 
-$ZEPHYR_BASE/scripts/twister -M -v -T . -W --platform qemu_malta_be $*
+$ZEPHYR_BASE/scripts/twister -M -v -T . -W --platform qemu_malta/qemu_malta/be $*

--- a/tests/decode/test1_suit_old_formats/testcase.yaml
+++ b/tests/decode/test1_suit_old_formats/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   zcbor.decode.test1_suit_old_formats:
-    platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+    platform_allow: native_posix native_posix_64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor decode test1

--- a/tests/decode/test2_suit/testcase.yaml
+++ b/tests/decode/test2_suit/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   zcbor.decode.test2_suit:
-    platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+    platform_allow: native_posix native_posix_64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor decode test2

--- a/tests/decode/test3_simple/testcase.yaml
+++ b/tests/decode/test3_simple/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   zcbor.decode.test3_simple:
-    platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+    platform_allow: native_posix native_posix_64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor decode test3

--- a/tests/decode/test5_corner_cases/testcase.yaml
+++ b/tests/decode/test5_corner_cases/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   zcbor.decode.test5_corner_cases:
-    platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+    platform_allow: native_posix native_posix_64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor decode test5
   zcbor.decode.test5_corner_cases.indefinite_length_arrays:
-    platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+    platform_allow: native_posix native_posix_64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor decode test5 indefinite
     extra_args: TEST_INDEFINITE_LENGTH_ARRAYS=1

--- a/tests/decode/test7_suit9_simple/testcase.yaml
+++ b/tests/decode/test7_suit9_simple/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   zcbor.decode.test7_suit9_simple:
-    platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+    platform_allow: native_posix native_posix_64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor decode test7

--- a/tests/decode/test8_suit12/testcase.yaml
+++ b/tests/decode/test8_suit12/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   zcbor.decode.test8_suit12:
-    platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+    platform_allow: native_posix native_posix_64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor decode test8

--- a/tests/decode/test9_manifest14/testcase.yaml
+++ b/tests/decode/test9_manifest14/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   zcbor.decode.test9_manifest14:
-    platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+    platform_allow: native_posix native_posix_64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor decode manifest14 test9
   zcbor.cbor_decode.test9_manifest16.canonical:
-    platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+    platform_allow: native_posix native_posix_64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor decode manifest16 test9 canonical
     extra_args: MANIFEST=manifest16 CANONICAL=ON

--- a/tests/encode/test1_suit/testcase.yaml
+++ b/tests/encode/test1_suit/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
   zcbor.encode.test1_suit.canonical:
-    platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+    platform_allow: native_posix native_posix_64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor encode canonical test1
     extra_args: CANONICAL=CANONICAL

--- a/tests/encode/test2_simple/testcase.yaml
+++ b/tests/encode/test2_simple/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   zcbor.encode.test2_simple:
-    platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+    platform_allow: native_posix native_posix_64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor encode test
   zcbor.encode.test2_simple.canonical:
-    platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+    platform_allow: native_posix native_posix_64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor encode canonical test
     extra_args: CANONICAL=CANONICAL

--- a/tests/encode/test3_corner_cases/testcase.yaml
+++ b/tests/encode/test3_corner_cases/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   zcbor.encode.test3_corner_cases:
-    platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+    platform_allow: native_posix native_posix_64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor encode test3
   zcbor.encode.test3_corner_cases.canonical:
-    platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+    platform_allow: native_posix native_posix_64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor encode canonical test3
     extra_args: CANONICAL=CANONICAL

--- a/tests/encode/test4_senml/testcase.yaml
+++ b/tests/encode/test4_senml/testcase.yaml
@@ -1,8 +1,8 @@
 tests:
   zcbor.encode.test4_senml:
-    platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+    platform_allow: native_posix native_posix_64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor encode test4
   zcbor.encode.test4_senml.canonical:
-    platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+    platform_allow: native_posix native_posix_64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor encode canonical test4
     extra_args: CANONICAL=CANONICAL

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -14,4 +14,4 @@ if [[ -z "$ZEHPYR_BASE" ]]; then
         ZEPHYR_BASE=$(west topdir)/zephyr
 fi
 
-$ZEPHYR_BASE/scripts/twister -M -v -T . -W --exclude-tag release --platform native_posix --platform native_posix_64 --platform mps2_an521 $*
+$ZEPHYR_BASE/scripts/twister -M -v -T . -W --exclude-tag release --platform native_posix --platform native_posix_64 --platform mps2/an521/cpu0 $*

--- a/tests/unit/test1_unit_tests/testcase.yaml
+++ b/tests/unit/test1_unit_tests/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  platform_allow: native_posix native_posix_64 mps2_an521 qemu_malta_be
+  platform_allow: native_posix native_posix_64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
   tags: zcbor unit
   timeout: 120  # Because of test_size64
 

--- a/tests/unit/test2_cpp/testcase.yaml
+++ b/tests/unit/test2_cpp/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   zcbor.unit.test2:
-    platform_allow: mps2_an521 qemu_malta_be
+    platform_allow: mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor unit cpp
 common: 
   harness: console

--- a/tests/unit/test3_float16/testcase.yaml
+++ b/tests/unit/test3_float16/testcase.yaml
@@ -4,6 +4,6 @@ tests:
     tags: zcbor unit float16
     timeout: 240
   zcbor.unit.test3.release:
-    platform_allow: mps2_an521 qemu_malta_be
+    platform_allow: mps2/an521/cpu0 qemu_malta/qemu_malta/be
     tags: zcbor unit float16 release
     timeout: 7200


### PR DESCRIPTION
Updates the board name used by tests to account for the change when moving to hwmv2 in zephyr