### PR TITLE
zcbor.py: Add support for unordered maps in generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ usage: zcbor code [-h] -c CDDL [--no-prelude] [-v] [-q]
                   -t ENTRY_TYPES [ENTRY_TYPES ...] [-d] [-e] [--time-header]
                   [--git-sha-header] [-b {8,16,32,64}]
                   [--include-prefix INCLUDE_PREFIX] [-s]
-                  [--file-header FILE_HEADER] [--defines]
+                  [--file-header FILE_HEADER] [--defines] [--unordered-maps]
 
 Parse a CDDL file and produce C code that validates and xcodes CBOR.
 The output from this script is a C file and a header file. The header file
@@ -599,6 +599,16 @@ options:
                         and place them in the generated header file. This is
                         off by default because it may create naming conflicts
                         that don't show up otherwise.
+  --unordered-maps      [EXPERIMENTAL] Generate code in such a way that it can
+                        decode maps with unknown element order. When enabled,
+                        the generated code will use the
+                        zcbor_unordered_map_*() API to decode data whenever
+                        inside a map. zcbor detects from the CDDL whether
+                        ZCBOR_MAP_SMART_SEARCH is needed and enables it in the
+                        generated cmake file if so. Enabling --unordered-maps
+                        places some restrictions on the level of ambiguity
+                        allowed between map keys in a map. This option only
+                        affects decoding (--decode/-d).
 
 ```
 

--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -152,9 +152,9 @@ struct {
 	size_t map_elems_processed; /**< The number of elements of an unordered map
 	                                 that have been processed. */
 #endif
-	size_t map_start_backup_num; /** The index of the backup made at the start of the current map.
-	                                 This is used to move to the start of the map when searching
-	                                 unordered maps. */
+	size_t map_start_backup_num; /** The index of the backup made at the start of the current
+	                                 map. This is used to move to the start of the map when
+	                                 traversing unordered maps during zcbor_unordered_map_search. */
 	size_t map_elem_count; /**< Number of elements in the current unordered map.
 	                            This also serves as the number of bits (not bytes)
 	                            in the map_search_elem_state array (when applicable). */
@@ -588,8 +588,10 @@ float zcbor_float16_to_32(uint16_t input);
  */
 uint16_t zcbor_float32_to_16(float input);
 
-#ifdef ZCBOR_MAP_SMART_SEARCH
+/** Round up x to the nearest multiple of align. */
 #define ZCBOR_ROUND_UP(x, align) (((x) + (align) - 1) / (align) * (align))
+
+#ifdef ZCBOR_MAP_SMART_SEARCH
 #define ZCBOR_BITS_PER_BYTE 8
 
 /** Calculate the number of bytes needed to hold @p num_flags 1 bit flags

--- a/samples/pet/src/pet_decode.c
+++ b/samples/pet/src/pet_decode.c
@@ -19,6 +19,7 @@
 	bool(*)(zcbor_state_t *, struct Pet *): ((zcbor_decoder_t *)func), \
 	default: ZCBOR_CAST_FP(func))
 
+
 #define log_result(state, result, func) do { \
 	if (!result) { \
 		zcbor_trace_file(state); \
@@ -70,6 +71,5 @@ int cbor_decode_Pet(
 		decode_Pet(states, result);
 	}
 
-	return zcbor_entry_function(payload, payload_len, (void *)result, payload_len_out, states,
-		(zcbor_decoder_t *)ZCBOR_CUSTOM_CAST_FP(decode_Pet), sizeof(states) / sizeof(zcbor_state_t), ZCBOR_LARGE_ELEM_COUNT);
+	return zcbor_entry_function(payload, payload_len, (void *)result, payload_len_out, states, (zcbor_decoder_t *)ZCBOR_CUSTOM_CAST_FP(decode_Pet), sizeof(states) / sizeof(zcbor_state_t), ZCBOR_LARGE_ELEM_COUNT);
 }

--- a/samples/pet/src/pet_encode.c
+++ b/samples/pet/src/pet_encode.c
@@ -19,6 +19,7 @@
 	bool(*)(zcbor_state_t *, const struct Pet *): ((zcbor_encoder_t *)func), \
 	default: ZCBOR_CAST_FP(func))
 
+
 #define log_result(state, result, func) do { \
 	if (!result) { \
 		zcbor_trace_file(state); \
@@ -71,6 +72,5 @@ int cbor_encode_Pet(
 		encode_Pet(states, input);
 	}
 
-	return zcbor_entry_function(payload, payload_len, (void *)input, payload_len_out, states,
-		(zcbor_decoder_t *)ZCBOR_CUSTOM_CAST_FP(encode_Pet), sizeof(states) / sizeof(zcbor_state_t), 0);
+	return zcbor_entry_function(payload, payload_len, (void *)input, payload_len_out, states, (zcbor_decoder_t *)ZCBOR_CUSTOM_CAST_FP(encode_Pet), sizeof(states) / sizeof(zcbor_state_t), 0);
 }

--- a/tests/cases/serial_recovery.cddl
+++ b/tests/cases/serial_recovery.cddl
@@ -4,13 +4,11 @@
 ; SPDX-License-Identifier: Apache-2.0
 ;
 
-Member = ("image" => int) /
-	("data" => bstr) /
-	("len" => int) /
-	("off" => int) /
-	("sha" => bstr) /
-	(tstr => any)
-
 Upload = {
-	3*8members: Member
+	? "image" => uint,
+	? "len" => uint,
+	  "off" => uint,
+	? "sha" => bstr,
+	? "data" => bstr,
+	? "upgrade" => bool,
 }

--- a/tests/cases/unordered_map.cddl
+++ b/tests/cases/unordered_map.cddl
@@ -1,0 +1,114 @@
+;
+; Copyright (c) 2023 Nordic Semiconductor ASA
+;
+; SPDX-License-Identifier: Apache-2.0
+;
+
+UnorderedMap1 = {
+	1 => "one",
+	2 => "two",
+	int => bstr,
+	"foo" => "bar",
+	bazboz,
+	*bstr => intlist,
+}
+
+bazboz = ("baz" => "boz")
+intlist = [*int]
+
+UnorderedMap2 = {
+	+typeUnion,
+	"map" => {
+		?-1 => bstr,
+		?-2 => bstr,
+		?bool => int,
+	}
+}
+
+typeUnion = type1 / type2 / typeDefault
+type1 = 1 => tstr
+type2 = 2 => tstr
+typeDefault = int => nil
+
+UnorderedMap3 = {
+	1*2000 uint => uint,
+	1*2000 nint => nint,
+}
+
+group1 = 3*3 (
+	uint => tstr,
+	nint => bstr,
+)
+
+UnorderedMap4 = {
+	1*3 group1,
+	?int => (tstr / bstr)
+}
+
+UnorderedMap5 = {
+	1 => bool,
+	2 => {
+		-1 => int,
+		-2 => int,
+		-3 => UnorderedMap2,
+		*uint => bstr,
+	},
+
+}
+
+; NOTE: This is bad CDDL design, but used here to test a corner case.
+UnorderedMap6 = {
+	(
+		(typechoice2: 1 => uint,
+		2 => tstr) //
+		(typechoice3: 1 => uint,
+		3 => tstr) //
+		(typechoice4: 1 => uint,
+		4 => tstr)
+	)
+}
+
+bool_or_nil = bool / nil
+
+UnorderedMap7 = {
+	1*6 (
+		(-1 => tstr) / (-2 => bstr) / (+nint .lt -2 => bool_or_nil)
+	),
+	1*100 uint => int,
+}
+
+UnorderedMap8 = {
+	union1: (1 => int // 2 => int // 3 => int),
+	union2: (4 => int // 5 => int // 6 => int),
+	?union3: (7 => 42 // 8 => int // 9 => int) .default (7 => 42)
+}
+
+UnorderedMap9 = {
+	"map91": uint,
+	"map92": uint
+}
+
+UnorderedMap10 = {
+	? "map101": uint,
+	? "map102": uint
+}
+
+UnorderedMap11 = {
+	? "map111": {
+		? "map112": uint
+	}
+}
+
+UnorderedMap12 = {
+	"map121": {
+		1: uint,
+		2: uint
+	}
+}
+
+UnorderedMap13 = {
+	"map131": {
+		"map132": uint,
+		"map133": uint
+	}
+}

--- a/tests/decode/test3_simple/CMakeLists.txt
+++ b/tests/decode/test3_simple/CMakeLists.txt
@@ -35,6 +35,7 @@ set(py_command_serial_recovery
   -d
   ${bit_arg}
   --short-names
+  --unordered-maps
 
   # Testing the --include-prefix option
   --include-prefix serial

--- a/tests/decode/test3_simple/src/main.c
+++ b/tests/decode/test3_simple/src/main.c
@@ -487,19 +487,15 @@ ZTEST(cbor_decode_test3, test_serial1)
 	zassert_equal(ZCBOR_SUCCESS, ret, "decoding failed: %d.", ret);
 	zassert_equal(sizeof(serial_rec_input1), decode_len, NULL);
 
-	zassert_equal(5, upload.members_count,
-		"expect 5 members");
-	zassert_equal(Member_data_c, upload.members[0].members
-		.Member_choice, "expect data 1st");
-	zassert_equal(Member_image_c, upload.members[1].members
-		.Member_choice, "expect image 2nd");
-	zassert_equal(Member_len_c, upload.members[2].members
-		.Member_choice, "was %d\r\n", upload.members[2].members
-		.Member_choice);
-	zassert_equal(Member_off_c, upload.members[3].members
-		.Member_choice, "expect off 4th");
-	zassert_equal(Member_sha_c, upload.members[4].members
-		.Member_choice, "expect sha 5th");
+	zassert_true(upload.data_present, NULL);
+	zassert_equal(0x129, upload.data.data.len, NULL);
+	zassert_true(upload.image_present, NULL);
+	zassert_equal(0, upload.image.image, NULL);
+	zassert_true(upload.len_present, NULL);
+	zassert_equal(0x3b2c, upload.len.len, NULL);
+	zassert_equal(0, upload.off, NULL);
+	zassert_true(upload.sha_present, NULL);
+	zassert_equal(0x20, upload.sha.sha.len, NULL);
 }
 
 ZTEST(cbor_decode_test3, test_serial2)
@@ -511,18 +507,15 @@ ZTEST(cbor_decode_test3, test_serial2)
 	zassert_equal(ZCBOR_SUCCESS, ret, "decoding failed: %d.", ret);
 	zassert_equal(sizeof(serial_rec_input2), decode_len, NULL);
 
-	zassert_equal(5, upload.members_count,
-		"expect 5 members");
-	zassert_equal(Member_data_c, upload.members[0].members
-		.Member_choice, "expect data 1st");
-	zassert_equal(Member_image_c, upload.members[1].members
-		.Member_choice, "expect image 2nd");
-	zassert_equal(Member_len_c, upload.members[2].members
-		.Member_choice, "expect len 3rd");
-	zassert_equal(Member_off_c, upload.members[3].members
-		.Member_choice, "expect off 4th");
-	zassert_equal(Member_sha_c, upload.members[4].members
-		.Member_choice, "expect sha 5th");
+	zassert_true(upload.data_present, NULL);
+	zassert_equal(0x129, upload.data.data.len, NULL);
+	zassert_true(upload.image_present, NULL);
+	zassert_equal(0, upload.image.image, NULL);
+	zassert_true(upload.len_present, NULL);
+	zassert_equal(0x2fe0, upload.len.len, NULL);
+	zassert_equal(0, upload.off, NULL);
+	zassert_true(upload.sha_present, NULL);
+	zassert_equal(0x20, upload.sha.sha.len, NULL);
 }
 
 ZTEST_SUITE(cbor_decode_test3, NULL, NULL, NULL, NULL, NULL);

--- a/tests/decode/test9_manifest14/CMakeLists.txt
+++ b/tests/decode/test9_manifest14/CMakeLists.txt
@@ -8,6 +8,7 @@ cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(test9_manifest14)
+set(MAP_SEARCH_FLAGS ON)  # Because of --unordered maps
 include(../../cmake/test_template.cmake)
 
 if (NOT MANIFEST)
@@ -30,6 +31,7 @@ set(py_command
   SUIT_Common_Sequence
   -d
   ${bit_arg}
+  --unordered-maps
   )
 
 execute_process(

--- a/tests/decode/testA_unordered_map/CMakeLists.txt
+++ b/tests/decode/testA_unordered_map/CMakeLists.txt
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(test9_manifest14)
+set(MAP_SEARCH_FLAGS ON)  # Because of --unordered maps
+set(MAP_SMART_SEARCH ON)
+include(../../cmake/test_template.cmake)
+
+set(py_command
+  ${PYTHON_EXECUTABLE}
+  ${CMAKE_CURRENT_LIST_DIR}/../../../zcbor/zcbor.py
+  code
+  -c ${CMAKE_CURRENT_LIST_DIR}/../../cases/unordered_map.cddl
+  --output-cmake ${PROJECT_BINARY_DIR}/unordered_map.cmake
+  -t
+  UnorderedMap1
+  UnorderedMap2
+  UnorderedMap3
+  UnorderedMap4
+  UnorderedMap5
+  UnorderedMap6
+  UnorderedMap7
+  UnorderedMap8
+  UnorderedMap9
+  UnorderedMap10
+  UnorderedMap11
+  UnorderedMap12
+  UnorderedMap13
+  -d
+  ${bit_arg}
+  --unordered-maps
+  --defines
+  )
+
+execute_process(
+  COMMAND
+  ${py_command}
+  COMMAND_ERROR_IS_FATAL ANY
+)
+
+include(${PROJECT_BINARY_DIR}/unordered_map.cmake)
+
+target_link_libraries(unordered_map PRIVATE zephyr_interface)
+target_link_libraries(app PRIVATE unordered_map)

--- a/tests/decode/testA_unordered_map/prj.conf
+++ b/tests/decode/testA_unordered_map/prj.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_ZTEST=y
+CONFIG_ZTEST_STACK_SIZE=131072

--- a/tests/decode/testA_unordered_map/src/main.c
+++ b/tests/decode/testA_unordered_map/src/main.c
@@ -1,0 +1,659 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zcbor_common.h>
+#include <zcbor_encode.h>
+#include <zcbor_print.h>
+#include "unordered_map_decode.h"
+#include <common_test.h>
+
+ZTEST(cbor_decode_testA, test_unordered_map1)
+{
+	const uint8_t payload_unordered_map1_1[] = {
+		MAP(7),
+		3, 0x40,
+		0x41, 0, LIST(3), 1, 2, 3, END
+		2, 0x63, 't', 'w', 'o',
+		0x63, 'b', 'a', 'z', 0x63, 'b', 'o', 'z',
+		0x41, 2, LIST(0), END
+		1, 0x63, 'o', 'n', 'e',
+		0x63, 'f', 'o', 'o', 0x63, 'b', 'a', 'r',
+		END
+	};
+
+	const uint8_t payload_unordered_map1_2[] = {
+		MAP(5),
+		2, 0x63, 't', 'w', 'o',
+		3, 0x40,
+		1, 0x63, 'o', 'n', 'e',
+		0x63, 'b', 'a', 'z', 0x63, 'b', 'o', 'z',
+		0x63, 'f', 'o', 'o', 0x63, 'b', 'a', 'r',
+		END
+	};
+
+	const uint8_t payload_unordered_map1_inv3[] = {
+		MAP(5),
+		2, 0x63, 't', 'w', 'o',
+		3, 0x40,
+		1, 0x63, 'o', 'n', 'f' /* here */,
+		0x63, 'b', 'a', 'z', 0x63, 'b', 'o', 'z',
+		0x63, 'f', 'o', 'o', 0x63, 'b', 'a', 'r',
+		END
+	};
+
+	const uint8_t payload_unordered_map1_inv4[] = {
+		MAP(6),
+		3, 0x40,
+		0x63, 'b', 'a', 'z', 0x63, 'b', 'o', 'z',
+		0x41, 0, LIST(3), 1, 2, 0x40 /* here */, END
+		0x63, 'f', 'o', 'o', 0x63, 'b', 'a', 'r',
+		1, 0x63, 'o', 'n', 'e',
+		2, 0x63, 't', 'w', 'o',
+		END
+	};
+
+	struct UnorderedMap1 unordered_map1;
+
+	int err = cbor_decode_UnorderedMap1(payload_unordered_map1_1, sizeof(payload_unordered_map1_1), &unordered_map1, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+	zassert_equal(3, unordered_map1.UnorderedMap1_intbstr_key);
+	zassert_equal(0, unordered_map1.UnorderedMap1_intbstr.len);
+	zassert_equal(2, unordered_map1.UnorderedMap1_intlist_m_count);
+	zassert_equal(1, unordered_map1.UnorderedMap1_intlist_m[0].UnorderedMap1_intlist_m_key.len);
+	zassert_equal(2, unordered_map1.UnorderedMap1_intlist_m[0].UnorderedMap1_intlist_m_key.value[0]);
+	zassert_equal(0, unordered_map1.UnorderedMap1_intlist_m[0].UnorderedMap1_intlist_m.intlist_int_count);
+	zassert_equal(1, unordered_map1.UnorderedMap1_intlist_m[1].UnorderedMap1_intlist_m_key.len);
+	zassert_equal(0, unordered_map1.UnorderedMap1_intlist_m[1].UnorderedMap1_intlist_m_key.value[0]);
+	zassert_equal(3, unordered_map1.UnorderedMap1_intlist_m[1].UnorderedMap1_intlist_m.intlist_int_count);
+	zassert_equal(1, unordered_map1.UnorderedMap1_intlist_m[1].UnorderedMap1_intlist_m.intlist_int[0]);
+	zassert_equal(2, unordered_map1.UnorderedMap1_intlist_m[1].UnorderedMap1_intlist_m.intlist_int[1]);
+	zassert_equal(3, unordered_map1.UnorderedMap1_intlist_m[1].UnorderedMap1_intlist_m.intlist_int[2]);
+
+	err = cbor_decode_UnorderedMap1(payload_unordered_map1_2, sizeof(payload_unordered_map1_2), &unordered_map1, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+	zassert_equal(3, unordered_map1.UnorderedMap1_intbstr_key);
+	zassert_equal(0, unordered_map1.UnorderedMap1_intbstr.len);
+	zassert_equal(0, unordered_map1.UnorderedMap1_intlist_m_count);
+
+	err = cbor_decode_UnorderedMap1(payload_unordered_map1_inv3, sizeof(payload_unordered_map1_inv3), &unordered_map1, NULL);
+	zassert_equal(ZCBOR_ERR_WRONG_VALUE, err, "%s\n", zcbor_error_str(err));
+
+	err = cbor_decode_UnorderedMap1(payload_unordered_map1_inv4, sizeof(payload_unordered_map1_inv4), &unordered_map1, NULL);
+	zassert_equal(ZCBOR_ERR_ELEMS_NOT_PROCESSED, err, "%s\n", zcbor_error_str(err));
+}
+
+ZTEST(cbor_decode_testA, test_unordered_map2)
+{
+	const uint8_t payload_unordered_map2_1[] = {
+		MAP(4),
+		1, 0x61, 'a',
+		0x63, 'm', 'a', 'p', MAP(3),
+			0x20, 0x40,
+			0x21, 0x40,
+			0xF4, 0x18, 100,
+			END
+		0x21, 0xF6,
+		2, 0x61, 'b',
+		END
+	};
+
+	const uint8_t payload_unordered_map2_2[] = {
+		MAP(2),
+		0x63, 'm', 'a', 'p', MAP(1),
+			0xF5, 0x39, 0x12, 0x34,
+			END
+		0x22, 0xF6,
+		END
+	};
+
+	const uint8_t payload_unordered_map2_3[] = {
+		MAP(3),
+		2, 0x66, 'f', 'o', 'o', 'b', 'a', 'r',
+		0x63, 'm', 'a', 'p', MAP(2),
+			0x21, 0x40,
+			0x20, 0x40,
+			END
+		1, 0x60,
+		END
+	};
+
+	const uint8_t payload_unordered_map2_inv4[] = {
+		MAP(4),
+		1, 0x61, 'a',
+		0x63, 'm', 'a', 'p', MAP(3),
+			0x20, 0x40,
+			0x21, 0x40,
+			0xF4, 0xF6 /* here */,
+			END
+		0x21, 0xF6,
+		2, 0x61, 'b',
+		END
+	};
+
+	const uint8_t payload_unordered_map2_inv5[] = {
+		MAP(4),
+		1, 0x61, 'a',
+		0x62, 'm', 'a', /* here */ MAP(3),
+			0x20, 0x40,
+			0x21, 0x40,
+			0xF4, 0x18, 100,
+			END
+		0x21, 0xF6,
+		2, 0x61, 'b',
+		END
+	};
+
+	struct UnorderedMap2 unordered_map2;
+
+	int err = cbor_decode_UnorderedMap2(payload_unordered_map2_1, sizeof(payload_unordered_map2_1), &unordered_map2, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+	zassert_equal(3, unordered_map2.UnorderedMap2_typeUnion_m_count);
+	zassert_equal(typeUnion_type1_m_c, unordered_map2.UnorderedMap2_typeUnion_m[0].typeUnion_choice);
+	zassert_equal(typeUnion_type2_m_c, unordered_map2.UnorderedMap2_typeUnion_m[1].typeUnion_choice);
+	zassert_equal(typeUnion_typeDefault_m_c, unordered_map2.UnorderedMap2_typeUnion_m[2].typeUnion_choice);
+	zassert_equal(1, unordered_map2.UnorderedMap2_typeUnion_m[0].typeUnion_type1_m.type1.len);
+	zassert_equal('a', unordered_map2.UnorderedMap2_typeUnion_m[0].typeUnion_type1_m.type1.value[0]);
+	zassert_equal(1, unordered_map2.UnorderedMap2_typeUnion_m[1].typeUnion_type2_m.type2.len);
+	zassert_equal('b', unordered_map2.UnorderedMap2_typeUnion_m[1].typeUnion_type2_m.type2.value[0]);
+	zassert_equal(-2, unordered_map2.UnorderedMap2_typeUnion_m[2].typeUnion_typeDefault_m.typeDefault_key);
+	zassert_true(unordered_map2.map_nint1bstr_present);
+	zassert_true(unordered_map2.map_nint2bstr_present);
+	zassert_true(unordered_map2.map_boolint_present);
+	zassert_equal(0, unordered_map2.map_nint1bstr.map_nint1bstr.len);
+	zassert_equal(0, unordered_map2.map_nint2bstr.map_nint2bstr.len);
+	zassert_false(unordered_map2.map_boolint.UnorderedMap2_map_boolint_key);
+	zassert_equal(100, unordered_map2.map_boolint.map_boolint);
+
+	err = cbor_decode_UnorderedMap2(payload_unordered_map2_2, sizeof(payload_unordered_map2_2), &unordered_map2, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+	zassert_equal(1, unordered_map2.UnorderedMap2_typeUnion_m_count);
+	zassert_equal(typeUnion_typeDefault_m_c, unordered_map2.UnorderedMap2_typeUnion_m[0].typeUnion_choice);
+	zassert_equal(-3, unordered_map2.UnorderedMap2_typeUnion_m[0].typeUnion_typeDefault_m.typeDefault_key);
+	zassert_true(unordered_map2.map_boolint_present);
+	zassert_true(unordered_map2.map_boolint.UnorderedMap2_map_boolint_key);
+	zassert_equal(-0x1235, unordered_map2.map_boolint.map_boolint);
+
+	err = cbor_decode_UnorderedMap2(payload_unordered_map2_3, sizeof(payload_unordered_map2_3), &unordered_map2, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+	zassert_equal(2, unordered_map2.UnorderedMap2_typeUnion_m_count);
+	zassert_equal(typeUnion_type1_m_c, unordered_map2.UnorderedMap2_typeUnion_m[0].typeUnion_choice);
+	zassert_equal(typeUnion_type2_m_c, unordered_map2.UnorderedMap2_typeUnion_m[1].typeUnion_choice);
+	zassert_equal(0, unordered_map2.UnorderedMap2_typeUnion_m[0].typeUnion_type1_m.type1.len);
+	zassert_equal(6, unordered_map2.UnorderedMap2_typeUnion_m[1].typeUnion_type2_m.type2.len);
+	zassert_mem_equal("foobar", unordered_map2.UnorderedMap2_typeUnion_m[1].typeUnion_type2_m.type2.value, 6);
+	zassert_true(unordered_map2.map_nint1bstr_present);
+	zassert_true(unordered_map2.map_nint2bstr_present);
+	zassert_equal(0, unordered_map2.map_nint1bstr.map_nint1bstr.len);
+	zassert_equal(0, unordered_map2.map_nint2bstr.map_nint2bstr.len);
+
+	err = cbor_decode_UnorderedMap2(payload_unordered_map2_inv4, sizeof(payload_unordered_map2_inv4), &unordered_map2, NULL);
+	zassert_equal(ZCBOR_ERR_ELEMS_NOT_PROCESSED, err, "%s %d\n", zcbor_error_str(err), err);
+
+	err = cbor_decode_UnorderedMap2(payload_unordered_map2_inv5, sizeof(payload_unordered_map2_inv5), &unordered_map2, NULL);
+	zassert_equal(ZCBOR_ERR_ELEM_NOT_FOUND, err, "%s %d\n", zcbor_error_str(err), err);
+}
+
+
+ZTEST(cbor_decode_testA, test_unordered_map3)
+{
+	uint8_t payload_unordered_map3_1[21000];
+
+	ZCBOR_STATE_E(state_e, 1, payload_unordered_map3_1, sizeof(payload_unordered_map3_1), 0);
+
+	zassert_true(zcbor_map_start_encode(state_e, 2000));
+	for (uint32_t i = 1; i <= 1000; i++) {
+		zassert_true(zcbor_uint32_put(state_e, i), "%d\n", i);
+		zassert_true(zcbor_uint32_put(state_e, i), "%d\n", i);
+		zassert_true(zcbor_int32_put(state_e, -i), "%d\n", -i);
+		zassert_true(zcbor_int32_put(state_e, -i), "%d\n", -i);
+	}
+	zassert_true(zcbor_map_end_encode(state_e, 2000));
+
+	struct UnorderedMap3 unordered_map3;
+
+	int err = cbor_decode_UnorderedMap3(payload_unordered_map3_1, sizeof(payload_unordered_map3_1), &unordered_map3, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+
+	zassert_equal(1000, unordered_map3.UnorderedMap3_uintuint_count, "%d != %d", 1000, unordered_map3.UnorderedMap3_uintuint_count);
+	zassert_equal(1000, unordered_map3.UnorderedMap3_nintnint_count, "%d != %d", 1000, unordered_map3.UnorderedMap3_nintnint_count);
+}
+
+
+ZTEST(cbor_decode_testA, test_unordered_map4)
+{
+	uint8_t payload_unordered_map4_1[100];
+	struct UnorderedMap4 unordered_map4;
+	int err;
+
+	/* Valid case */
+	ZCBOR_STATE_E(state_e, 1, payload_unordered_map4_1, sizeof(payload_unordered_map4_1), 0);
+
+	zassert_true(zcbor_map_start_encode(state_e, 10));
+	for (int32_t i = -1; i >= -6; i--) {
+		zassert_true(zcbor_int32_put(state_e, i), "%d\n", i);
+		zassert_true(zcbor_bstr_put_lit(state_e, "world"), NULL);
+	}
+	for (uint32_t i = 1; i <= 6; i++) {
+		zassert_true(zcbor_uint32_put(state_e, i), "%d\n", i);
+		zassert_true(zcbor_tstr_put_lit(state_e, "hello"), NULL);
+	}
+	zassert_true(zcbor_map_end_encode(state_e, 6));
+
+	err = cbor_decode_UnorderedMap4(payload_unordered_map4_1, sizeof(payload_unordered_map4_1), &unordered_map4, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+
+	zassert_equal(2, unordered_map4.UnorderedMap4_group1_m_count, "%d != %d", 2, unordered_map4.UnorderedMap4_group1_m_count);
+	zassert_equal(3, unordered_map4.UnorderedMap4_group1_m[0].UnorderedMap4_group1_m.group1_count, "%d != %d", 3, unordered_map4.UnorderedMap4_group1_m[0].UnorderedMap4_group1_m.group1_count);
+	zassert_false(unordered_map4.UnorderedMap4_intunion_present);
+	for (int32_t i = 0; i < 2; i++) {
+		for (int32_t j = 1; j <= 3; j++) {
+			zassert_equal(j + (i * 3), unordered_map4.UnorderedMap4_group1_m[i].UnorderedMap4_group1_m.group1[j - 1].group1_uinttstr_key);
+			zassert_equal(-j - (i * 3), unordered_map4.UnorderedMap4_group1_m[i].UnorderedMap4_group1_m.group1[j - 1].group1_nintbstr_key);
+		}
+	}
+
+	/* Valid case (tests map elem state backup) */
+	ZCBOR_STATE_E(state_e2, 1, payload_unordered_map4_1, sizeof(payload_unordered_map4_1), 0);
+
+	zassert_true(zcbor_map_start_encode(state_e2, 10));
+	for (int32_t i = -1; i >= -3; i--) {
+		zassert_true(zcbor_int32_put(state_e2, i), "%d\n", i);
+		zassert_true(zcbor_bstr_put_lit(state_e2, "world"), NULL);
+	}
+
+	/* Put an extra int that will first be attempted to fit into a third iteration of
+	   group1, then the backup will clear it so it can be consumed as part of the next
+	   line instead. */
+	for (uint32_t i = 1; i <= 4; i++) {
+		zassert_true(zcbor_uint32_put(state_e2, i), "%d\n", i);
+		zassert_true(zcbor_tstr_put_lit(state_e2, "hello"), NULL);
+	}
+	zassert_true(zcbor_map_end_encode(state_e2, 6));
+
+	err = cbor_decode_UnorderedMap4(payload_unordered_map4_1, sizeof(payload_unordered_map4_1), &unordered_map4, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+
+	zassert_equal(1, unordered_map4.UnorderedMap4_group1_m_count, "%d != %d", 1, unordered_map4.UnorderedMap4_group1_m_count);
+	zassert_equal(3, unordered_map4.UnorderedMap4_group1_m[0].UnorderedMap4_group1_m.group1_count, "%d != %d", 3, unordered_map4.UnorderedMap4_group1_m[0].UnorderedMap4_group1_m.group1_count);
+	zassert_true(unordered_map4.UnorderedMap4_intunion_present);
+	for (int32_t i = 0; i < 1; i++) {
+		for (int32_t j = 1; j <= 3; j++) {
+			zassert_equal(j + (i * 3), unordered_map4.UnorderedMap4_group1_m[i].UnorderedMap4_group1_m.group1[j - 1].group1_uinttstr_key);
+			zassert_equal(-j - (i * 3), unordered_map4.UnorderedMap4_group1_m[i].UnorderedMap4_group1_m.group1[j - 1].group1_nintbstr_key);
+		}
+	}
+	zassert_equal(4, unordered_map4.UnorderedMap4_intunion.UnorderedMap4_intunion_key);
+
+	/* Invalid case */
+	ZCBOR_STATE_E(state_e_inv1, 1, payload_unordered_map4_1, sizeof(payload_unordered_map4_1), 0);
+
+	zassert_true(zcbor_map_start_encode(state_e_inv1, 10));
+	for (int32_t i = -1; i >= -5; i--) { /* <- Here (Not a multiple of 3 )*/
+		zassert_true(zcbor_int32_put(state_e_inv1, i), "%d\n", i);
+		zassert_true(zcbor_bstr_put_lit(state_e_inv1, "world"), NULL);
+	}
+	for (uint32_t i = 1; i <= 6; i++) {
+		zassert_true(zcbor_uint32_put(state_e_inv1, i), "%d\n", i);
+		zassert_true(zcbor_tstr_put_lit(state_e_inv1, "hello"), NULL);
+	}
+	zassert_true(zcbor_map_end_encode(state_e_inv1, 6));
+
+	err = cbor_decode_UnorderedMap4(payload_unordered_map4_1, sizeof(payload_unordered_map4_1), &unordered_map4, NULL);
+	zassert_equal(ZCBOR_ERR_ELEMS_NOT_PROCESSED, err, "%s %d\n", zcbor_error_str(err), err);
+
+
+	/* Invalid case */
+	ZCBOR_STATE_E(state_e_inv2, 1, payload_unordered_map4_1, sizeof(payload_unordered_map4_1), 0);
+
+	zassert_true(zcbor_map_start_encode(state_e_inv2, 10));
+	for (int32_t i = -1; i >= -3; i--) {
+		zassert_true(zcbor_int32_put(state_e_inv2, i), "%d\n", i);
+		zassert_true(zcbor_bstr_put_lit(state_e_inv2, "world"), NULL);
+	}
+	for (uint32_t i = 1; i <= 2; i++) { /* <- Here (Not a multiple of 3 )*/
+		zassert_true(zcbor_uint32_put(state_e_inv2, i), "%d\n", i);
+		zassert_true(zcbor_tstr_put_lit(state_e_inv2, "hello"), NULL);
+	}
+	zassert_true(zcbor_map_end_encode(state_e_inv2, 6));
+
+	err = cbor_decode_UnorderedMap4(payload_unordered_map4_1, sizeof(payload_unordered_map4_1), &unordered_map4, NULL);
+	zassert_equal(ZCBOR_ERR_ITERATIONS, err, "%s %d\n", zcbor_error_str(err), err);
+}
+
+
+ZTEST(cbor_decode_testA, test_unordered_map5)
+{
+	uint8_t payload_unordered_map5_1[] = {
+		MAP(2),
+			0x01, 0xF5,
+			0x02, MAP(6),
+				0x10, 0x40,
+				0x11, 0x41, 0x01,
+				0x12, 0x42, 0x01, 0x02,
+				0x22, MAP(2),
+					0x63, 'm', 'a', 'p', MAP(1),
+						0xF5, 0x39, 0x12, 0x34,
+						END
+					0x22, 0xF6,
+				END
+				0x21, 0x12,
+				0x20, 0x02,
+			END
+		END
+
+	};
+
+	struct UnorderedMap5 unordered_map5;
+
+	int err = cbor_decode_UnorderedMap5(payload_unordered_map5_1, sizeof(payload_unordered_map5_1), &unordered_map5, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+}
+
+
+ZTEST(cbor_decode_testA, test_unordered_map6)
+{
+	uint8_t payload_unordered_map6_1[] = {
+		MAP(2),
+			0x01, 0x10,
+			0x03, 0x61, 'a',
+		END
+	};
+	uint8_t payload_unordered_map6_2[] = {
+		MAP(2),
+			0x04, 0x61, 'b',
+			0x01, 0x11,
+		END
+	};
+	uint8_t payload_unordered_map6_3[] = {
+		MAP(2),
+			0x02, 0x61, 'c',
+			0x01, 0x12,
+		END
+	};
+
+	struct UnorderedMap6 unordered_map6;
+	int err;
+
+	err = cbor_decode_UnorderedMap6(payload_unordered_map6_1, sizeof(payload_unordered_map6_1), &unordered_map6, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+	zassert_equal(union_typechoice3_l_c, unordered_map6.UnorderedMap6_union_choice);
+	zassert_equal(0x10, unordered_map6.typechoice3_l_typechoice3);
+	zassert_equal(1, unordered_map6.typechoice3_l_uint3tstr.len);
+	zassert_equal('a', unordered_map6.typechoice3_l_uint3tstr.value[0]);
+
+	err = cbor_decode_UnorderedMap6(payload_unordered_map6_2, sizeof(payload_unordered_map6_2), &unordered_map6, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+	zassert_equal(union_typechoice4_l_c, unordered_map6.UnorderedMap6_union_choice);
+	zassert_equal(0x11, unordered_map6.typechoice4_l_typechoice4);
+	zassert_equal(1, unordered_map6.typechoice4_l_uint4tstr.len);
+	zassert_equal('b', unordered_map6.typechoice4_l_uint4tstr.value[0]);
+
+	err = cbor_decode_UnorderedMap6(payload_unordered_map6_3, sizeof(payload_unordered_map6_3), &unordered_map6, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+	zassert_equal(union_typechoice2_l_c, unordered_map6.UnorderedMap6_union_choice);
+	zassert_equal(0x12, unordered_map6.typechoice2_l_typechoice2);
+	zassert_equal(1, unordered_map6.typechoice2_l_uint2tstr.len);
+	zassert_equal('c', unordered_map6.typechoice2_l_uint2tstr.value[0]);
+}
+
+
+// static void zassert_zcbor_string_equal_lit(const char *expected, const struct zcbor_string *str)
+#define zassert_zcbor_string_equal_lit(expected, str) \
+do { \
+	zassert_equal(strlen(expected), (str)->len, "%d != %d\n", strlen(expected), (str)->len); \
+	zassert_mem_equal(expected, (str)->value, (str)->len, "%s != %s\n", expected, (str)->value); \
+} while(0)
+
+
+ZTEST(cbor_decode_testA, test_unordered_map7)
+{
+	uint8_t payload_unordered_map7_1[500];
+
+	ZCBOR_STATE_E(state_e, 1, payload_unordered_map7_1, sizeof(payload_unordered_map7_1), 0);
+	zassert_true(zcbor_map_start_encode(state_e, 300));
+	for (int32_t i = 1; i <= 100; i++) {
+		zassert_true(zcbor_uint32_put(state_e, i), "%d\n", i);
+		zassert_true(zcbor_int32_put(state_e, -i), NULL);
+	}
+	zassert_true(zcbor_int32_put(state_e, -1), NULL);
+	zassert_true(zcbor_tstr_put_lit(state_e, "hello"), NULL);
+	zassert_true(zcbor_int32_put(state_e, -2), NULL);
+	zassert_true(zcbor_bstr_put_lit(state_e, "world"), NULL);
+	zassert_true(zcbor_int32_put(state_e, -10), NULL);
+	zassert_true(zcbor_bool_put(state_e, true), NULL);
+	zassert_true(zcbor_int32_put(state_e, -11), NULL);
+	zassert_true(zcbor_nil_put(state_e, NULL), NULL);
+	zassert_true(zcbor_int32_put(state_e, -12), NULL);
+	zassert_true(zcbor_nil_put(state_e, NULL), NULL);
+	zassert_true(zcbor_int32_put(state_e, -13), NULL);
+	zassert_true(zcbor_nil_put(state_e, NULL), NULL);
+	zassert_true(zcbor_int32_put(state_e, -14), NULL);
+	zassert_true(zcbor_nil_put(state_e, NULL), NULL);
+	zassert_true(zcbor_int32_put(state_e, -15), NULL);
+	zassert_true(zcbor_nil_put(state_e, NULL), NULL);
+	zassert_true(zcbor_int32_put(state_e, -16), NULL);
+	zassert_true(zcbor_nil_put(state_e, NULL), NULL);
+	zassert_true(zcbor_int32_put(state_e, -17), NULL);
+	zassert_true(zcbor_nil_put(state_e, NULL), NULL);
+	zassert_true(zcbor_map_end_encode(state_e, 300));
+
+	struct UnorderedMap7 unordered_map7;
+	int err;
+
+	err = cbor_decode_UnorderedMap7(payload_unordered_map7_1, sizeof(payload_unordered_map7_1), &unordered_map7, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+	zassert_equal(100, unordered_map7.UnorderedMap7_uintint_count, "%d != %d", 100, unordered_map7.UnorderedMap7_uintint_count);
+	for (int32_t i = 1; i <= 100; i++) {
+		zassert_equal(i, unordered_map7.UnorderedMap7_uintint[i - 1].UnorderedMap7_uintint_key);
+		zassert_equal(-i, unordered_map7.UnorderedMap7_uintint[i - 1].UnorderedMap7_uintint);
+	}
+	zassert_equal(5, unordered_map7.UnorderedMap7_union_count, "%d != %d", 5, unordered_map7.UnorderedMap7_union_count);
+
+	zassert_equal(union_nint1tstr_c, unordered_map7.UnorderedMap7_union[0].UnorderedMap7_union_choice);
+	zassert_zcbor_string_equal_lit("hello", &unordered_map7.UnorderedMap7_union[0].union_nint1tstr);
+
+	zassert_equal(union_nint2bstr_c, unordered_map7.UnorderedMap7_union[1].UnorderedMap7_union_choice);
+	zassert_zcbor_string_equal_lit("world", &unordered_map7.UnorderedMap7_union[1].union_nint2bstr);
+
+	zassert_equal(union_bool_or_nil_m_c, unordered_map7.UnorderedMap7_union[2].UnorderedMap7_union_choice);
+	zassert_equal(3, unordered_map7.UnorderedMap7_union[2].union_bool_or_nil_m_count);
+	zassert_equal(-10, unordered_map7.UnorderedMap7_union[2].union_bool_or_nil_m[0].UnorderedMap7_union_bool_or_nil_m_key);
+	zassert_equal(bool_or_nil_bool_c, unordered_map7.UnorderedMap7_union[2].union_bool_or_nil_m[0].union_bool_or_nil_m.bool_or_nil_choice);
+	zassert_equal(true, unordered_map7.UnorderedMap7_union[2].union_bool_or_nil_m[0].union_bool_or_nil_m.bool_or_nil_bool);
+	zassert_equal(-11, unordered_map7.UnorderedMap7_union[2].union_bool_or_nil_m[1].UnorderedMap7_union_bool_or_nil_m_key);
+	zassert_equal(bool_or_nil_nil_c, unordered_map7.UnorderedMap7_union[2].union_bool_or_nil_m[1].union_bool_or_nil_m.bool_or_nil_choice);
+	zassert_equal(-12, unordered_map7.UnorderedMap7_union[2].union_bool_or_nil_m[2].UnorderedMap7_union_bool_or_nil_m_key);
+	zassert_equal(bool_or_nil_nil_c, unordered_map7.UnorderedMap7_union[2].union_bool_or_nil_m[2].union_bool_or_nil_m.bool_or_nil_choice);
+
+	zassert_equal(union_bool_or_nil_m_c, unordered_map7.UnorderedMap7_union[3].UnorderedMap7_union_choice);
+	zassert_equal(3, unordered_map7.UnorderedMap7_union[3].union_bool_or_nil_m_count);
+	zassert_equal(-13, unordered_map7.UnorderedMap7_union[3].union_bool_or_nil_m[0].UnorderedMap7_union_bool_or_nil_m_key);
+	zassert_equal(bool_or_nil_nil_c, unordered_map7.UnorderedMap7_union[3].union_bool_or_nil_m[0].union_bool_or_nil_m.bool_or_nil_choice);
+	zassert_equal(-14, unordered_map7.UnorderedMap7_union[3].union_bool_or_nil_m[1].UnorderedMap7_union_bool_or_nil_m_key);
+	zassert_equal(bool_or_nil_nil_c, unordered_map7.UnorderedMap7_union[3].union_bool_or_nil_m[1].union_bool_or_nil_m.bool_or_nil_choice);
+	zassert_equal(-15, unordered_map7.UnorderedMap7_union[3].union_bool_or_nil_m[2].UnorderedMap7_union_bool_or_nil_m_key);
+	zassert_equal(bool_or_nil_nil_c, unordered_map7.UnorderedMap7_union[3].union_bool_or_nil_m[2].union_bool_or_nil_m.bool_or_nil_choice);
+
+	zassert_equal(union_bool_or_nil_m_c, unordered_map7.UnorderedMap7_union[4].UnorderedMap7_union_choice);
+	zassert_equal(2, unordered_map7.UnorderedMap7_union[4].union_bool_or_nil_m_count);
+	zassert_equal(-16, unordered_map7.UnorderedMap7_union[4].union_bool_or_nil_m[0].UnorderedMap7_union_bool_or_nil_m_key);
+	zassert_equal(bool_or_nil_nil_c, unordered_map7.UnorderedMap7_union[4].union_bool_or_nil_m[0].union_bool_or_nil_m.bool_or_nil_choice);
+	zassert_equal(-17, unordered_map7.UnorderedMap7_union[4].union_bool_or_nil_m[1].UnorderedMap7_union_bool_or_nil_m_key);
+	zassert_equal(bool_or_nil_nil_c, unordered_map7.UnorderedMap7_union[4].union_bool_or_nil_m[1].union_bool_or_nil_m.bool_or_nil_choice);
+}
+
+
+ZTEST(cbor_decode_testA, test_unordered_map8)
+{
+	uint8_t payload_unordered_map8_1[] = {MAP(2), 0x04, 0x23, 0x01, 0x20, END};
+	uint8_t payload_unordered_map8_2[] = {MAP(3), 0x05, 0x24, 0x09, 0x28, 0x03, 0x22, END};
+	uint8_t payload_unordered_map8_3[] = {MAP(3), 0x08, 0x27, 0x02, 0x21, 0x06, 0x25, END};
+
+	struct UnorderedMap8 unordered_map8;
+
+	int err = cbor_decode_UnorderedMap8(payload_unordered_map8_1, sizeof(payload_unordered_map8_1), &unordered_map8, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+	zassert_equal(union2_uint4int_c, unordered_map8.UnorderedMap8_union2_choice);
+	zassert_equal(-4, unordered_map8.union2_uint4int);
+	zassert_equal(union1_uint1int_c, unordered_map8.UnorderedMap8_union1_choice);
+	zassert_equal(-1, unordered_map8.union1_uint1int);
+	zassert_equal(false, unordered_map8.UnorderedMap8_union3_present);
+	zassert_equal(UnorderedMap8_union3_uint42_c, unordered_map8.UnorderedMap8_union3.UnorderedMap8_union3_choice); // Default value reported
+
+	err = cbor_decode_UnorderedMap8(payload_unordered_map8_2, sizeof(payload_unordered_map8_2), &unordered_map8, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+	zassert_equal(union2_uint5int_c, unordered_map8.UnorderedMap8_union2_choice);
+	zassert_equal(-5, unordered_map8.union2_uint4int);
+	zassert_equal(union1_uint3int_c, unordered_map8.UnorderedMap8_union1_choice);
+	zassert_equal(-3, unordered_map8.union1_uint1int);
+	zassert_equal(true, unordered_map8.UnorderedMap8_union3_present);
+	zassert_equal(union3_uint9int_c, unordered_map8.UnorderedMap8_union3.UnorderedMap8_union3_choice);
+	zassert_equal(-9, unordered_map8.UnorderedMap8_union3.union3_uint9int);
+
+	err = cbor_decode_UnorderedMap8(payload_unordered_map8_3, sizeof(payload_unordered_map8_3), &unordered_map8, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+	zassert_equal(union1_uint2int_c, unordered_map8.UnorderedMap8_union1_choice);
+	zassert_equal(-2, unordered_map8.union1_uint1int);
+	zassert_equal(union2_uint6int_c, unordered_map8.UnorderedMap8_union2_choice);
+	zassert_equal(-6, unordered_map8.union2_uint4int);
+	zassert_equal(true, unordered_map8.UnorderedMap8_union3_present);
+	zassert_equal(union3_uint8int_c, unordered_map8.UnorderedMap8_union3.UnorderedMap8_union3_choice);
+	zassert_equal(-8, unordered_map8.UnorderedMap8_union3.union3_uint8int);
+}
+
+
+ZTEST(cbor_decode_testA, test_unordered_map9)
+{
+	const uint8_t payload_unordered_map9[] = {
+		MAP(2),
+		0x65, 'm', 'a', 'p', '9', '1',
+		0x18, 0x2A,
+		0x65, 'm', 'a', 'p', '9', '2',
+		0x18, 0x18,
+		END
+	};
+
+	const uint8_t payload_unordered_map9_inv[] = {
+		MAP(1),
+		0x65, 'm', 'a', 'p', '9', '1',
+		0x61, 0x2A,
+		END
+	};
+
+	struct UnorderedMap9 unordered_map9;
+
+	int err = cbor_decode_UnorderedMap9(payload_unordered_map9,
+			sizeof(payload_unordered_map9), &unordered_map9, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+
+	err = cbor_decode_UnorderedMap9(payload_unordered_map9_inv,
+			sizeof(payload_unordered_map9_inv), &unordered_map9, NULL);
+	zassert_not_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+}
+
+ZTEST(cbor_decode_testA, test_unordered_map10)
+{
+	const uint8_t payload_unordered_map10_1[] = {
+		MAP(2),
+		0x66, 'm', 'a', 'p', '1', '0', '1',
+		0x18, 0x2A,
+		0x66, 'm', 'a', 'p', '1', '0', '2',
+		0x18, 0x18,
+		END
+	};
+
+	const uint8_t payload_unordered_map10_2[] = {
+		MAP(1),
+		0x66, 'm', 'a', 'p', '1', '0', '1',
+		0x61, 0x2A,
+		END
+	};
+
+	const uint8_t payload_unordered_map10_3[] = {
+		MAP(2),
+		0x66, 'm', 'a', 'p', '1', '0', '2',
+		0x18, 0x18,
+		0x66, 'm', 'a', 'p', '1', '0', '1',
+		0x18, 0x2A,
+		END
+	};
+
+	struct UnorderedMap10 unordered_map10;
+
+	int err = cbor_decode_UnorderedMap10(payload_unordered_map10_1,
+			sizeof(payload_unordered_map10_1), &unordered_map10, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+
+	err = cbor_decode_UnorderedMap10(payload_unordered_map10_2,
+			sizeof(payload_unordered_map10_2), &unordered_map10, NULL);
+	zassert_not_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+
+	err = cbor_decode_UnorderedMap10(payload_unordered_map10_3,
+			sizeof(payload_unordered_map10_3), &unordered_map10, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+}
+
+ZTEST(cbor_decode_testA, test_unordered_map11)
+{
+	const uint8_t payload_unordered_map11[] = {
+		MAP(1),
+		0x66, 'm', 'a', 'p', '1', '1', '1',
+			MAP(1),
+			0x66, 'm', 'a', 'p', '1', '1', '2',
+			0x18, 0x2A,
+			END
+		END
+	};
+
+	struct UnorderedMap11 unordered_map11;
+
+	int err = cbor_decode_UnorderedMap11(payload_unordered_map11,
+			sizeof(payload_unordered_map11), &unordered_map11, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+}
+
+ZTEST(cbor_decode_testA, test_unordered_map12)
+{
+	const uint8_t payload_unordered_map12[] = {
+		MAP(1),
+		0x66, 'm', 'a', 'p', '1', '2', '1',
+			MAP(2),
+			0x01, 0x18, 0x2A,
+			0x02, 0x18, 0x18,
+			END
+		END
+	};
+
+	struct UnorderedMap12 unordered_map12;
+
+	int err = cbor_decode_UnorderedMap12(payload_unordered_map12,
+			sizeof(payload_unordered_map12), &unordered_map12, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+}
+
+ZTEST(cbor_decode_testA, test_unordered_map13)
+{
+	const uint8_t payload_unordered_map13[] = {
+		MAP(1),
+		0x66, 'm', 'a', 'p', '1', '3', '1',
+			MAP(2),
+			0x66, 'm', 'a', 'p', '1', '3', '2',
+			0x18, 0x2A,
+			0x66, 'm', 'a', 'p', '1', '3', '3',
+			0x18, 0x18,
+			END
+		END
+	};
+
+	struct UnorderedMap13 unordered_map13;
+
+	int err = cbor_decode_UnorderedMap13(payload_unordered_map13,
+			sizeof(payload_unordered_map13), &unordered_map13, NULL);
+	zassert_equal(ZCBOR_SUCCESS, err, "%s %d\n", zcbor_error_str(err), err);
+}
+
+ZTEST_SUITE(cbor_decode_testA, NULL, NULL, NULL, NULL, NULL);

--- a/tests/decode/testA_unordered_map/testcase.yaml
+++ b/tests/decode/testA_unordered_map/testcase.yaml
@@ -1,0 +1,12 @@
+tests:
+  zcbor.decode.testA_unordered_map:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - decode
+      - unordered_map
+      - testA

--- a/tests/scripts/test_zcbor.py
+++ b/tests/scripts/test_zcbor.py
@@ -2079,6 +2079,19 @@ class OtherTests(TestCase):
         cp_from_cddl("foo = ?(false / 0) .default false").my_types["foo"]
         cp_from_cddl("foo = ?(false / 0) .default 0").my_types["foo"]
 
+    def test_nested_map_tstr_keys(self):
+        cddl = """foo = {"map1": {"map2": uint, "map3": uint}}"""
+        parsed = cp_from_cddl(cddl).my_types["foo"]
+        self.assertEqual("MAP", parsed.type)
+        self.assertEqual(1, len(parsed.value))
+        self.assertEqual("MAP", parsed.value[0].type)
+        self.assertEqual(2, len(parsed.value[0].value))
+        self.assertEqual("map1", parsed.value[0].key.value)
+        self.assertEqual("UINT", parsed.value[0].value[0].type)
+        self.assertEqual("map2", parsed.value[0].value[0].key.value)
+        self.assertEqual("UINT", parsed.value[0].value[1].type)
+        self.assertEqual("map3", parsed.value[0].value[1].key.value)
+
 
 if __name__ == "__main__":
     main()

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -1244,7 +1244,7 @@ class CddlParser:
         match_uint = r"(0x[0-9a-fA-F]+|0o[0-7]+|0b[01]+|\d+)"  # Matches unsigned integers in decimal, hexadecimal, octal, or binary
         match_nint = r"(-" + match_uint + ")"
 
-        quotes = r"{startend}(?P<item>.*?)(?<!\\){startend}"  # Regex for string enclosed by quotes (start and end are the same)
+        quotes = r"{startend}(?P<item>(\\{startend}|[^{startend}])*?)(?<!\\){startend}"  # Regex for string enclosed by quotes (start and end are the same)
         parens = r"(?P<{name}>{start}(?P<item>(?>[^{start}{end}]+|(?&{name}))*){end})"  # Regex for string enclosed by parens/brackets (start and end are different)
 
         quote = quotes.format(startend=r"\'")

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -1599,6 +1599,7 @@ class CddlXcoder(CddlParser):
         self.dependsOnCall = False
         self.skipped = False
         self.stored_id = None
+        self.unordered_maps = False
 
     def var_name(self, with_prefix=False, observe_skipped=True):
         """Name of variables and enum members for this element."""
@@ -1614,6 +1615,7 @@ class CddlXcoder(CddlParser):
             name = name.capitalize()
         elif name in c_keywords_underscore:
             name = "_" + name
+        assert name is not None and name != "None", "No name for %s" % self
         return name
 
     def skip_condition(self):
@@ -1853,6 +1855,11 @@ class CddlXcoder(CddlParser):
             or self.type_def_condition()
             or (self.type in ["LIST", "MAP"])
             or (self.type == "GROUP" and len(self.value) != 0)
+            or (
+                self.unordered_maps
+                and self.is_key
+                and (self.repeated_single_func_impl_condition() or self.range_check_condition())
+            )
         )
 
     def repeated_single_func_impl_condition(self):
@@ -2524,6 +2531,7 @@ class CodeGenerator(CddlXcoder):
         add_defines=False,
         default_bit_size=defaults["default_bit_size"],
         default_max_qty_define="ZCBOR_DEFAULT_MAX_QTY",
+        unordered_maps=False,
         **kwargs,
     ):
         super(CodeGenerator, self).__init__(**kwargs)
@@ -2532,6 +2540,7 @@ class CodeGenerator(CddlXcoder):
         self.add_defines = add_defines
         self.default_bit_size = default_bit_size
         self.default_max_qty_define = default_max_qty_define
+        self.unordered_maps = unordered_maps
 
     @classmethod
     def from_cddl(cddl_class, *, mode, **kwargs):
@@ -2565,6 +2574,7 @@ class CodeGenerator(CddlXcoder):
             "add_defines": self.add_defines,
             "default_bit_size": self.default_bit_size,
             "default_max_qty_define": self.default_max_qty_define,
+            "unordered_maps": self.unordered_maps,
         }
 
     def delegate_type_condition(self):
@@ -2997,8 +3007,12 @@ class CodeGenerator(CddlXcoder):
         else:
             return self.single_func_prim(self.repeated_val_access(), ptr_result=ptr_result)
 
-    def has_backup(self):
-        return self.cbor_var_condition() or self.type in ["LIST", "MAP", "UNION"]
+    def num_backups_self(self):
+        return (
+            int(self.cbor_var_condition())
+            + int(self.type in ["LIST", "MAP", "UNION"])
+            + int(self.multi_decode_w_backup_condition())
+        )
 
     def num_backups(self):
         """Calculate the number of state var backups needed for this element and all descendants."""
@@ -3011,9 +3025,139 @@ class CodeGenerator(CddlXcoder):
             total += max([child.num_backups() for child in self.value] + [0])
         if self.type == "OTHER":
             total += self.my_types[self.value].num_backups()
-        if self.has_backup():
-            total += 1
+        total += self.num_backups_self()
         return total
+
+    def _num_map_search_flags(self, is_in_map=False):
+        """Calculate the number of map search flags needed for this element and all descendants.
+
+        When maps are nested, they all need flags at the same time, so this functions finds the
+        "longest path", i.e. which combination of nestings needs the highest number of flags.
+
+        Some of the calculations are returned as strings representing C expressions, since they
+        might involve C macros, e.g. *_DEFAULT_MAX_QTY."""
+
+        def s_filter(it):
+            return filter(lambda x: x not in ("", "0"), it)
+
+        def s_sum(it):
+            filtered_it = list(s_filter(it))
+            if all(x.isdigit() for x in filtered_it):
+                return str(sum(int(x) for x in filtered_it))
+            return " + ".join(filtered_it)
+
+        def s_max(it):
+            filtered_it = list(s_filter(it))
+            if len(filtered_it) == 0:
+                return ""
+            elif len(filtered_it) == 1:
+                return str(filtered_it[0])
+            elif all(x.isdigit() for x in filtered_it):
+                return str(max(int(x) for x in filtered_it))
+            else:
+                return f"MAX({filtered_it[0]}, {s_max(filtered_it[1:])})"
+
+        def s_mult(it):
+            list_it = list(it)
+            if len(list_it) == 0 or any(x in ("", "0") for x in list_it):
+                return ""
+            filtered_it = [f"{x}" if "+" in x else x for x in filter(lambda x: x.strip("()") != "1", it)]
+            if all(x.isdigit() for x in filtered_it):
+                return str(prod(int(x) for x in filtered_it))
+            return " * ".join(filtered_it) if filtered_it else "1"
+
+        def s_round_bits_to_nearest_byte(bits_str):
+            if bits_str in ("", "0"):
+                return ""
+            elif bits_str.isdigit():
+                return str(divide_round_up(int(bits_str), 8) * 8)
+            else:
+                return f"ZCBOR_ROUND_UP({bits_str}, 8)"
+
+        total_this = ""  # Number of flags needed for the current map
+        total_nested = ""  # Number of flags needed for nested maps
+        total_multi_decode = 0  # Number of times multi_decode is used in the map
+        total_unions = 0  # Number of nested unions within the map
+
+        if self.multi_decode_w_backup_condition():
+            total_multi_decode += 1
+        if self.key:
+            flags, nested_flags, _, __ = self.key._num_map_search_flags(is_in_map=is_in_map)
+            assert flags == "", "keys cannot have keys"
+            total_nested = s_sum((total_nested, nested_flags))
+            total_this = s_sum((total_this, "1"))
+        if self.cbor_var_condition():
+            flags, nested_flags, _, __ = self.cbor._num_map_search_flags(is_in_map=False)
+            assert flags == "", "Cannot have bare keys directly within .cbor."
+            total_nested = s_sum((total_nested, nested_flags))
+        if self.type in ["LIST", "MAP", "GROUP", "UNION"]:
+            c_is_in_map = {"LIST": False, "MAP": True, "GROUP": is_in_map, "UNION": is_in_map}[self.type]
+            c_flags, c_nested_flags, c_total_multi_decode, c_total_unions = zip(
+                *(child._num_map_search_flags(is_in_map=c_is_in_map) for child in self.value)
+            )
+            total_nested = s_max([total_nested] + list(c_nested_flags))
+            if self.type == "MAP":
+                # Round up to the nearest byte because only whole bytes worth of flags can be
+                # reserved per map.
+                # Also, this is where the flag count is moved from "this" map to a "nested" map.
+                c_flags_rounded = s_round_bits_to_nearest_byte(s_sum(c_flags))
+                if c_flags_rounded not in ("", "0"):
+                    if self.unordered_maps:
+                        multiplier = 1 + max(c_total_multi_decode) + max(c_total_unions)
+                        mult_flags = s_mult((c_flags_rounded, str(multiplier)))
+                        total_nested = s_sum((total_nested, mult_flags))
+                    else:
+                        total_nested = s_sum((total_nested, c_flags_rounded))
+            elif self.type == "LIST":
+                assert not any(c_flags), "Cannot have keys in LIST"
+            elif self.type == "GROUP":
+                total_this = s_sum([total_this] + list(c_flags))
+                total_multi_decode += max(c_total_multi_decode)
+                total_unions += max(c_total_unions)
+            elif self.type == "UNION":
+                # Take the max since only one member of a union will be found at one time.
+                total_this = s_sum((total_this, s_max(c_flags)))
+                total_multi_decode += max(c_total_multi_decode)
+                total_unions += max(c_total_unions)
+                if not self.implicit_union_condition():
+                    total_unions += 1
+
+        if self.type == "OTHER":
+            search_flags_out = self.my_types[self.value]._num_map_search_flags(is_in_map=is_in_map)
+            flags, nested_flags, multi_decode, unions = search_flags_out
+            total_this = s_sum((total_this, flags))
+            total_nested = s_sum((total_nested, nested_flags))
+            total_multi_decode += multi_decode
+            total_unions += unions
+
+        total_this_out = ""
+        equal = self.min_qty == self.max_qty and self.min_qty is not None
+        qty_expr = self.val_define_name_or_lit("MAX_QTY" if not equal else "QTY")
+        max_qty = "1" if self.max_qty == 1 else str(qty_expr)
+        if total_this not in ("", "0"):
+            total_this_out = s_mult((total_this, max_qty))
+        else:
+            total_this_out = ""
+
+        if total_nested not in ("", "0"):
+            if total_nested.isdigit():
+                total_nested_out = total_nested
+            else:
+                total_nested_out = f"({total_nested})"
+        else:
+            total_nested_out = ""
+
+        # Only the total_this is affected by repetitions, because the nested flags are freed and
+        # allocated for each repetition.
+        return total_this_out, total_nested_out, total_multi_decode, total_unions
+
+    def num_map_search_flags(self):
+        """Calculate the number of map search flags needed with this element as root.
+
+        Discard all but the nested flags, assuming there are no flags used before we are in a map.
+        """
+
+        return self._num_map_search_flags()[1]
 
     def depends_on(self):
         """Return a number indicating how many other elements this element depends on.
@@ -3073,22 +3217,71 @@ class CodeGenerator(CddlXcoder):
         }[self.type]()
         return retval
 
+    def is_multiple_elem_group(self):
+        """Recursively determine whether the current element is a GROUP with multiple elements."""
+        if self.type == "UNION":
+            return any(child.is_multiple_elem_group() for child in self.value)
+        elif self.type == "GROUP":
+            if (len(self.value) > 1) and (self.max_qty != self.min_qty):
+                return True
+        elif self.type == "OTHER":
+            if self.my_types[self.value].list_counts() != (1, 1) and (self.max_qty != self.min_qty):
+                return True
+            return self.my_types[self.value].is_multiple_elem_group()
+        return False
+
+    def elem_needs_map_smart_search(self, is_in_map):
+        """Recursively determine whether the current element needs ZCBOR_MAP_SMART_SEARCH defined"""
+        if (
+            is_in_map
+            and self.unordered_maps
+            and (
+                (self.max_qty is None)
+                or (self.max_qty > 1)
+                or (self.key and not self.key.is_unambiguous_repeated())
+            )
+        ):
+            return True
+
+        if (
+            self.type == "OTHER"
+            and (self.value not in self.entry_type_names or is_in_map)
+            and self.my_types[self.value].elem_needs_map_smart_search(is_in_map)
+        ):
+            return True
+
+        # Validation of child elements.
+        if self.type in ["MAP", "LIST", "UNION", "GROUP"]:
+            for child in self.value:
+                if child.elem_needs_map_smart_search(
+                    self.type != "LIST" and (is_in_map or self.type == "MAP")
+                ):
+                    return True
+        if self.cbor:
+            if self.cbor.elem_needs_map_smart_search(False):
+                return True
+
     def xcode_list(self):
         """Return the full code needed to encode/decode a "LIST" or "MAP" element with children."""
         start_func = f"zcbor_{self.type.lower()}_start_{self.mode}"
         end_func = f"zcbor_{self.type.lower()}_end_{self.mode}"
         end_func_force = f"zcbor_list_map_end_force_{self.mode}"
+        if self.type == "MAP" and self.mode == "decode" and self.unordered_maps:
+            start_func = "zcbor_unordered_map_start_decode"
+            end_func = "zcbor_unordered_map_end_decode"
         assert start_func in [
             "zcbor_list_start_decode",
             "zcbor_list_start_encode",
             "zcbor_map_start_decode",
             "zcbor_map_start_encode",
+            "zcbor_unordered_map_start_decode",
         ]
         assert end_func in [
             "zcbor_list_end_decode",
             "zcbor_list_end_encode",
             "zcbor_map_end_decode",
             "zcbor_map_end_encode",
+            "zcbor_unordered_map_end_decode",
         ]
         assert self.type in ["LIST", "MAP"], "Expected LIST or MAP type, was %s." % self.type
         _, max_counts = (
@@ -3114,11 +3307,34 @@ class CodeGenerator(CddlXcoder):
             [self.value[0].full_xcode(union_int)] + [child.full_xcode() for child in self.value[1:]]
         )
 
+    def is_in_map(self):
+        """Return whether this element is in a map (i.e. elements need keys)."""
+        if self.key:
+            return True
+        if self.type in ["LIST", "MAP"]:
+            return False
+        if self.type in ["GROUP", "UNION"]:
+            return any(child.is_in_map() for child in self.value)
+        if self.type == "OTHER":
+            return self.my_types[self.value].is_in_map()
+
+    def expect_union_condition(self):
+        """Whether this UNION element can be decoded without union_start/union_end functions.
+
+        Union optimization is disabled in unordered maps because unpredictable key ordering
+        means we cannot know that any current element is part of the union.
+        """
+        return self.is_int_disambiguated() and not (self.unordered_maps and self.is_in_map())
+
+    def implicit_union_condition(self):
+        """Whether this element is a UNION that can be encoded/decoded without union_start/union_end functions."""
+        return self.all_children_int_disambiguated() and not (self.unordered_maps and self.is_in_map())
+
     def xcode_union(self):
         """Return the full code needed to encode/decode a "UNION" element's children."""
         assert self.type in ["UNION"], "Expected UNION type."
         if self.mode == "decode":
-            if self.all_children_int_disambiguated():
+            if self.implicit_union_condition():
                 lines = []
                 lines.extend(
                     [
@@ -3131,7 +3347,6 @@ class CodeGenerator(CddlXcoder):
                         for child in self.value
                     ]
                 )
-                bit_size = self.value[0].bit_size()
                 func = (
                     f"zcbor_uint_{self.mode}"
                     if self.all_children_uint_disambiguated()
@@ -3148,7 +3363,7 @@ class CodeGenerator(CddlXcoder):
             child_values = [
                 "(%s && ((%s = %s), true))"
                 % (
-                    child.full_xcode(union_int="EXPECT" if child.is_int_disambiguated() else None),
+                    child.full_xcode(union_int="EXPECT" if child.expect_union_condition() else None),
                     self.choice_var_access(),
                     child.enum_var_name(),
                 )
@@ -3157,16 +3372,20 @@ class CodeGenerator(CddlXcoder):
 
             # Reset state for all but the first child.
             for i in range(1, len(child_values)):
-                if (not self.value[i].is_int_disambiguated()) and self.value[
-                    i - 1
-                ].simple_func_condition():
+                if (
+                    not self.value[i].expect_union_condition()
+                    and self.value[i - 1].simple_func_condition()
+                ):
                     child_values[i] = f"(zcbor_union_elem_code(state) && {child_values[i]})"
 
             child_code = f"{newl_ind}|| ".join(child_values)
-            return (
-                f"(zcbor_union_start_code(state) "
-                + f"&& (int_res = ({child_code}), zcbor_union_end_code(state), int_res))"
-            )
+            if len(self.value) > 0:
+                return (
+                    f"(zcbor_union_start_code(state) "
+                    + f"&& (int_res = ({child_code}), zcbor_union_end_code(state), int_res))"
+                )
+            else:
+                return f"({child_code})"
         else:
             return ternary_if_chain(
                 self.choice_var_access(),
@@ -3372,6 +3591,17 @@ class CodeGenerator(CddlXcoder):
 
         return range_checks
 
+    def xcode_key(self, union_int):
+        if self.mode == "decode" and self.unordered_maps and union_int != "DROP":
+            func, *arguments = self.key.single_func(
+                self.key.val_access(), union_int=union_int, ptr_result=True
+            )
+            assert func is not None, "Function missing (union_int issue?)."
+            x_args = xcode_args(*arguments)
+            return [f"zcbor_unordered_map_search(ZCBOR_CUSTOM_CAST_FP({func}), {x_args})"]
+        else:
+            return [self.key.full_xcode(union_int=union_int)]
+
     def repeated_xcode(self, union_int=None, top_level=False):
         """Return the full code needed to encode/decode this element.
 
@@ -3402,12 +3632,14 @@ class CodeGenerator(CddlXcoder):
         }[self.type]
         xcoders = []
         if self.key:
-            xcoders.append(self.key.full_xcode(union_int))
+            xcoders.extend(self.xcode_key(union_int))
         if self.tags:
             xcoders.extend(self.xcode_tags())
         if self.mode == "decode":
             xcoders.append(xcoder())
             xcoders.extend(range_checks)
+            if self.key and self.unordered_maps:
+                xcoders.append("zcbor_elem_processed(state)")
         elif self.type == "BSTR" and self.cbor:
             xcoders.append(xcoder())
             xcoders.extend(self.range_checks("tmp_str"))
@@ -3423,6 +3655,11 @@ class CodeGenerator(CddlXcoder):
             return "0"
         else:
             return "sizeof(%s)" % self.repeated_type_name()
+
+    def multi_decode_w_backup_condition(self):
+        return (
+            self.count_var_condition() or self.present_var_condition()
+        ) and self.repeated_single_func_impl_condition()
 
     def full_xcode(self, union_int=None, top_level=False):
         """Return the full code needed to encode/decode this element.
@@ -3467,23 +3704,24 @@ class CodeGenerator(CddlXcoder):
                         default_assignment, f"{self.present_var_access()} = {decode_str}", "true"
                     )
                 func, *arguments = self.repeated_single_func(ptr_result=True)
+                present_func = (
+                    "zcbor_present_decode"
+                    if not self.multi_decode_w_backup_condition()
+                    else "zcbor_present_decode_w_backup"
+                )
                 return comma_operator(
                     default_assignment,
-                    f"(zcbor_present_decode(&(%s), ZCBOR_CUSTOM_CAST_FP(%s), %s))"
-                    % (
-                        self.present_var_access(),
-                        func,
-                        xcode_args(*arguments),
-                    ),
+                    f"({present_func}(&({self.present_var_access()}), ZCBOR_CUSTOM_CAST_FP({func}), {xcode_args(*arguments)}))",
                 )
 
         elif self.count_var_condition():
             func, arg = self.repeated_single_func(ptr_result=True)
 
-            minmax = "_minmax" if self.mode == "encode" else ""
-            mode = self.mode
+            multi_func = "zcbor_multi_decode" if self.mode == "decode" else "zcbor_multi_encode_minmax"
+            if self.mode == "decode" and self.multi_decode_w_backup_condition():
+                multi_func = "zcbor_multi_decode_w_backup"
             equal = self.min_qty == self.max_qty and self.min_qty is not None
-            return f"zcbor_multi_{mode}{minmax}(%s, %s, &%s, ZCBOR_CUSTOM_CAST_FP(%s), %s, %s)" % (
+            return f"{multi_func}(%s, %s, &%s, ZCBOR_CUSTOM_CAST_FP(%s), %s, %s)" % (
                 self.val_define_name_or_lit("MIN_QTY" if not equal else "QTY"),
                 self.val_define_name_or_lit("MAX_QTY" if not equal else "QTY"),
                 self.count_var_access(),
@@ -3561,6 +3799,8 @@ class CodeRenderer:
             modes = [modes]
         assert isinstance(modes, list), "modes must be a list of strings."
 
+        self.needs_map_smart_search = {"encode": False, "decode": False}
+
         # Sort type definitions so the typedefs will come in the correct order in the header file
         # and the function in the correct order in the c file.
         for mode in modes:
@@ -3572,6 +3812,11 @@ class CodeRenderer:
             self.functions[mode] = self.used_funcs(mode)
             self.type_defs[mode] = self.unique_types(mode)
             self.defines[mode] = self.used_defines(mode)
+
+            if mode == "decode":
+                self.needs_map_smart_search[mode] = any(
+                    t.elem_needs_map_smart_search(False) for t in self.sorted_types[mode]
+                )
 
         self.version = __version__
 
@@ -3677,8 +3922,10 @@ static bool {xcoder.func_name}(zcbor_state_t *state, {"" if mode == "decode" els
         func_re = rf"ZCBOR_CUSTOM_CAST_FP\((?P<func>{arg_re})\)"
         # Match a triplet of function pointer, state arg, and result arg.
         call_re = rf"{func_re}, (?P<state>{arg_re}), (?P<arg>{arg_re})"
-        multi_re = rf"{paren_re}zcbor_multi_(en|de)code(_minmax)?\(({arg_re},){{3}} {call_re}"
-        present_re = rf"{paren_re}zcbor_present_(en|de)code\({arg_re}, {call_re}\)"
+        multi_re = (
+            rf"{paren_re}zcbor_multi_(en|de)code(_minmax)?(_w_backup)?\(({arg_re},){{3}} {call_re}"
+        )
+        present_re = rf"{paren_re}zcbor_present_(en|de)code(_w_backup)?\({arg_re}, {call_re}\)"
         map_re = rf"{paren_re}zcbor_unordered_map_search\({call_re}\)"
         all_funcs = chain(
             getrp(multi_re).finditer(body),
@@ -3724,22 +3971,65 @@ static bool {xcoder.func_name}(
 	return res;
 }}""".replace("	\n", "")  # call replace() to remove empty lines.
 
+    def _calculate_elem_state_requirements(self, xcoder, mode):
+        """Calculate state and flag requirements for unordered maps."""
+        base_states = f"{xcoder.val_define_name_or_lit('NUM_BACKUPS')} + ZCBOR_EXTRA_STATES"
+        if not (
+            xcoder.unordered_maps
+            and mode == "decode"
+            and (num_flags := xcoder.num_map_search_flags()) not in ("", "0")
+        ):
+            # No flags needed.
+            return "", base_states, "zcbor_entry_function", []
+
+        # Calculate total_states at compile time (because it depends on sizeof(zcbor_state_t))
+        num_flags_var = f"const size_t num_flags = {num_flags};"
+        total_states = base_states + f" + ZCBOR_FLAG_STATES(num_flags)"
+        entry_func = "zcbor_entry_function_with_elem_states"
+        extra_args = ["num_flags"]
+
+        return num_flags_var, total_states, entry_func, extra_args
+
     def render_entry_function(self, xcoder, mode):
         """Render a single entry function (API function) with signature and body."""
         func_name, func_arg = (xcoder.xcode_func_name(), struct_ptr_name(mode))
         elem_count = "ZCBOR_LARGE_ELEM_COUNT" if mode == "decode" else "0"
+
+        arg_list = [
+            "payload",
+            "payload_len",
+            f"(void *){func_arg}",
+            "payload_len_out",
+            "states",
+            f"(zcbor_decoder_t *)ZCBOR_CUSTOM_CAST_FP({func_name})",
+            "sizeof(states) / sizeof(zcbor_state_t)",
+            f"{elem_count}",
+        ]
+
+        num_flags_var, num_states, entry_func, extra_args = self._calculate_elem_state_requirements(
+            xcoder, mode
+        )
+        arg_list += extra_args
+
         return f"""
 {xcoder.public_xcode_func_sig()}
 {{
-	zcbor_state_t states[{xcoder.val_define_name_or_lit("NUM_BACKUPS")} + ZCBOR_EXTRA_STATES];
+	{num_flags_var}
+	zcbor_state_t states[{num_states}];
 {self.render_arg_check(((func_name, "states", func_arg),))}
-	return zcbor_entry_function(payload, payload_len, (void *){func_arg}, payload_len_out, states,
-		(zcbor_decoder_t *)ZCBOR_CUSTOM_CAST_FP({func_name}), sizeof(states) / sizeof(zcbor_state_t), {elem_count});
-}}"""
+	return {entry_func}({', '.join(arg_list)});
+}}""".replace("	\n", "")  # call replace() to remove empty lines.
 
     def render_file_header(self, line_prefix):
         lp = line_prefix
         return (f"\n{lp} " + self.file_header.replace("\n", f"\n{lp} ")).replace(" \n", "\n")
+
+    def render_smart_search_check(self):
+        return """
+#ifndef ZCBOR_MAP_SMART_SEARCH
+#error "This file needs ZCBOR_MAP_SMART_SEARCH to function"
+#endif
+"""
 
     def render_c_file(self, header_file_name, mode):
         """Render the entire generated C file contents."""
@@ -3765,6 +4055,7 @@ do { \\
 
 {self.render_cast_macro(mode)}
 
+{self.render_smart_search_check() if self.needs_map_smart_search[mode] else ''}
 {log_result_define}
 
 {linesep.join([self.render_forward_declaration(xcoder, mode) for xcoder in self.functions[mode]])}
@@ -3866,6 +4157,8 @@ extern "C" {{
                 )
             )
         )
+        add_smart_search = any(self.needs_map_smart_search[mode] for mode in ("decode", "encode"))
+        smart_search = f"\ntarget_compile_definitions({target_name} PUBLIC ZCBOR_MAP_SMART_SEARCH)\n"
 
         def relativify(p):
             try:
@@ -3891,7 +4184,7 @@ target_sources({target_name} PRIVATE
 target_include_directories({target_name} PUBLIC
     {(linesep + "    ").join(((str(relativify(f)) for f in include_dirs)))}
     )
-"""
+{f'{smart_search}' if add_smart_search else ''}"""
 
     def render(
         self,
@@ -4165,6 +4458,21 @@ the file's contents will be used.""",
 generated header file. This is off by default because it may create naming conflicts that don't
 show up otherwise.""",
     )
+    code_parser.add_argument(
+        "--unordered-maps",
+        required=False,
+        action="store_true",
+        default=False,
+        help="""[EXPERIMENTAL] Generate code in such a way that it can decode maps with unknown
+element order.
+When enabled, the generated code will use the zcbor_unordered_map_*() API to decode data
+whenever inside a map.
+zcbor detects from the CDDL whether ZCBOR_MAP_SMART_SEARCH is needed and enables it in the generated
+cmake file if so.
+Enabling --unordered-maps places some restrictions on the level of ambiguity allowed between map
+keys in a map.
+This option only affects decoding (--decode/-d).""",
+    )
     code_parser.set_defaults(process=process_code)
 
     validate_parent_parser = ArgumentParser(add_help=False)
@@ -4333,6 +4641,7 @@ def process_code(args):
                 entry_type_names=args.entry_types,
                 add_defines=args.defines,
                 default_bit_size=args.default_bit_size,
+                unordered_maps=args.unordered_maps,
                 short_names=args.short_names,
                 default_max_qty_define=default_max_qty_define,
             )


### PR DESCRIPTION
Add support for the --unordered-maps option to zcbor code
which makes use of the zcbor_unordered_maps_*() API in generated code.

Fixes #411 