### PR TITLE
zcbor.py: Fix bug where NINT literals were not given unique names

### DIFF
--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -790,7 +790,7 @@ ZTEST(cbor_decode_test5, test_map)
 
 	struct Map map;
 
-	zassert_equal(union_nintuint_c, -8,
+	zassert_equal(union_nint8uint_c, -8,
 		"The union_int optimization seems to not be working.\r\n");
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Map(payload_map1, sizeof(payload_map1),
@@ -830,8 +830,8 @@ ZTEST(cbor_decode_test5, test_map)
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Map(payload_map5, sizeof(payload_map5),
 			&map, NULL), NULL);
 	zassert_false(map.listkey, NULL);
-	zassert_equal(union_nintuint_c, map.Union_choice, NULL);
-	zassert_equal(1, map.nintuint, NULL);
+	zassert_equal(union_nint8uint_c, map.Union_choice, NULL);
+	zassert_equal(1, map.nint8uint, NULL);
 	zassert_equal(2, map.twotothree_count, NULL);
 }
 
@@ -1930,7 +1930,7 @@ ZTEST(cbor_decode_test5, test_union_int)
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_UnionInt2(union_int_payload3,
 		sizeof(union_int_payload3), &result2, &num_decode), NULL);
 	zassert_equal(sizeof(union_int_payload3), num_decode, NULL);
-	zassert_equal(result2.Union_choice, union_nint_l_c, NULL);
+	zassert_equal(result2.Union_choice, union_nint100000_l_c, NULL);
 	zassert_equal(result2.number_m.number_choice, number_int_c, NULL);
 	zassert_equal(result2.number_m.Int, 1, NULL);
 
@@ -2052,7 +2052,7 @@ ZTEST(cbor_decode_test5, test_intmax)
 	zassert_equal(sizeof(intmax3_payload1), num_decode, NULL);
 	zassert_equal(result3.Union_choice, Intmax3_union_uint254_c, NULL);
 	zassert_equal(result3.Int, 65534, NULL);
-	zassert_equal(result3.nintbstr.len, 127, NULL);
+	zassert_equal(result3.nint128bstr.len, 127, NULL);
 }
 
 

--- a/tests/encode/test3_corner_cases/src/main.c
+++ b/tests/encode/test3_corner_cases/src/main.c
@@ -627,8 +627,8 @@ ZTEST(cbor_encode_test3, test_map)
 		}
 	};
 	struct Map map3 = {
-		.Union_choice = union_nintuint_c,
-		.nintuint = 1,
+		.Union_choice = union_nint8uint_c,
+		.nint8uint = 1,
 		.twotothree_count = 2,
 		.twotothree = {
 			{.twotothree = {.value = "hello", .len = 5}},
@@ -1429,7 +1429,7 @@ ZTEST(cbor_encode_test3, test_union_int)
 	zassert_equal(sizeof(exp_union_int_payload2), num_encode, NULL);
 	zassert_mem_equal(exp_union_int_payload2, output, num_encode, NULL);
 
-	input.Union_choice = union_nint_l_c;
+	input.Union_choice = union_nint100000_l_c;
 	input.number_m.number_choice = number_int_c;
 	input.number_m.Int = 1;
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_UnionInt2(output, sizeof(output),

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -352,8 +352,8 @@ class CddlParser:
             or (f"{self.value.replace(self.backslash_quotation_mark, '')}_{self.type.lower()}"
                 if self.type == "TSTR" and self.value is not None else None)
             # Name an integer by its expected value:
-            or (f"{self.type.lower()}{self.value}"
-                if self.type in ["INT", "UINT"] and self.value is not None else None)
+            or (f"{self.type.lower()}{abs(self.value)}"
+                if self.type in ["INT", "UINT", "NINT"] and self.value is not None else None)
             # Name a type by its type name
             or (next((key for key, value in self.my_types.items() if value == self), None))
             # Name a control group by its name


### PR DESCRIPTION
For positive integers, the value is part of the name, but this was missed for negative integers. This fixes it.