### PR TITLE
update_version.py: Don't copy previous entry

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,18 +1,5 @@
 # zcbor v. 0.9.99
 
-* `zcbor_simple_*()` functions have been removed to avoid confusion about their use.
-  They are still in the C file because they are used by other functions.
-  Instead, use the specific functions for the currently supported simple values, i.e.
-  `zcbor_bool_*()`, `zcbor_nil_*()`, and `zcbor_undefined_*()`.
-  If a removed variant is strictly needed, add your own forward declaration in your code.
-
-* Code generation naming:
-
-  * More C keywords are now capitalized to avoid naming collision.
-    You might have to capitalize some instances if your code was generated to have those names.
-
-  * A fix was made to the naming of bstr elements with a .size specifier, which might mean that these elements change name in your code when you regenerate.
-
 
 # zcbor v. 0.9.0
 

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -15,15 +15,23 @@ p_RELEASE_NOTES = Path(p_root, 'RELEASE_NOTES.md')
 p_MIGRATION_GUIDE = Path(p_root, 'MIGRATION_GUIDE.md')
 p_common_h = Path(p_root, 'include', 'zcbor_common.h')
 
-def update_relnotes(p_relnotes, version, include_date=True):
+RELEASE_NOTES_boilerplate = """
+Any new bugs, requests, or missing features should be reported as [Github issues](https://github.com/NordicSemiconductor/zcbor/issues).
+
+## Improvements:
+
+## Bugfixes:
+"""
+
+
+def update_relnotes(p_relnotes, version, boilerplate="", include_date=True):
     relnotes_contents = p_relnotes.read_text(encoding="utf-8")
     relnotes_lines = relnotes_contents.splitlines()
     if version not in relnotes_lines[0]:
         new_date = f" ({datetime.today().strftime('%Y-%m-%d')})" if include_date else ""
         relnotes_new_header = f"# zcbor v. {version}{new_date}\n"
         if ".99" not in relnotes_lines[0]:
-            prev_entry = match(r"\A# zcbor.*?(?=# zcbor v.)", relnotes_contents, S).group(0)
-            relnotes_contents = prev_entry + relnotes_contents
+            relnotes_contents = relnotes_new_header + boilerplate + '\n\n' + relnotes_contents
         relnotes_contents = sub(r".*?\n", relnotes_new_header, relnotes_contents, count=1)
         p_relnotes.write_text(relnotes_contents, encoding="utf-8")
 
@@ -36,7 +44,7 @@ if __name__ == "__main__":
     (major, minor, bugfix) = version.split('.')
 
     p_VERSION.write_text(version, encoding="utf-8")
-    update_relnotes(p_RELEASE_NOTES, version)
+    update_relnotes(p_RELEASE_NOTES, version, boilerplate=RELEASE_NOTES_boilerplate)
     update_relnotes(p_MIGRATION_GUIDE, version, include_date=False)
     p_common_h_contents = p_common_h.read_text(encoding="utf-8")
     common_h_new_contents = sub(r"(#define ZCBOR_VERSION_MAJOR )\d+", f"\\g<1>{major}", p_common_h_contents)


### PR DESCRIPTION
when updating RELEASE_NOTES and MIGRATION_GUIDE.
Instead use specified boilerplate when constructing the new entry.

Fix duplicated MIGRATION_GUIDE entry.