### PR TITLE
zcbor_decode.c: Gracefully handle calling elem_processed early

### DIFF
--- a/tests/unit/test1_unit_tests/src/main.c
+++ b/tests/unit/test1_unit_tests/src/main.c
@@ -1281,6 +1281,9 @@ ZTEST(zcbor_unit_tests, test_unordered_map)
 	/* Test that looping stops both if it starts at the very start and very end of the map.
 	 * Also test ZCBOR_ERR_MAP_MISALIGNED. */
 	zassert_true(zcbor_unordered_map_start_decode(state_d2), NULL);
+	zassert_false(zcbor_elem_processed(state_d2), NULL);
+	int err = zcbor_pop_error(state_d2);
+	zassert_equal(err, ZCBOR_ERR_MAP_MISALIGNED, "err: %d\n", err);
 	zassert_false(zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_int32_pexpect, state_d2, &(int32_t){3}), NULL);
 	ret = zcbor_unordered_map_search((zcbor_decoder_t *)zcbor_int32_pexpect, state_d2, &(int32_t){2});
 	zassert_true(ret, "err: %d\n", zcbor_peek_error(state_d2));


### PR DESCRIPTION
If zcbor_elem_processed() was called immediately upon entering an unordered map, get_current_index() would return SIZE_MAX.

This would be caught and result in a ZCBOR_ERR_MAP_FLAGS_NOT_AVAILABLE error.

This commit fixes get_current_index(), but also errors early in this case.
The returned error is now ZCBOR_ERR_MAP_MISALIGNED