### PR TITLE
zcbor.py: Fix a few bugs in code generation to do with dereferencing

### DIFF
--- a/scripts/requirements-test.txt
+++ b/scripts/requirements-test.txt
@@ -1,4 +1,4 @@
-pyelftools==0.26
+pyelftools
 pycodestyle
 west
 ecdsa

--- a/tests/cases/corner_cases.cddl
+++ b/tests/cases/corner_cases.cddl
@@ -354,3 +354,10 @@ EmptyGroup = ()
 EmptyList = []
 
 EmptyContainer = [int, EmptyGroup, EmptyList, EmptyMap]
+
+SingleElemList = [
+    [tstr],
+    [[MyInt]],
+    [true],
+    {1: bstr},
+]

--- a/tests/decode/test5_corner_cases/CMakeLists.txt
+++ b/tests/decode/test5_corner_cases/CMakeLists.txt
@@ -56,6 +56,7 @@ set(py_command
     MapUnionPrimAlias
     Keywords
     EmptyContainer
+    SingleElemList
   --decode
   --git-sha-header
   --short-names

--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -2224,4 +2224,28 @@ ZTEST(cbor_decode_test5, test_empty_group)
 }
 
 
+ZTEST(cbor_decode_test5, test_single_elem_list)
+{
+	uint8_t single_elem_list_payload1[] = {LIST(4),
+		LIST(1), 0x61, 's', END
+		LIST(1), LIST(1), 0, END END
+		LIST(1), 0xf5, END
+		MAP(1), 1, 0x41, 0x02, END
+		END
+	};
+
+	struct SingleElemList result;
+	size_t num_decode;
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_SingleElemList(single_elem_list_payload1,
+		sizeof(single_elem_list_payload1), &result, &num_decode), NULL);
+	zassert_equal(sizeof(single_elem_list_payload1), num_decode, NULL);
+	zassert_equal(1, result.tstr.len);
+	zassert_equal('s', result.tstr.value[0]);
+	zassert_equal(0, result.MyInt_m);
+	zassert_equal(1, result.uint1bstr.len);
+	zassert_equal(2, result.uint1bstr.value[0]);
+}
+
+
 ZTEST_SUITE(cbor_decode_test5, NULL, NULL, NULL, NULL, NULL);

--- a/tests/encode/test3_corner_cases/CMakeLists.txt
+++ b/tests/encode/test3_corner_cases/CMakeLists.txt
@@ -47,6 +47,7 @@ set(py_command
   InvalidIdentifiers
   MapUnionPrimAlias
   EmptyContainer
+  SingleElemList
   -e
   ${bit_arg}
   --short-names

--- a/tests/encode/test3_corner_cases/src/main.c
+++ b/tests/encode/test3_corner_cases/src/main.c
@@ -1622,4 +1622,31 @@ ZTEST(cbor_encode_test3, test_empty_group)
 }
 
 
+ZTEST(cbor_encode_test3, test_single_elem_list)
+{
+	uint8_t exp_single_elem_list_payload1[] = {LIST(4),
+		LIST(1), 0x61, 's', END
+		LIST(1), LIST(1), 0, END END
+		LIST(1), 0xf5, END
+		MAP(1), 1, 0x41, 0x02, END
+		END
+	};
+
+	struct SingleElemList input = {
+		.tstr.len = 1,
+		.tstr.value = &(uint8_t){'s'},
+		.MyInt_m = 0,
+		.uint1bstr.len = 1,
+		.uint1bstr.value = &(uint8_t){2},
+	};
+	size_t num_encode;
+	uint8_t payload[20];
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_SingleElemList(payload,
+		sizeof(payload), &input, &num_encode), NULL);
+	zassert_equal(num_encode, sizeof(exp_single_elem_list_payload1));
+	zassert_mem_equal(exp_single_elem_list_payload1, payload, num_encode);
+}
+
+
 ZTEST_SUITE(cbor_encode_test3, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
- Two elements with different names referring to the same value were generated
- Sometimes a value was attempted dereferenced as result->somevalue, but it should have been just result.

This introduces the concept of delegated types, where the a type takes on the C type of one of its children. This was handled via a shortcut that failed for certain corner cases.

This also refactors the "skip" mechanism which was inconsistently referring to itself or its parent, as part of the shortcut mentioned above.

Add tests