### PR TITLE
zcbor.py: Support unicode escape sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,28 @@ The following data types are supported by CBOR, but not by YAML (or JSON which i
 
 You can see an example of the conversions in [tests/cases/yaml_compatibility.yaml](tests/cases/yaml_compatibility.yaml) and its CDDL file [tests/cases/yaml_compatibility.cddl](tests/cases/yaml_compatibility.cddl).
 
+Unicode
+-------
+
+The zcbor Python script fully supports unicode. All text files read by the script, including CDDL files and YAML/JSON files must be utf-8. All produced text files are utf-8.
+
+Unicode escape sequences
+------------------------
+
+String literals in CDDL files can contain unicode escape sequences as described in the [CDDL spec update](https://datatracker.ietf.org/doc/html/rfc9682):
+
+ - 16-bit: "\uXXXX"
+ - 32-bit: "\U00XXXXXX"
+ - variable-length: "\u{XXXX}"
+ - characters, e.g.: "\\ \n \t \""
+
+As an example, the CDDL 'Foo = "\U0001F000\u{72}"' (equivalent to 'Foo = "🀀H"') will expect the CBOR data `65f09f808072`.
+
+In code generation, characters that are escaped in the CDDL will be escaped in the C string literals, while characters that are non-escaped in the CDDL will be non-escaped in the generated C code. In both cases, the characters must be non-escaped in the data.
+
+When using the script to handle YAML/JSON, input YAML/JSON data can contain escaped characters as supported in those standards, which will be handled as equivalent to the non-escaped characters.
+
+Surrogate pairs are allowed in CDDL (as `\uD8xx\uDCxx`), and will be converted to their proper representation internally.
 
 Code generation
 ===============

--- a/tests/cases/corner_cases.cddl
+++ b/tests/cases/corner_cases.cddl
@@ -376,3 +376,19 @@ OptList = [
 	optlist_int: int,
 	?optlist: [uint],
 ]
+
+; Unicode test case adapted from updated CDDL spec (https://datatracker.ietf.org/doc/html/rfc9682)
+UnicodeEscape = [a, b, c, d, x, y, z]
+UnicodeEscapeTstr = [a, b, c, d]
+
+; "🁳", DOMINO TILE VERTICAL-02-02, and
+; "⌘", PLACE OF INTEREST SIGN, in a text string:
+a = "D\u{6f}mino's \u{1F073} + \u{2318}"      ; \u{}-escape 3 chars
+b = "Domino's \uD83C\uDC73 + \u2318"          ; escape JSON-like
+c = "Domino's 🁳 + ⌘"                         ; unescaped
+d = "Domino's \U0001F073 + \U00002318"        ; \U{}-escape 2 chars
+
+; in a byte string given as text, the ' needs to be escaped:
+x = 'D\u{6f}mino\u{27}s \u{1F073} + \u{2318}' ; \u{}-escape 4 chars
+y = 'Domino\'s \uD83C\uDC73 + \u2318'         ; escape JSON-like
+z = 'Domino\'s 🁳 + ⌘'                        ; escape ' only

--- a/tests/decode/test5_corner_cases/CMakeLists.txt
+++ b/tests/decode/test5_corner_cases/CMakeLists.txt
@@ -63,6 +63,7 @@ set(py_command
     Choice4
     Choice5
     OptList
+    UnicodeEscape
   --decode
   --git-sha-header
   --short-names

--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -2473,5 +2473,29 @@ ZTEST(cbor_decode_test5, test_optlist)
 	zassert_equal(100, result.uint);
 }
 
+ZTEST(cbor_decode_test5, test_unicode_escape)
+{
+	uint8_t unicode_escape_payload1[] = {
+		LIST(7),
+			0x73, 'D', 'o', 'm', 'i', 'n', 'o', '\'', 's', ' ',
+				0xf0, 0x9f, 0x81, 0xb3, ' ', '+', ' ', 0xe2, 0x8c, 0x98,
+			0x73, 'D', 'o', 'm', 'i', 'n', 'o', '\'', 's', ' ',
+				0xf0, 0x9f, 0x81, 0xb3, ' ', '+', ' ', 0xe2, 0x8c, 0x98,
+			0x73, 'D', 'o', 'm', 'i', 'n', 'o', '\'', 's', ' ',
+				0xf0, 0x9f, 0x81, 0xb3, ' ', '+', ' ', 0xe2, 0x8c, 0x98,
+			0x73, 'D', 'o', 'm', 'i', 'n', 'o', '\'', 's', ' ',
+				0xf0, 0x9f, 0x81, 0xb3, ' ', '+', ' ', 0xe2, 0x8c, 0x98,
+			0x53, 'D', 'o', 'm', 'i', 'n', 'o', '\'', 's', ' ',
+				0xf0, 0x9f, 0x81, 0xb3, ' ', '+', ' ', 0xe2, 0x8c, 0x98,
+			0x53, 'D', 'o', 'm', 'i', 'n', 'o', '\'', 's', ' ',
+				0xf0, 0x9f, 0x81, 0xb3, ' ', '+', ' ', 0xe2, 0x8c, 0x98,
+			0x53, 'D', 'o', 'm', 'i', 'n', 'o', '\'', 's', ' ',
+				0xf0, 0x9f, 0x81, 0xb3, ' ', '+', ' ', 0xe2, 0x8c, 0x98,
+		END
+	};
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_UnicodeEscape(unicode_escape_payload1,
+		sizeof(unicode_escape_payload1), NULL, NULL));
+}
 
 ZTEST_SUITE(cbor_decode_test5, NULL, NULL, NULL, NULL, NULL);

--- a/tests/scripts/test_zcbor.py
+++ b/tests/scripts/test_zcbor.py
@@ -14,7 +14,7 @@ from hashlib import sha256
 import cbor2
 from platform import python_version_tuple
 from sys import platform, exit
-from yaml import safe_load
+from yaml import safe_load, safe_dump
 from tempfile import mkdtemp
 from shutil import rmtree
 from os import linesep
@@ -1298,6 +1298,24 @@ class TestInvalidIdentifiers(TestCase):
         self.assertTrue(decoded.f_1one_tstr)
         self.assertTrue(decoded.f_)
         self.assertTrue(decoded.a_z_tstr)
+
+
+class TestUnicodeEscape(TestCase):
+    def test_unicode_escape0(self):
+        expected = "Domino's 🁳 + ⌘"
+        cddl_res = zcbor.DataDecoder.from_cddl(p_corner_cases.read_text(encoding="utf-8"), 16)
+        cddl = cddl_res.my_types["UnicodeEscapeTstr"]
+        test_yaml = safe_dump([expected] * 4)
+        cddl.decode_str_yaml(test_yaml)
+
+        test_json = r"""[
+            "D\u006fmino's 🁳 + \u2318",
+            "Domino's 🁳 + ⌘",
+            "Domino's \uD83C\uDC73 + \u2318",
+            "Domino's 🁳 + ⌘"
+        ]"""
+
+        cddl.from_json(test_json)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As described in RFC9682.
Add tests both for code generation and validation. Add information in the README about unicode and escape sequences.