### PR TITLE
MIGRATION_GUIDE.md: Add a migration guide file

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,0 +1,43 @@
+# zcbor v. 0.8.99
+
+* `zcbor_simple_*()` functions have been removed to avoid confusion about their use.
+  They are still in the C file because they are used by other functions.
+  Instead, use the specific functions for the currently supported simple values, i.e.
+  `zcbor_bool_*()`, `zcbor_nil_*()`, and `zcbor_undefined_*()`.
+  If a removed variant is strictly needed, add your own forward declaration in your code.
+
+* Code generation naming:
+
+  * More C keywords are now capitalized to avoid naming collision.
+    You might have to capitalize some instances if your code was generated to have those names.
+
+  * A fix was made to the naming of bstr elements with a .size specifier, which might mean that these elements change name in your code when you regenerate.
+
+
+# zcbor v. 0.8.0
+
+(copied after the fact from [Zephyr 3.6.0 migration guide](https://github.com/zephyrproject-rtos/zephyr/blob/v3.6.0/doc/releases/migration-guide-3.6.rst))
+
+* If you have zcbor-generated code that relies on the zcbor libraries through Zephyr, you must
+  regenerate the files using zcbor 0.8.1. Note that the names of generated types and members has
+  been overhauled, so the code using the generated code must likely be changed.
+  For example:
+
+  * Leading single underscores and all double underscores are largely gone,
+  * Names sometimes gain suffixes like ``_m`` or ``_l`` for disambiguation.
+  * All enum (choice) names have now gained a ``_c`` suffix, so the enum name no longer matches
+    the corresponding member name exactly (because this broke C++ namespace rules).
+
+* The function `zcbor_new_state`, `zcbor_new_decode_state` and the macro
+  `ZCBOR_STATE_D` have gained new parameters related to decoding of unordered maps.
+  Unless you are using that new functionality, these can all be set to NULL or 0.
+
+* The functions `zcbor_bstr_put_term` and `zcbor_tstr_put_term` have gained a new
+  parameter ``maxlen``, referring to the maximum length of the parameter ``str``.
+  This parameter is passed directly to `strnlen` under the hood.
+
+* The function `zcbor_tag_encode` has been renamed to `zcbor_tag_put`.
+
+* Printing has been changed significantly, e.g. `zcbor_print` is now called
+  `zcbor_log`, and `zcbor_trace` with no parameters is gone, and in its place are
+  `zcbor_trace_file` and `zcbor_trace`, both of which take a ``state`` parameter.

--- a/tests/scripts/test_versions.py
+++ b/tests/scripts/test_versions.py
@@ -14,6 +14,7 @@ p_script_dir = Path(__file__).absolute().parents[0]
 p_root = p_script_dir.parents[1]
 p_VERSION = p_root / "zcbor" / "VERSION"
 p_release_notes = p_root / "RELEASE_NOTES.md"
+p_migration_guide = p_root / "MIGRATION_GUIDE.md"
 p_HEAD_REF = p_script_dir / "HEAD_REF"
 
 
@@ -39,6 +40,10 @@ class VersionTest(TestCase):
             p_release_notes.read_text(encoding="utf-8").splitlines()[0],
             r"# zcbor v. " + version_number + f" ({date.today():%Y-%m-%d})",
             f"{p_release_notes} has not been updated with the correct version number.")
+        self.assertEqual(
+            p_migration_guide.read_text(encoding="utf-8").splitlines()[0],
+            r"# zcbor v. " + version_number,
+            f"{p_migration_guide} has not been updated with the correct version number.")
 
         tags_stdout, _ = Popen(['git', 'tag'], stdout=PIPE).communicate()
         tags = tags_stdout.decode("utf-8").strip().splitlines()


### PR DESCRIPTION
To be updated at least with each minor version.
Add release test for the version number.
Add entries for changes so far.
Populate the 0.8.0 entry with text from Zephyr migration guide.