### PR TITLE
zcbor_common.h: Introduce the ZCBOR_CAST_FP() macro

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -5,6 +5,11 @@
   Arguments have not changed otherwise.
   This was done to avoid ambiguity to do with positional arguments, and generally simplify passing arguments around inside zcbor.
 
+* [Recommended] A new macro `ZCBOR_CAST_FP` has been added for casting function pointers for use in the zcbor API.
+  The macro will first check that the function pointer has one of the supported signatures.
+  You are recommended to use it on any function pointer that is passed as an argument to a zcbor function.
+  See the macro documentation in zcbor_common.h for more info.
+
 * Code generation:
 
   * Integers whose values are known to be within 8 or 16 bytes now use the corresponding integer types (`uint8_t`/`int8_t`/`uint16_t`/`int16_t`) instead of larger types.

--- a/include/zcbor_decode.h
+++ b/include/zcbor_decode.h
@@ -203,6 +203,8 @@ bool zcbor_unordered_map_start_decode(zcbor_state_t *state);
  *                         keys in the map until it returns true, at which point
  *                         @ref zcbor_unordered_map_search will return true.
  *                         For example, a zcbor_*_pexpect() function.
+ *                         Please use @ref ZCBOR_CAST_FP to cast the function
+ *                         since it will also check for compatibility.
  * @param[inout] state  The current state of decoding. Must be currently decoding
  *                      the contents of a map, and pointing to one (any) of the
  *                      keys, not one of the values. If successful, the @p state
@@ -337,6 +339,8 @@ bool zcbor_any_skip(zcbor_state_t *state, void *unused);
  *                           an array of result variables.
  *                           Should not be an _expect() function, use
  *                           _pexpect() instead.
+ *                           Please use @ref ZCBOR_CAST_FP to cast the function
+ *                           since it will also check for compatibility.
  * @param[out] result        Where to place the decoded values. Must be an array
  *                           of at least @p max_decode elements.
  * @param[in]  result_len    The length of each result variable. Must be the
@@ -357,6 +361,8 @@ bool zcbor_multi_decode(size_t min_decode, size_t max_decode, size_t *num_decode
  *
  * @param[out] present  Whether or not the data was present and successfully decoded.
  * @param[in]  decoder  The decoder to attempt.
+ *                      Please use @ref ZCBOR_CAST_FP to cast the function
+ *                      since it will also check for compatibility.
  * @param[out] result   The result, if present.
  *
  * @return Should always return true.

--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -176,6 +176,8 @@ bool zcbor_list_map_end_force_encode(zcbor_state_t *state);
  *                           The input pointer is moved @p input_len bytes for
  *                           each call to @p encoder, i.e. @p input refers to an
  *                           array of input variables.
+ *                           Please use @ref ZCBOR_CAST_FP to cast the function
+ *                           since it will also check for compatibility.
  * @param[in]  input         Source of the encoded values. Must be an array of
  *                           at least @p max_encode elements.
  * @param[in]  input_len     The length of the input variables. Must be the

--- a/src/zcbor_common.c
+++ b/src/zcbor_common.c
@@ -471,3 +471,13 @@ size_t strnlen (const char *s, size_t maxlen)
 	}
 	return i;
 }
+
+
+bool zcbor_cast_error(zcbor_state_t *state, void *unused)
+{
+	(void)state;
+	(void)unused;
+	zcbor_log("This function should never be called.\n");
+	zcbor_log("It means ZCBOR_CAST_FP() was called with a bad function pointer.\n");
+	ZCBOR_ERR(ZCBOR_ERR_BAD_ARG);
+}

--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -1149,7 +1149,7 @@ bool zcbor_search_key_bstr_ptr(zcbor_state_t *state, char const *ptr, size_t len
 {
 	struct zcbor_string zs = { .value = (const uint8_t *)ptr, .len = len };
 
-	return zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_bstr_expect, state, &zs);
+	return zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_bstr_expect), state, &zs);
 }
 
 
@@ -1157,7 +1157,7 @@ bool zcbor_search_key_tstr_ptr(zcbor_state_t *state, char const *ptr, size_t len
 {
 	struct zcbor_string zs = { .value = (const uint8_t *)ptr, .len = len };
 
-	return zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_tstr_expect, state, &zs);
+	return zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_tstr_expect), state, &zs);
 }
 
 

--- a/tests/unit/test1_unit_tests/src/main.c
+++ b/tests/unit/test1_unit_tests/src/main.c
@@ -288,8 +288,8 @@ ZTEST(zcbor_unit_tests, test_stop_on_error)
 	zassert_false(zcbor_map_start_encode(state_e, 0), NULL);
 	zassert_false(zcbor_map_end_encode(state_e, 0), NULL);
 	zassert_false(zcbor_list_end_encode(state_e, 1), NULL);
-	zassert_false(zcbor_multi_encode(1, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)14, 0), NULL);
-	zassert_false(zcbor_multi_encode_minmax(1, 1, &(size_t){1}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)15, 0), NULL);
+	zassert_false(zcbor_multi_encode(1, ZCBOR_CAST_FP(zcbor_int32_encode), state_e, &(int32_t){14}, 0), NULL);
+	zassert_false(zcbor_multi_encode_minmax(1, 1, &(size_t){1}, ZCBOR_CAST_FP(zcbor_int32_encode), state_e, &(int32_t){15}, 0), NULL);
 
 
 	zassert_mem_equal(&state_backup, state_e, sizeof(state_backup), NULL);
@@ -349,8 +349,8 @@ ZTEST(zcbor_unit_tests, test_stop_on_error)
 	zassert_true(zcbor_map_start_encode(state_e, 0), NULL);
 	zassert_true(zcbor_map_end_encode(state_e, 0), NULL);
 	zassert_true(zcbor_list_end_encode(state_e, 1), NULL);
-	zassert_true(zcbor_multi_encode(1, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)14, 0), NULL);
-	zassert_true(zcbor_multi_encode_minmax(1, 1, &(size_t){1}, (zcbor_encoder_t *)zcbor_int32_put, state_e, (void*)15, 0), NULL);
+	zassert_true(zcbor_multi_encode(1, ZCBOR_CAST_FP(zcbor_int32_encode), state_e, &(int32_t){14}, 0), NULL);
+	zassert_true(zcbor_multi_encode_minmax(1, 1, &(size_t){1}, ZCBOR_CAST_FP(zcbor_int32_encode), state_e, &(int32_t){15}, 0), NULL);
 
 	ZCBOR_STATE_D(state_d, 3, payload, sizeof(payload), 50, 0);
 	state_d->constant_state->stop_on_error = true;
@@ -410,8 +410,8 @@ ZTEST(zcbor_unit_tests, test_stop_on_error)
 	zassert_false(zcbor_map_start_decode(state_d), NULL);
 	zassert_false(zcbor_map_end_decode(state_d), NULL);
 	zassert_false(zcbor_list_end_decode(state_d), NULL);
-	zassert_false(zcbor_multi_decode(1, 1, &(size_t){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)14, 0), NULL);
-	zassert_false(zcbor_present_decode(&(bool){true}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)15), NULL);
+	zassert_false(zcbor_multi_decode(1, 1, &(size_t){1}, ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d, &(int32_t){14}, 0), NULL);
+	zassert_false(zcbor_present_decode(&(bool){true}, ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d, &(int32_t){15}), NULL);
 
 	zassert_mem_equal(&state_backup, state_d, sizeof(state_backup), NULL);
 	zassert_mem_equal(&constant_state_backup, state_d->constant_state, sizeof(constant_state_backup), NULL);
@@ -468,8 +468,8 @@ ZTEST(zcbor_unit_tests, test_stop_on_error)
 	zassert_true(zcbor_map_start_decode(state_d), NULL);
 	zassert_true(zcbor_map_end_decode(state_d), NULL);
 	zassert_true(zcbor_list_end_decode(state_d), NULL);
-	zassert_true(zcbor_multi_decode(1, 1, &(size_t){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)14, 0), NULL);
-	zassert_true(zcbor_present_decode(&(bool){1}, (zcbor_decoder_t *)zcbor_int32_expect, state_d, (void*)15), NULL);
+	zassert_true(zcbor_multi_decode(1, 1, &(size_t){1}, ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d, &(int32_t){14}, 0), NULL);
+	zassert_true(zcbor_present_decode(&(bool){1}, ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d, &(int32_t){15}), NULL);
 
 	/* Everything has been decoded. */
 	zassert_equal(state_e->payload, state_d->payload, NULL);
@@ -1230,10 +1230,10 @@ ZTEST(zcbor_unit_tests, test_pexpect)
 void decode_inner_map(zcbor_state_t *state, void *result)
 {
 	zassert_true(zcbor_unordered_map_start_decode(state), NULL);
-	zassert_true(zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_bool_pexpect, state, &(bool){false}), NULL);
+	zassert_true(zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_bool_pexpect), state, &(bool){false}), NULL);
 	zassert_true(zcbor_undefined_expect(state, NULL), NULL);
 	zcbor_elem_processed(state);
-	zassert_true(zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_tstr_expect, state, &(struct zcbor_string){"hello", 5}), NULL);
+	zassert_true(zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_tstr_expect), state, &(struct zcbor_string){"hello", 5}), NULL);
 	zassert_true(zcbor_tstr_expect(state, &(struct zcbor_string){"world", 5}), NULL);
 	zcbor_elem_processed(state);
 	bool ret = zcbor_unordered_map_end_decode(state);
@@ -1312,7 +1312,7 @@ ZTEST(zcbor_unit_tests, test_unordered_map)
 
 	/* Test empty map */
 	zassert_true(zcbor_unordered_map_start_decode(state_d), NULL);
-	zassert_false(zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_int32_pexpect, state_d, &(int32_t){2}), NULL);
+	zassert_false(zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d, &(int32_t){2}), NULL);
 	zassert_equal(ZCBOR_ERR_ELEM_NOT_FOUND, zcbor_peek_error(state_d), "err: %d\n", zcbor_peek_error(state_d));
 	ret = zcbor_unordered_map_end_decode(state_d);
 	zassert_true(ret, "err: %d\n", zcbor_peek_error(state_d));
@@ -1320,7 +1320,7 @@ ZTEST(zcbor_unit_tests, test_unordered_map)
 
 	/* Test single entry map */
 	zassert_true(zcbor_unordered_map_start_decode(state_d), NULL);
-	ret = zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_int32_pexpect, state_d, &(int32_t){1});
+	ret = zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d, &(int32_t){1});
 	zassert_true(ret, "err: %d\n", zcbor_peek_error);
 	zassert_true(zcbor_int32_expect(state_d, 1), NULL);
 	ret = zcbor_unordered_map_end_decode(state_d);
@@ -1333,15 +1333,15 @@ ZTEST(zcbor_unit_tests, test_unordered_map)
 	zassert_false(zcbor_elem_processed(state_d2), NULL);
 	int err = zcbor_pop_error(state_d2);
 	zassert_equal(err, ZCBOR_ERR_MAP_MISALIGNED, "err: %d\n", err);
-	zassert_false(zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_int32_pexpect, state_d2, &(int32_t){3}), NULL);
-	ret = zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_int32_pexpect, state_d2, &(int32_t){2});
+	zassert_false(zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d2, &(int32_t){3}), NULL);
+	ret = zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d2, &(int32_t){2});
 	zassert_true(ret, "err: %d\n", zcbor_peek_error(state_d2));
-	zassert_false(zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_int32_pexpect, state_d2, &(int32_t){1}), NULL);
+	zassert_false(zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d2, &(int32_t){1}), NULL);
 	zassert_equal(zcbor_peek_error(state_d2), ZCBOR_ERR_MAP_MISALIGNED, NULL);
 	zassert_true(zcbor_int32_expect(state_d2, 2), NULL);
 	zassert_true(zcbor_array_at_end(state_d2), NULL);
-	zassert_false(zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_int32_pexpect, state_d2, &(int32_t){3}), NULL);
-	zassert_true(zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_int32_pexpect, state_d2, &(int32_t){1}), NULL);
+	zassert_false(zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d2, &(int32_t){3}), NULL);
+	zassert_true(zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d2, &(int32_t){1}), NULL);
 	zassert_true(zcbor_int32_expect(state_d2, 1), NULL);
 	ret = zcbor_unordered_map_end_decode(state_d2);
 	zassert_true(ret, NULL);
@@ -1352,7 +1352,7 @@ ZTEST(zcbor_unit_tests, test_unordered_map)
 	zassert_false(zcbor_unordered_map_start_decode(state_d3), NULL);
 #else
 	zassert_true(zcbor_unordered_map_start_decode(state_d3), NULL);
-	zassert_false(zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_int32_pexpect, state_d3, &(int32_t){2}), NULL);
+	zassert_false(zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d3, &(int32_t){2}), NULL);
 #endif
 	zassert_equal(zcbor_peek_error(state_d3), ZCBOR_ERR_MAP_FLAGS_NOT_AVAILABLE, NULL);
 #endif
@@ -1365,17 +1365,17 @@ ZTEST(zcbor_unit_tests, test_unordered_map)
 #ifndef ZCBOR_CANONICAL
 	zcbor_elem_processed(state_d); // Should do nothing because no elements have been discovered.
 #endif
-	zassert_true(zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_int32_pexpect, state_d, &(int32_t){1}), NULL);
+	zassert_true(zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d, &(int32_t){1}), NULL);
 	zassert_true(zcbor_int32_expect(state_d, 1), NULL);
 	ret = zcbor_unordered_map_end_decode(state_d);
 	zassert_false(ret, NULL);
 	zassert_equal(ZCBOR_ERR_ELEMS_NOT_PROCESSED, zcbor_peek_error(state_d), NULL);
 	/* Cause a restart of the map */
-	zassert_false(zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_int32_pexpect, state_d, &(int32_t){3}), NULL);
+	zassert_false(zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d, &(int32_t){3}), NULL);
 	ret = zcbor_unordered_map_end_decode(state_d);
 	zassert_false(ret, NULL);
 	zassert_equal(ZCBOR_ERR_ELEMS_NOT_PROCESSED, zcbor_peek_error(state_d), NULL);
-	zassert_true(zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_int32_pexpect, state_d, &(int32_t){2}), NULL);
+	zassert_true(zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d, &(int32_t){2}), NULL);
 	zassert_true(zcbor_int32_expect(state_d, 2), NULL);
 	ret = zcbor_unordered_map_end_decode(state_d);
 	zassert_true(ret, "err: %d\n", zcbor_peek_error(state_d));
@@ -1384,18 +1384,19 @@ ZTEST(zcbor_unit_tests, test_unordered_map)
 	/* Test a large map, including nesting. */
 	state_d->constant_state->manually_process_elem = true;
 	zassert_true(zcbor_unordered_map_start_decode(state_d), NULL);
-	ret = zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_int32_pexpect, state_d, &(int32_t){-1});
+	ret = zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d, &(int32_t){-1});
 	zassert_true(ret, "err: %d\n", zcbor_peek_error(state_d));
 	zassert_true(zcbor_tstr_decode(state_d, &str_result1), NULL);
 	zcbor_elem_processed(state_d);
 
-	zassert_true(zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_bool_pexpect, state_d, &(bool){true}), NULL);
+	zassert_true(zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_bool_pexpect), state_d, &(bool){true}), NULL);
 	zassert_true(zcbor_tstr_decode(state_d, &str_result2), NULL);
 	zcbor_elem_processed(state_d);
-	zassert_true(zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_int32_pexpect, state_d, &(int32_t){2}), NULL);
+	zassert_true(zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d, &(int32_t){2}), NULL);
 	zassert_true(zcbor_int32_decode(state_d, &int_result1), NULL);
 	zcbor_elem_processed(state_d);
-	zassert_true(zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_int32_pexpect, state_d, &(int32_t){1}), NULL);
+	ret = zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d, &(int32_t){1});
+	zassert_true(ret, "%s\n", zcbor_error_str(zcbor_peek_error(state_d)));
 	zassert_true(zcbor_tstr_decode(state_d, &str_result3), NULL);
 	zcbor_elem_processed(state_d);
 
@@ -1435,7 +1436,7 @@ ZTEST(zcbor_unit_tests, test_unordered_map)
 	zcbor_elem_processed(state_d);
 
 	for (size_t i = 34; i > 2; i--) {
-		zassert_true(zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_int32_pexpect, state_d, &i), "i: %d, err: %d\n", i, zcbor_peek_error(state_d));
+		zassert_true(zcbor_unordered_map_search(ZCBOR_CAST_FP(zcbor_int32_pexpect), state_d, &i), "i: %d, err: %d\n", i, zcbor_peek_error(state_d));
 		zassert_false(zcbor_int32_expect(state_d, i), NULL);
 		zassert_true(zcbor_int32_expect(state_d, -1 * i), NULL);
 		zcbor_elem_processed(state_d);


### PR DESCRIPTION
for casting function pointers.