### PR TITLE
zcbor.py: Support canonical encoding when converting to CBOR in script

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,29 @@ Name                      | Description
 `ZCBOR_BIG_ENDIAN`        | All decoded values are returned as big-endian. The default is little-endian.
 `ZCBOR_MAP_SMART_SEARCH`  | Applies to decoding of unordered maps. When enabled, a flag is kept for each element in an array, ensuring it is not processed twice. If disabled, a count is kept for map as a whole. Enabling increases code size and memory usage, and requires the state variable to possess the memory necessary for the flags.
 
+Canonical encoding
+------------------
+
+The C library supports some of the rules for canonical encoding (also called "deterministically encoded CBOR"). To enable these, use the `ZCBOR_CANONICAL` config for encoding, or the `enforce_canonical` flag for decoding. Note that enabling `ZCBOR_CANONICAL` changes the default value of `enforce_canonical`.
+
+Some rules are not supported because it would introduce significant code size or complexity.
+
+The following canonical encoding rules are enforced for encoding:
+
+ - integers are minimally encoded (always)
+ - lists and maps do not use indefinite length encoding (when `ZCBOR_CANONCAL` is enabled)
+ - floats are encoded minimally (when using the function `zcbor_float_min_encode` or `zcbor_float_min_put`).
+
+The following canonical encoding rules are enforced for decoding:
+
+ - integers are minimally encoded (when `enforce_canonical` is enabled)
+ - lists and maps do not use indefinite length encoding (when `enforce_canonical` is enabled)
+
+The following canonical encoding rules are not enforced:
+
+ - floats are encoded minimally (during decoding)
+ - map keys are sorted by bytewise value
+
 
 Python script and module
 ========================
@@ -146,6 +169,11 @@ When accessing the data, you can choose between two internal formats:
     When returning this format, DataTranslator hides the idiomatic representations for bytestrings, tags, and non-text keys described above.
  2. A custom format which allows accessing the data via the names from the CDDL description file.
     This format is implemented using named tuples, and is immutable, meaning that it can be used for inspecting data, but not for changing or creating data.
+
+Canonical encoding
+------------------
+
+CBOR data created by the python script can be made canonical with `--output-canonical`, or by setting the `canonical` argument to `True` in supported `DataTranslator` functions. Note that in CBOR data from the script, integers are always minimally encoded, and indeterminate length lists are never used, even without the `canonical` argument.
 
 Making CBOR YAML-/JSON-compatible
 ---------------------------------
@@ -607,7 +635,7 @@ usage: zcbor convert [-h] -c CDDL [--no-prelude] [-v] [-q] -i INPUT
                      [--yaml-compatibility] -o OUTPUT
                      [--output-as {yaml,json,cbor,cborhex,c_code}]
                      [--c-code-var-name C_CODE_VAR_NAME]
-                     [--c-code-columns C_CODE_COLUMNS]
+                     [--c-code-columns C_CODE_COLUMNS] [--output-canonical]
 
 Parse a CDDL file and validate/convert between CBOR and YAML/JSON. The script
 decodes the CBOR/YAML/JSON data from a file or stdin and verifies that it
@@ -664,5 +692,8 @@ options:
                         files. The number of bytes per line in the variable
                         instantiation. If omitted, the entire declaration is a
                         single line.
+  --output-canonical    If the output data is CBOR, use canonical CBOR rules.
+                        (no indefinite length lists, minially encoded floats,
+                        map elements sorted by key value).
 
 ```

--- a/tests/scripts/test_zcbor.py
+++ b/tests/scripts/test_zcbor.py
@@ -13,7 +13,7 @@ from hashlib import sha256
 import cbor2
 from sys import exit
 from yaml import safe_load
-from tempfile import mkdtemp
+from tempfile import mkdtemp, NamedTemporaryFile
 from shutil import rmtree
 
 
@@ -1405,6 +1405,108 @@ class TestIntSize(PopenTest, TempdTest):
         for mode in ("decode", "encode"):
             for bit_size in (8, 16, 32, 64):
                 self.do_test_int_size(mode, bit_size)
+
+
+class TestCanonical(PopenTest):
+    canonical_cddl = """
+        Dict = {+tstr => int}
+        Canonical = [
+            num: float,
+            map: {
+                +int => tstr
+            },
+            cbor_bstr: bstr .cbor Dict
+        ]
+    """
+
+    test_yaml = b"""
+        [
+            1.5,
+            {2: "two", 1: "one"},
+            {"zcbor_bstr": {"two": 2, "one": 1}},
+        ]
+    """
+
+    # fmt: off
+    expected_payload = bytes((
+        0x83,
+            0xfb, 0x3f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0xA2,
+                0x02, 0x63, ord('t'), ord('w'), ord('o'),
+                0x01, 0x63, ord('o'), ord('n'), ord('e'),
+            0x4B, 0xA2,
+                0x63, ord('t'), ord('w'), ord('o'), 0x02,
+                0x63, ord('o'), ord('n'), ord('e'), 0x01,
+        )
+    )
+
+    expected_payload_canonical = bytes((
+        0x83,
+            0xf9, 0x3e, 0x00,
+            0xA2,
+                0x01, 0x63, ord('o'), ord('n'), ord('e'),
+                0x02, 0x63, ord('t'), ord('w'), ord('o'),
+            0x4B, 0xA2,
+                0x63, ord('o'), ord('n'), ord('e'), 0x01,
+                0x63, ord('t'), ord('w'), ord('o'), 0x02,
+        )
+    )
+    # fmt: on
+
+    def test_canonical(self):
+        cddl = zcbor.DataTranslator.from_cddl(
+            cddl_string=self.canonical_cddl, default_max_qty=16
+        ).my_types["Canonical"]
+
+        out = cddl.from_yaml(self.test_yaml, yaml_compat=True)
+        out_canon = cddl.from_yaml(self.test_yaml, yaml_compat=True, canonical=True)
+        self.assertEqual(self.expected_payload, out)
+        self.assertEqual(self.expected_payload_canonical, out_canon)
+
+    def test_canonical_cli(self):
+        # Must have delete=False because of permission error on Windows.
+        # Cannot use delete_on_close because it is not present in Python 3.11 and earlier.
+        try:
+            with NamedTemporaryFile(mode="w", delete=False) as fc:
+                fc.write(self.canonical_cddl)
+                fc.flush()
+                args = [
+                    "zcbor",
+                    "convert",
+                    "-c",
+                    fc.name,
+                    "-i",
+                    "-",
+                    "--input-as",
+                    "yaml",
+                    "-o",
+                    "-",
+                    "-t",
+                    "Canonical",
+                    "--yaml-compatibility",
+                ]
+                out, _ = self.popen_test(args, self.test_yaml, exp_retcode=0)
+                out_canon, _ = self.popen_test(
+                    args + ["--output-canonical"], self.test_yaml, exp_retcode=0
+                )
+
+                args[args.index("yaml")] = "cborhex"
+                out2, _ = self.popen_test(
+                    args, bytes(self.expected_payload.hex(), encoding="utf-8"), exp_retcode=0
+                )
+                out_canon2, _ = self.popen_test(
+                    args + ["--output-canonical"],
+                    bytes(self.expected_payload.hex(), encoding="utf-8"),
+                    exp_retcode=0,
+                )
+
+        finally:
+            Path(fc.name).unlink()
+
+        self.assertEqual(self.expected_payload, out)
+        self.assertEqual(self.expected_payload_canonical, out_canon)
+        self.assertEqual(self.expected_payload, out2)
+        self.assertEqual(self.expected_payload_canonical, out_canon2)
 
 
 if __name__ == "__main__":

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -2025,10 +2025,10 @@ CBOR-formatted bstr, all elements must be bstrs. If not, it is a programmer erro
             raise e
         return decoded
 
-    def decode_str_yaml(self, yaml_str, yaml_compat=False):
+    def decode_str_yaml(self, yaml_str, yaml_compat=False, canonical=False):
         """YAML => python object"""
         yaml_obj = yaml_load(yaml_str)
-        obj = self._from_yaml_obj(yaml_obj) if yaml_compat else yaml_obj
+        obj = self._from_yaml_obj(yaml_obj, canonical) if yaml_compat else yaml_obj
         self.validate_obj(obj)
         return self.decode_obj(obj)
 
@@ -2047,34 +2047,33 @@ CBOR-formatted bstr, all elements must be bstrs. If not, it is a programmer erro
         cbor_obj = loads(cbor_str)
         return self.validate_obj(cbor_obj)
 
-    def _from_yaml_obj(self, obj):
+    def _from_yaml_obj(self, obj, can):
         """Convert object from YAML/JSON (with special dicts for bstr, tag etc) to CBOR object
         that cbor2 understands.
         """
         if isinstance(obj, list):
             if len(obj) == 1 and obj[0] == "zcbor_undefined":
                 return undefined
-            return [self._from_yaml_obj(elem) for elem in obj]
+            return [self._from_yaml_obj(elem, can) for elem in obj]
         elif isinstance(obj, dict):
             if ["zcbor_bstr"] == list(obj.keys()):
                 if isinstance(obj["zcbor_bstr"], str):
                     bstr = bytes.fromhex(obj["zcbor_bstr"])
                 else:
-                    bstr = dumps(self._from_yaml_obj(obj["zcbor_bstr"]))
+                    bstr = dumps(self._from_yaml_obj(obj["zcbor_bstr"], can), canonical=can)
                 return bstr
             elif ["zcbor_tag", "zcbor_tag_val"] == list(obj.keys()):
-                return CBORTag(obj["zcbor_tag"], self._from_yaml_obj(obj["zcbor_tag_val"]))
+                return CBORTag(obj["zcbor_tag"], self._from_yaml_obj(obj["zcbor_tag_val"], can))
             retval = dict()
             for key, val in obj.items():
-                match = getrp(r"zcbor_keyval\d+").fullmatch(key)
-                if match is not None:
-                    new_key = self._from_yaml_obj(val["key"])
-                    new_val = self._from_yaml_obj(val["val"])
+                if isinstance(key, str) and getrp(r"zcbor_keyval\d+").fullmatch(key) is not None:
+                    new_key = self._from_yaml_obj(val["key"], can)
+                    new_val = self._from_yaml_obj(val["val"], can)
                     if isinstance(new_key, list):
                         new_key = tuple(new_key)
                     retval[new_key] = new_val
                 else:
-                    retval[key] = self._from_yaml_obj(val)
+                    retval[key] = self._from_yaml_obj(val, can)
             return retval
         return obj
 
@@ -2114,12 +2113,12 @@ CBOR-formatted bstr, all elements must be bstrs. If not, it is a programmer erro
         assert not isinstance(obj, bytes)
         return obj
 
-    def from_yaml(self, yaml_str, yaml_compat=False):
+    def from_yaml(self, yaml_str, yaml_compat=False, canonical=False):
         """YAML str => CBOR bytestr"""
         yaml_obj = yaml_load(yaml_str)
-        obj = self._from_yaml_obj(yaml_obj) if yaml_compat else yaml_obj
+        obj = self._from_yaml_obj(yaml_obj, canonical) if yaml_compat else yaml_obj
         self.validate_obj(obj)
-        return dumps(obj)
+        return dumps(obj, canonical=canonical)
 
     def obj_to_yaml(self, obj, yaml_compat=False):
         """CBOR object => YAML str"""
@@ -2131,12 +2130,12 @@ CBOR-formatted bstr, all elements must be bstrs. If not, it is a programmer erro
         """CBOR bytestring => YAML str"""
         return self.obj_to_yaml(loads(cbor_str), yaml_compat=yaml_compat)
 
-    def from_json(self, json_str, yaml_compat=False):
+    def from_json(self, json_str, yaml_compat=False, canonical=False):
         """JSON str => CBOR bytestr"""
         json_obj = json_load(json_str)
-        obj = self._from_yaml_obj(json_obj) if yaml_compat else json_obj
+        obj = self._from_yaml_obj(json_obj, canonical) if yaml_compat else json_obj
         self.validate_obj(obj)
-        return dumps(obj)
+        return dumps(obj, canonical=canonical)
 
     def obj_to_json(self, obj, yaml_compat=False):
         """CBOR object => JSON str"""
@@ -2154,6 +2153,12 @@ CBOR-formatted bstr, all elements must be bstrs. If not, it is a programmer erro
         if columns:
             arr = "\n" + indent("\n".join(wrap(arr, 6 * columns)), "\t") + "\n"
         return f"uint8_t {var_name}[] = {{{arr}}};\n"
+
+    def str_to_canonical(self, cbor_str):
+        """CBOR bytestring => canonical CBOR bytestring."""
+        return self.from_yaml(
+            self.str_to_yaml(cbor_str, yaml_compat=True), yaml_compat=True, canonical=True
+        )
 
 
 class XcoderTuple(NamedTuple):
@@ -3778,6 +3783,14 @@ If omitted, the format is inferred from the file name.
 The number of bytes per line in the variable instantiation. If omitted, the
 entire declaration is a single line.""",
     )
+    convert_parser.add_argument(
+        "--output-canonical",
+        required=False,
+        action="store_true",
+        default=False,
+        help="""If the output data is CBOR, use canonical CBOR rules.
+(no indefinite length lists, minially encoded floats, map elements sorted by key value).""",
+    )
     convert_parser.set_defaults(process=process_convert)
 
     args = parser.parse_args()
@@ -3932,23 +3945,31 @@ def parse_cddl(args):
     return cddl_res.my_types[args.entry_type]
 
 
-def read_data(args, cddl):
+def read_data(args, cddl, canonical=False):
     _, in_file_ext = path.splitext(args.input)
     in_file_format = args.input_as or in_file_ext.strip(".")
     if in_file_format in ["yaml", "yml"]:
         f = sys.stdin if args.input == "-" else open(args.input, "r", encoding="utf-8")
-        cbor_str = cddl.from_yaml(f.read(), yaml_compat=args.yaml_compatibility)
+        cbor_str = cddl.from_yaml(
+            f.read(), yaml_compat=args.yaml_compatibility, canonical=canonical
+        )
     elif in_file_format == "json":
         f = sys.stdin if args.input == "-" else open(args.input, "r", encoding="utf-8")
-        cbor_str = cddl.from_json(f.read(), yaml_compat=args.yaml_compatibility)
-    elif in_file_format == "cborhex":
-        f = sys.stdin if args.input == "-" else open(args.input, "r", encoding="utf-8")
-        cbor_str = bytes.fromhex(f.read().replace("\n", ""))
+        cbor_str = cddl.from_json(
+            f.read(), yaml_compat=args.yaml_compatibility, canonical=canonical
+        )
+    else:  # CBOR or CBORHEX
+        if in_file_format == "cborhex":
+            f = sys.stdin if args.input == "-" else open(args.input, "r", encoding="utf-8")
+            cbor_str = bytes.fromhex(f.read().replace("\n", ""))
+        else:
+            f = sys.stdin.buffer if args.input == "-" else open(args.input, "rb", encoding="utf-8")
+            cbor_str = f.read()
+
         cddl.validate_str(cbor_str)
-    else:
-        f = sys.stdin.buffer if args.input == "-" else open(args.input, "rb", encoding="utf-8")
-        cbor_str = f.read()
-        cddl.validate_str(cbor_str)
+        if canonical:
+            cbor_str = cddl.str_to_canonical(cbor_str)
+            cddl.validate_str(cbor_str)
 
     return cbor_str
 
@@ -3983,7 +4004,7 @@ def process_validate(args):
 
 def process_convert(args):
     cddl = parse_cddl(args)
-    cbor_str = read_data(args, cddl)
+    cbor_str = read_data(args, cddl, canonical=args.output_canonical)
     write_data(args, cddl, cbor_str)
 
 


### PR DESCRIPTION
fixes #470