### PR TITLE
tests: Move LIST() and MAP() macros to dedicated header file

### DIFF
--- a/tests/cmake/test_template.cmake
+++ b/tests/cmake/test_template.cmake
@@ -3,6 +3,7 @@ FILE(GLOB app_sources_cpp src/*.cpp)
 target_sources(app PRIVATE
   ${app_sources} ${app_sources_cpp}
   )
+target_include_directories(app PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../include)
 
 if (VERBOSE)
   zephyr_compile_definitions(ZCBOR_VERBOSE)

--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -8,33 +8,8 @@
 #include <math.h>
 #include <corner_cases.h>
 #include <zcbor_decode.h>
+#include <common_test.h>
 #include <zcbor_print.h>
-
-#define CONCAT_BYTE(a,b) a ## b
-
-#ifdef TEST_INDEFINITE_LENGTH_ARRAYS
-#define LIST(num) 0x9F /* Use short count 31 (indefinite-length). Note that the 'num' argument is ignored */
-#define LIST2(num) 0x9F /* Use short count 31 (indefinite-length). Note that the 'num' argument is ignored */
-#define LIST3(num) 0x9F /* Use short count 31 (indefinite-length). Note that the 'num' argument is ignored */
-#define MAP(num) 0xBF  /* Use short count 31 (indefinite-length). Note that the 'num' argument is ignored */
-#define ARR_ERR1 ZCBOR_ERR_WRONG_TYPE
-#define ARR_ERR2 ZCBOR_ERR_NO_PAYLOAD
-#define ARR_ERR3 ZCBOR_ERR_WRONG_TYPE
-#define ARR_ERR4 ZCBOR_ERR_PAYLOAD_NOT_CONSUMED
-#define END 0xFF,
-#define STR_LEN(len, lists) (len + lists)
-#else
-#define LIST(num) CONCAT_BYTE(0x8, num)
-#define LIST2(num) CONCAT_BYTE(0x9, num)
-#define LIST3(num) 0x98, num
-#define MAP(num) CONCAT_BYTE(0xA, num)
-#define ARR_ERR1 ZCBOR_ERR_HIGH_ELEM_COUNT
-#define ARR_ERR2 ZCBOR_ERR_HIGH_ELEM_COUNT
-#define ARR_ERR3 ZCBOR_ERR_NO_PAYLOAD
-#define ARR_ERR4 ZCBOR_ERR_NO_PAYLOAD
-#define END
-#define STR_LEN(len, lists) (len)
-#endif
 
 
 ZTEST(cbor_decode_test5, test_numbers)

--- a/tests/encode/test2_simple/src/main.c
+++ b/tests/encode/test2_simple/src/main.c
@@ -8,26 +8,10 @@
 #include <pet_encode.h>
 #include <zcbor_encode.h>
 
-
-#define CONCAT_BYTE(a,b) a ## b
-
-/* LIST() adds a start byte for a list with 'num' elements.
- * MAP() does the same, but for a map.
- * END adds an end byte for the list/map.
- *
- * With ZCBOR_CANONICAL, the start byte contains the list, so no end byte is
- * needed. Without ZCBOR_CANONICAL, the start byte is the same no matter
- * the number of elements, so it needs an explicit end byte.
- */
 #ifndef ZCBOR_CANONICAL
-#define LIST(num) 0x9F
-#define MAP(num) 0xBF
-#define END 0xFF,
-#else
-#define LIST(num) CONCAT_BYTE(0x8, num)
-#define MAP(num) CONCAT_BYTE(0xA, num)
-#define END
+#define TEST_INDEFINITE_LENGTH_ARRAYS
 #endif
+#include <common_test.h>
 
 
 /* This test uses generated code to encode a 'Pet' instance. It populates the

--- a/tests/encode/test3_corner_cases/src/main.c
+++ b/tests/encode/test3_corner_cases/src/main.c
@@ -7,17 +7,10 @@
 #include <zephyr/ztest.h>
 #include "corner_cases_encode.h"
 
-#define CONCAT_BYTE(a,b) a ## b
-
 #ifndef ZCBOR_CANONICAL
-#define LIST(num) 0x9F
-#define MAP(num) 0xBF
-#define END 0xFF,
-#else
-#define LIST(num) CONCAT_BYTE(0x8, num)
-#define MAP(num) CONCAT_BYTE(0xA, num)
-#define END
+#define TEST_INDEFINITE_LENGTH_ARRAYS
 #endif
+#include <common_test.h>
 
 
 ZTEST(cbor_encode_test3, test_numbers)
@@ -1007,7 +1000,7 @@ ZTEST(cbor_encode_test3, test_value_range)
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_ValueRange(output, sizeof(output), &input1,
 				&out_len), NULL);
-	zassert_equal(sizeof(exp_payload_value_range1), out_len, NULL);
+	zassert_equal(sizeof(exp_payload_value_range1), out_len, "%d != %d\n", sizeof(exp_payload_value_range1), out_len);
 	zassert_mem_equal(exp_payload_value_range1, output, sizeof(exp_payload_value_range1), NULL);
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_ValueRange(output, sizeof(output), &input2,

--- a/tests/encode/test4_senml/src/main.c
+++ b/tests/encode/test4_senml/src/main.c
@@ -7,27 +7,10 @@
 #include <zephyr/ztest.h>
 #include "senml_encode.h"
 
-
-
-#define CONCAT_BYTE(a,b) a ## b
-
-/* LIST() adds a start byte for a list with 'num' elements.
- * MAP() does the same, but for a map.
- * END adds an end byte for the list/map.
- *
- * With ZCBOR_CANONICAL, the start byte contains the list, so no end byte is
- * needed. Without ZCBOR_CANONICAL, the start byte is the same no matter
- * the number of elements, so it needs an explicit end byte.
- */
 #ifndef ZCBOR_CANONICAL
-#define LIST(num) 0x9F
-#define MAP(num) 0xBF
-#define END 0xFF,
-#else
-#define LIST(num) CONCAT_BYTE(0x8, num)
-#define MAP(num) CONCAT_BYTE(0xA, num)
-#define END
+#define TEST_INDEFINITE_LENGTH_ARRAYS
 #endif
+#include <common_test.h>
 
 ZTEST(cbor_encode_test4, test_senml)
 {

--- a/tests/include/common_test.h
+++ b/tests/include/common_test.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef COMMON_TEST_H__
+#define COMMON_TEST_H__
+
+#define CONCAT_BYTE(a,b) a ## b
+
+#ifdef TEST_INDEFINITE_LENGTH_ARRAYS
+#define LIST(num) 0x9F /* Use short count 31 (indefinite-length). Note that the 'num' argument is ignored */
+#define LIST2(num) 0x9F /* Use short count 31 (indefinite-length). Note that the 'num' argument is ignored */
+#define LIST3(num) 0x9F /* Use short count 31 (indefinite-length). Note that the 'num' argument is ignored */
+#define MAP(num) 0xBF  /* Use short count 31 (indefinite-length). Note that the 'num' argument is ignored */
+#define ARR_ERR1 ZCBOR_ERR_WRONG_TYPE
+#define ARR_ERR2 ZCBOR_ERR_NO_PAYLOAD
+#define ARR_ERR3 ZCBOR_ERR_WRONG_TYPE
+#define ARR_ERR4 ZCBOR_ERR_PAYLOAD_NOT_CONSUMED
+#define END 0xFF,
+#define STR_LEN(len, lists) (len + lists)
+#else
+#define LIST(num) CONCAT_BYTE(0x8, num)
+#define LIST2(num) CONCAT_BYTE(0x9, num)
+#define LIST3(num) 0x98, num
+#define MAP(num) CONCAT_BYTE(0xA, num)
+#define ARR_ERR1 ZCBOR_ERR_HIGH_ELEM_COUNT
+#define ARR_ERR2 ZCBOR_ERR_HIGH_ELEM_COUNT
+#define ARR_ERR3 ZCBOR_ERR_NO_PAYLOAD
+#define ARR_ERR4 ZCBOR_ERR_NO_PAYLOAD
+#define END
+#define STR_LEN(len, lists) (len)
+#endif
+
+#endif /* COMMON_TEST_H__ */


### PR DESCRIPTION
instead of duplicating in all tests