### PR TITLE
tests: Update testcase.yaml files to not use space-separated lists

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -259,7 +259,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         asserts: ["", "-x VERBOSE=ON -x ASSERTS=ON"]
     name: Release tests 3 (Python ${{ matrix.python-version }}${{ matrix.asserts != '' && ' with asserts' || '' }})
     needs:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.x"
 
     - name: Checkout Zephyr
       run: |
@@ -120,10 +120,7 @@ jobs:
 
   merge-test-2-win:
     runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: ['3.12']
-    name: Merge tests 2 - Python (${{ matrix.python-version }}) functional tests (Windows)
+    name: Merge tests 2 - Python (latest) functional tests (Windows)
     steps:
     - name: Checkout the code
       uses: actions/checkout@v4
@@ -131,7 +128,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.x'
 
     - name: Read zcbor version
       run: |
@@ -166,7 +163,8 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.x'
+        check-latest: true
 
     - name: Install zcbor
       uses: ./.github/actions/install_zcbor

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -8,7 +8,7 @@ on:
 
 env:
   ZEPHYR_SDK_VERSION: 0.17.0
-  ZEPHYR_REV: c3466b14d09b1e51b6ca472f3b3654e40cba12d8
+  ZEPHYR_REV: 3142c51d87a11e54a0eb4381f22ab377e3b8bdb0
 
 jobs:
   merge-test-1:

--- a/tests/decode/test1_suit_old_formats/testcase.yaml
+++ b/tests/decode/test1_suit_old_formats/testcase.yaml
@@ -1,4 +1,11 @@
 tests:
   zcbor.decode.test1_suit_old_formats:
-    platform_allow: native_sim native_sim/native/64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor decode test1
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - decode
+      - test1

--- a/tests/decode/test2_suit/testcase.yaml
+++ b/tests/decode/test2_suit/testcase.yaml
@@ -1,4 +1,11 @@
 tests:
   zcbor.decode.test2_suit:
-    platform_allow: native_sim native_sim/native/64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor decode test2
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - decode
+      - test2

--- a/tests/decode/test3_simple/testcase.yaml
+++ b/tests/decode/test3_simple/testcase.yaml
@@ -1,4 +1,11 @@
 tests:
   zcbor.decode.test3_simple:
-    platform_allow: native_sim native_sim/native/64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor decode test3
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - decode
+      - test3

--- a/tests/decode/test5_corner_cases/testcase.yaml
+++ b/tests/decode/test5_corner_cases/testcase.yaml
@@ -1,9 +1,24 @@
 tests:
   zcbor.decode.test5_corner_cases:
-    platform_allow: native_sim native_sim/native/64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor decode test5
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - decode
+      - test5
     extra_args: CANONICAL=1
   zcbor.decode.test5_corner_cases.indefinite_length_arrays:
-    platform_allow: native_sim native_sim/native/64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor decode test5 indefinite
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - decode
+      - test5
+      - indefinite
     extra_args: TEST_INDEFINITE_LENGTH_ARRAYS=1

--- a/tests/decode/test7_suit9_simple/testcase.yaml
+++ b/tests/decode/test7_suit9_simple/testcase.yaml
@@ -1,4 +1,11 @@
 tests:
   zcbor.decode.test7_suit9_simple:
-    platform_allow: native_sim native_sim/native/64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor decode test7
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - decode
+      - test7

--- a/tests/decode/test8_suit12/testcase.yaml
+++ b/tests/decode/test8_suit12/testcase.yaml
@@ -1,4 +1,11 @@
 tests:
   zcbor.decode.test8_suit12:
-    platform_allow: native_sim native_sim/native/64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor decode test8
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - decode
+      - test8

--- a/tests/decode/test9_manifest14/testcase.yaml
+++ b/tests/decode/test9_manifest14/testcase.yaml
@@ -1,8 +1,27 @@
 tests:
   zcbor.decode.test9_manifest14:
-    platform_allow: native_sim native_sim/native/64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor decode manifest14 test9
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - decode
+      - manifest14
+      - test9
   zcbor.cbor_decode.test9_manifest16.canonical:
-    platform_allow: native_sim native_sim/native/64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor decode manifest16 test9 canonical
-    extra_args: MANIFEST=manifest16 CANONICAL=ON
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - decode
+      - manifest16
+      - test9
+      - canonical
+    extra_args:
+      - MANIFEST=manifest16
+      - CANONICAL=ON

--- a/tests/encode/test1_suit/testcase.yaml
+++ b/tests/encode/test1_suit/testcase.yaml
@@ -1,5 +1,13 @@
 tests:
   zcbor.encode.test1_suit.canonical:
-    platform_allow: native_sim native_sim/native/64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor encode canonical test1
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - encode
+      - canonical
+      - test1
     extra_args: CANONICAL=CANONICAL

--- a/tests/encode/test2_simple/testcase.yaml
+++ b/tests/encode/test2_simple/testcase.yaml
@@ -1,8 +1,23 @@
 tests:
   zcbor.encode.test2_simple:
-    platform_allow: native_sim native_sim/native/64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor encode test
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - encode
+      - test
   zcbor.encode.test2_simple.canonical:
-    platform_allow: native_sim native_sim/native/64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor encode canonical test
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - encode
+      - canonical
+      - test
     extra_args: CANONICAL=CANONICAL

--- a/tests/encode/test3_corner_cases/testcase.yaml
+++ b/tests/encode/test3_corner_cases/testcase.yaml
@@ -1,8 +1,23 @@
 tests:
   zcbor.encode.test3_corner_cases:
-    platform_allow: native_sim native_sim/native/64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor encode test3
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - encode
+      - test3
   zcbor.encode.test3_corner_cases.canonical:
-    platform_allow: native_sim native_sim/native/64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor encode canonical test3
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - encode
+      - canonical
+      - test3
     extra_args: CANONICAL=CANONICAL

--- a/tests/encode/test4_senml/testcase.yaml
+++ b/tests/encode/test4_senml/testcase.yaml
@@ -1,8 +1,23 @@
 tests:
   zcbor.encode.test4_senml:
-    platform_allow: native_sim native_sim/native/64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor encode test4
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - encode
+      - test4
   zcbor.encode.test4_senml.canonical:
-    platform_allow: native_sim native_sim/native/64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor encode canonical test4
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - encode
+      - canonical
+      - test4
     extra_args: CANONICAL=CANONICAL

--- a/tests/unit/test1_unit_tests/testcase.yaml
+++ b/tests/unit/test1_unit_tests/testcase.yaml
@@ -1,6 +1,12 @@
 common:
-  platform_allow: native_sim native_sim/native/64 mps2/an521/cpu0 qemu_malta/qemu_malta/be
-  tags: zcbor unit
+  platform_allow:
+    - native_sim
+    - native_sim/native/64
+    - mps2/an521/cpu0
+    - qemu_malta/qemu_malta/be
+  tags:
+    - zcbor
+    - unit
   timeout: 120  # Because of test_size64
 
 tests:

--- a/tests/unit/test2_cpp/testcase.yaml
+++ b/tests/unit/test2_cpp/testcase.yaml
@@ -1,7 +1,12 @@
 tests:
   zcbor.unit.test2:
-    platform_allow: mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor unit cpp
+    platform_allow:
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - unit
+      - cpp
 common: 
   harness: console
   harness_config:

--- a/tests/unit/test3_float16/testcase.yaml
+++ b/tests/unit/test3_float16/testcase.yaml
@@ -1,9 +1,20 @@
 tests:
   zcbor.unit.test3:
-    platform_allow: native_sim native_sim/native/64
-    tags: zcbor unit float16
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - zcbor
+      - unit
+      - float16
     timeout: 240
   zcbor.unit.test3.release:
-    platform_allow: mps2/an521/cpu0 qemu_malta/qemu_malta/be
-    tags: zcbor unit float16 release
+    platform_allow:
+      - mps2/an521/cpu0
+      - qemu_malta/qemu_malta/be
+    tags:
+      - zcbor
+      - unit
+      - float16
+      - release
     timeout: 7200


### PR DESCRIPTION
They have been deprecated, and support is removed in Zephyr.

https://github.com/zephyrproject-rtos/zephyr/pull/82404