### PR TITLE
test_repo_files: Refactor checking of links in docs

### DIFF
--- a/tests/scripts/doc_fail_cases/fail1.md
+++ b/tests/scripts/doc_fail_cases/fail1.md
@@ -1,0 +1,1 @@
+[gibberish URL](https://vwiovrvnfvklnvoldknvewoivnoevoindvolksnvckvsoodivnxvds.com)

--- a/tests/scripts/doc_fail_cases/fail2.md
+++ b/tests/scripts/doc_fail_cases/fail2.md
@@ -1,0 +1,1 @@
+[http url](http://wikipedia.org)

--- a/tests/scripts/doc_fail_cases/fail3.md
+++ b/tests/scripts/doc_fail_cases/fail3.md
@@ -1,0 +1,1 @@
+[invalid anchor](https://github.com/NordicSemiconductor/zcbor/blob/0.9.1/RELEASE_NOTES.md#invalidanchor)

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -352,6 +352,7 @@ class CddlParser:
         short_names=False,
         base_stem="",
     ):
+        super(CddlParser, self).__init__()
         self.id_prefix = "temp_" + str(counter())
         self.id_num = None  # Unique ID number. Only populated if needed.
         # The value of the data item. Has different meaning for different
@@ -3235,6 +3236,7 @@ class CodeRenderer:
         git_sha="",
         file_header="",
     ):
+        super(CodeRenderer, self).__init__()
         self.entry_types = entry_types
         self.print_time = print_time
         self.default_max_qty = default_max_qty


### PR DESCRIPTION
Use backoff timer if receiving a 429 error (because of changes in Github).

Only check links once if they appear multiple times across doc files.

Only check doc files that have been changed.