### PR TITLE
run-tests.yaml: Update versions of Zephyr and Zephyr SDK

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -7,8 +7,8 @@ on:
 
 
 env:
-  ZEPHYR_SDK_VERSION: 0.16.4
-  ZEPHYR_REV: v3.6.0-rc2
+  ZEPHYR_SDK_VERSION: 0.16.5
+  ZEPHYR_REV: v3.6.0
 
 jobs:
   merge-test-1:


### PR DESCRIPTION
that are used to run the CI tests.
Zephyr 3.6.0-rc2 -> 3.6.0
Zephyr SDK 0.16.4 -> 0.16.5