### PR TITLE
zcbor.py: Generate defines for magic values/numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ usage: zcbor code [-h] -c CDDL [--no-prelude] [-v] [-q]
                   -t ENTRY_TYPES [ENTRY_TYPES ...] [-d] [-e] [--time-header]
                   [--git-sha-header] [-b {8,16,32,64}]
                   [--include-prefix INCLUDE_PREFIX] [-s]
-                  [--file-header FILE_HEADER]
+                  [--file-header FILE_HEADER] [--defines]
 
 Parse a CDDL file and produce C code that validates and xcodes CBOR.
 The output from this script is a C file and a header file. The header file
@@ -595,6 +595,10 @@ options:
                         generated files, e.g. copyright. Can be a string or a
                         path to a file. If interpreted as a path to an
                         existing file, the file's contents will be used.
+  --defines             Make #defines for all magic numbers in generated code,
+                        and place them in the generated header file. This is
+                        off by default because it may create naming conflicts
+                        that don't show up otherwise.
 
 ```
 

--- a/include/zcbor_common.h
+++ b/include/zcbor_common.h
@@ -328,6 +328,8 @@ do { \
 /** Initial value for elem_count for when it just needs to be large. */
 #define ZCBOR_LARGE_ELEM_COUNT (ZCBOR_MAX_ELEM_COUNT - 15)
 
+#define ZCBOR_EXTRA_STATES 2 ///! The number of extra states always needed (e.g. for the constant state), i.e. in addition to the optional ones for backups and flags.
+
 
 /** Take a backup of the @p state. Then, overwrite the current elem_count in @p state.
  *  Can optionally take a backup of the elem_state if @p backup_elem_state is true.

--- a/include/zcbor_decode.h
+++ b/include/zcbor_decode.h
@@ -44,7 +44,7 @@ void zcbor_new_decode_state(zcbor_state_t *state_array, size_t n_states,
  *                            including elements in nested unordered maps.
  */
 #define ZCBOR_STATE_D(name, num_backups, payload, payload_size, elem_count, n_flags) \
-zcbor_state_t name[((num_backups) + 2 + ZCBOR_FLAG_STATES(n_flags))]; \
+zcbor_state_t name[((num_backups) + ZCBOR_EXTRA_STATES + ZCBOR_FLAG_STATES(n_flags))]; \
 do { \
 	zcbor_new_decode_state(name, ZCBOR_ARRAY_SIZE(name), payload, payload_size, elem_count, \
 			(uint8_t *)&name[(num_backups) + 1], ZCBOR_FLAG_STATES(n_flags) * sizeof(zcbor_state_t)); \

--- a/include/zcbor_encode.h
+++ b/include/zcbor_encode.h
@@ -40,7 +40,7 @@ void zcbor_new_encode_state(zcbor_state_t *state_array, size_t n_states,
  *  @param[in]  elem_count    The starting elem_count (typically 1).
  */
 #define ZCBOR_STATE_E(name, num_backups, payload, payload_size, elem_count) \
-zcbor_state_t name[((num_backups) + 2)]; \
+zcbor_state_t name[((num_backups) + ZCBOR_EXTRA_STATES)]; \
 do { \
 	zcbor_new_encode_state(name, ZCBOR_ARRAY_SIZE(name), payload, payload_size, elem_count); \
 } while(0)

--- a/samples/pet/src/pet_decode.c
+++ b/samples/pet/src/pet_decode.c
@@ -61,7 +61,7 @@ int cbor_decode_Pet(
 		struct Pet *result,
 		size_t *payload_len_out)
 {
-	zcbor_state_t states[4];
+	zcbor_state_t states[2 + ZCBOR_EXTRA_STATES];
 
 	if (false) {
 		/* For testing that the types of the arguments are correct.

--- a/samples/pet/src/pet_encode.c
+++ b/samples/pet/src/pet_encode.c
@@ -62,7 +62,7 @@ int cbor_encode_Pet(
 		const struct Pet *input,
 		size_t *payload_len_out)
 {
-	zcbor_state_t states[4];
+	zcbor_state_t states[2 + ZCBOR_EXTRA_STATES];
 
 	if (false) {
 		/* For testing that the types of the arguments are correct.

--- a/tests/decode/test5_corner_cases/CMakeLists.txt
+++ b/tests/decode/test5_corner_cases/CMakeLists.txt
@@ -19,6 +19,7 @@ set(py_command
   --output-c ${PROJECT_BINARY_DIR}/src/corner_cases.c
   --output-h ${PROJECT_BINARY_DIR}/include/corner_cases.h
   --copy-sources
+  --defines
   -t NestedListMap NestedMapListMap
     Numbers
     Numbers2

--- a/tests/scripts/test_zcbor.py
+++ b/tests/scripts/test_zcbor.py
@@ -1275,7 +1275,7 @@ class TestInvalidIdentifiers(CornerCaseTest):
 
 
 class TestIntSize(PopenTest, TempdTest):
-    def do_test_int_size(self, mode, bit_size):
+    def do_test_int_size(self, mode, defines_arg, bit_size):
         self.popen_test(
             [
                 "zcbor",
@@ -1295,6 +1295,7 @@ class TestIntSize(PopenTest, TempdTest):
                 "--output-cmake",
                 self.tempd / "intmax.cmake",
             ]
+            + defines_arg
         )
 
         expected_output_types = [
@@ -1316,22 +1317,58 @@ class TestIntSize(PopenTest, TempdTest):
             f"uint{bit_size}_t DefaultInt_uint",
         ]
 
+        expected_defines = {
+            "INTMAX1_INT_8_MIN_VAL": "INT8_MIN",
+            "INTMAX1_INT_8_MAX_VAL": "INT8_MAX",
+            "INTMAX1_UINT_8_MAX_VAL": "UINT8_MAX",
+            "INTMAX1_INT_16_MIN_VAL": "INT16_MIN",
+            "INTMAX1_INT_16_MAX_VAL": "INT16_MAX",
+            "INTMAX1_UINT_16_MAX_VAL": "UINT16_MAX",
+            "INTMAX1_INT_32_MIN_VAL": "INT32_MIN",
+            "INTMAX1_INT_32_MAX_VAL": "INT32_MAX",
+            "INTMAX1_UINT_32_MAX_VAL": "UINT32_MAX",
+            "INTMAX1_INT_64_MIN_VAL": "INT64_MIN",
+            "INTMAX1_INT_64_MAX_VAL": "INT64_MAX",
+            "INTMAX1_UINT_64_MAX_VAL": "UINT64_MAX",
+            "INTMAX4_INT_8_MIN_VAL": "INT8_MIN",
+            "INTMAX4_INT_8_MAX_VAL": "INT8_MAX",
+            "INTMAX4_UINT_8_MAX_VAL": "UINT8_MAX",
+            "INTMAX4_INT_16_MIN_VAL": "INT16_MIN",
+            "INTMAX4_INT_16_MAX_VAL": "INT16_MAX",
+            "INTMAX4_UINT_16_MAX_VAL": "UINT16_MAX",
+            "INTMAX4_INT_32_MIN_VAL": "INT32_MIN",
+            "INTMAX4_INT_32_MAX_VAL": "INT32_MAX",
+            "INTMAX4_UINT_32_MAX_VAL": "UINT32_MAX",
+            "INTMAX4_INT_64_MIN_VAL": "INT64_MIN",
+            "INTMAX4_INT_64_MAX_VAL": "INT64_MAX",
+            "INTMAX4_UINT_64_MAX_VAL": "UINT64_MAX",
+            "INTMAX5_INT_8_MIN_PLUS1_VAL": "-129",
+            "INTMAX5_INT_8_MAX_PLUS1_VAL": "128",
+            "INTMAX5_UINT_8_MAX_PLUS1_VAL": "256",
+            "INTMAX5_INT_16_MIN_PLUS1_VAL": "-32769",
+            "INTMAX5_INT_16_MAX_PLUS1_VAL": "32768",
+            "INTMAX5_UINT_16_MAX_PLUS1_VAL": "65536",
+            "INTMAX5_INT_32_MIN_PLUS1_VAL": "-2147483649LL",
+            "INTMAX5_INT_32_MAX_PLUS1_VAL": "2147483648",
+            "INTMAX5_UINT_32_MAX_PLUS1_VAL": "4294967296ULL",
+        }
+
         lit_func = "put" if mode == "encode" else "expect"
         lit_p_func = "encode" if mode == "encode" else "pexpect"
         result_var = "input" if mode == "encode" else "result"
         expected_output_code = [
-            f"zcbor_int8_{lit_func}(state, (INT8_MIN))",
-            f"zcbor_uint8_{lit_func}(state, (INT8_MAX))",
-            f"zcbor_uint8_{lit_func}(state, (UINT8_MAX))",
-            f"zcbor_int16_{lit_func}(state, (INT16_MIN))",
-            f"zcbor_uint16_{lit_func}(state, (INT16_MAX))",
-            f"zcbor_uint16_{lit_func}(state, (UINT16_MAX))",
-            f"zcbor_int32_{lit_func}(state, (INT32_MIN))",
-            f"zcbor_uint32_{lit_func}(state, (INT32_MAX))",
-            f"zcbor_uint32_{lit_func}(state, (UINT32_MAX))",
-            f"zcbor_int64_{lit_func}(state, (INT64_MIN))",
-            f"zcbor_uint64_{lit_func}(state, (INT64_MAX))",
-            f"zcbor_uint64_{lit_func}(state, (UINT64_MAX))",
+            f"zcbor_int8_{lit_func}(state, (INTMAX1_INT_8_MIN_VAL)",
+            f"zcbor_uint8_{lit_func}(state, (INTMAX1_INT_8_MAX_VAL)",
+            f"zcbor_uint8_{lit_func}(state, (INTMAX1_UINT_8_MAX_VAL)",
+            f"zcbor_int16_{lit_func}(state, (INTMAX1_INT_16_MIN_VAL)",
+            f"zcbor_uint16_{lit_func}(state, (INTMAX1_INT_16_MAX_VAL)",
+            f"zcbor_uint16_{lit_func}(state, (INTMAX1_UINT_16_MAX_VAL)",
+            f"zcbor_int32_{lit_func}(state, (INTMAX1_INT_32_MIN_VAL)",
+            f"zcbor_uint32_{lit_func}(state, (INTMAX1_INT_32_MAX_VAL)",
+            f"zcbor_uint32_{lit_func}(state, (INTMAX1_UINT_32_MAX_VAL)",
+            f"zcbor_int64_{lit_func}(state, (INTMAX1_INT_64_MIN_VAL)",
+            f"zcbor_uint64_{lit_func}(state, (INTMAX1_INT_64_MAX_VAL)",
+            f"zcbor_uint64_{lit_func}(state, (INTMAX1_UINT_64_MAX_VAL)",
             f"zcbor_int8_{mode}(state, (&(*{result_var}).Intmax2_INT_8)",
             f"zcbor_uint8_{mode}(state, (&(*{result_var}).Intmax2_UINT_8)",
             f"zcbor_int16_{mode}(state, (&(*{result_var}).Intmax2_INT_16)",
@@ -1340,27 +1377,27 @@ class TestIntSize(PopenTest, TempdTest):
             f"zcbor_uint32_{mode}(state, (&(*{result_var}).Intmax2_UINT_32)",
             f"zcbor_int64_{mode}(state, (&(*{result_var}).Intmax2_INT_64)",
             f"zcbor_uint64_{mode}(state, (&(*{result_var}).Intmax2_UINT_64)",
-            f"&(*{result_var}).Intmax4_INT_8_MIN_count, ZCBOR_CUSTOM_CAST_FP(zcbor_int8_{lit_p_func}), state, (&(int8_t){{INT8_MIN}})",
-            f"&(*{result_var}).Intmax4_INT_8_MAX_count, ZCBOR_CUSTOM_CAST_FP(zcbor_uint8_{lit_p_func}), state, (&(uint8_t){{INT8_MAX}})",
-            f"&(*{result_var}).Intmax4_UINT_8_MAX_count, ZCBOR_CUSTOM_CAST_FP(zcbor_uint8_{lit_p_func}), state, (&(uint8_t){{UINT8_MAX}})",
-            f"&(*{result_var}).Intmax4_INT_16_MIN_count, ZCBOR_CUSTOM_CAST_FP(zcbor_int16_{lit_p_func}), state, (&(int16_t){{INT16_MIN}})",
-            f"&(*{result_var}).Intmax4_INT_16_MAX_count, ZCBOR_CUSTOM_CAST_FP(zcbor_uint16_{lit_p_func}), state, (&(uint16_t){{INT16_MAX}})",
-            f"&(*{result_var}).Intmax4_UINT_16_MAX_count, ZCBOR_CUSTOM_CAST_FP(zcbor_uint16_{lit_p_func}), state, (&(uint16_t){{UINT16_MAX}})",
-            f"&(*{result_var}).Intmax4_INT_32_MIN_count, ZCBOR_CUSTOM_CAST_FP(zcbor_int32_{lit_p_func}), state, (&(int32_t){{INT32_MIN}})",
-            f"&(*{result_var}).Intmax4_INT_32_MAX_count, ZCBOR_CUSTOM_CAST_FP(zcbor_uint32_{lit_p_func}), state, (&(uint32_t){{INT32_MAX}})",
-            f"&(*{result_var}).Intmax4_UINT_32_MAX_count, ZCBOR_CUSTOM_CAST_FP(zcbor_uint32_{lit_p_func}), state, (&(uint32_t){{UINT32_MAX}})",
-            f"&(*{result_var}).Intmax4_INT_64_MIN_count, ZCBOR_CUSTOM_CAST_FP(zcbor_int64_{lit_p_func}), state, (&(int64_t){{INT64_MIN}})",
-            f"&(*{result_var}).Intmax4_INT_64_MAX_count, ZCBOR_CUSTOM_CAST_FP(zcbor_uint64_{lit_p_func}), state, (&(uint64_t){{INT64_MAX}})",
-            f"&(*{result_var}).Intmax4_UINT_64_MAX_count, ZCBOR_CUSTOM_CAST_FP(zcbor_uint64_{lit_p_func}), state, (&(uint64_t){{UINT64_MAX}}),",
-            f"zcbor_int16_{lit_func}(state, (-129))",
-            f"zcbor_uint8_{lit_func}(state, (128))",
-            f"zcbor_uint16_{lit_func}(state, (256))",
-            f"zcbor_int32_{lit_func}(state, (-32769))",
-            f"zcbor_uint16_{lit_func}(state, (32768))",
-            f"zcbor_uint32_{lit_func}(state, (65536))",
-            f"zcbor_int64_{lit_func}(state, (-2147483649))",
-            f"zcbor_uint32_{lit_func}(state, (2147483648))",
-            f"zcbor_uint64_{lit_func}(state, (4294967296))",
+            f"&(*{result_var}).Intmax4_INT_8_MIN_count, ZCBOR_CUSTOM_CAST_FP(zcbor_int8_{lit_p_func}), state, (&(int8_t){{INTMAX4_INT_8_MIN_VAL}})",
+            f"&(*{result_var}).Intmax4_INT_8_MAX_count, ZCBOR_CUSTOM_CAST_FP(zcbor_uint8_{lit_p_func}), state, (&(uint8_t){{INTMAX4_INT_8_MAX_VAL}})",
+            f"&(*{result_var}).Intmax4_UINT_8_MAX_count, ZCBOR_CUSTOM_CAST_FP(zcbor_uint8_{lit_p_func}), state, (&(uint8_t){{INTMAX4_UINT_8_MAX_VAL}})",
+            f"&(*{result_var}).Intmax4_INT_16_MIN_count, ZCBOR_CUSTOM_CAST_FP(zcbor_int16_{lit_p_func}), state, (&(int16_t){{INTMAX4_INT_16_MIN_VAL}})",
+            f"&(*{result_var}).Intmax4_INT_16_MAX_count, ZCBOR_CUSTOM_CAST_FP(zcbor_uint16_{lit_p_func}), state, (&(uint16_t){{INTMAX4_INT_16_MAX_VAL}})",
+            f"&(*{result_var}).Intmax4_UINT_16_MAX_count, ZCBOR_CUSTOM_CAST_FP(zcbor_uint16_{lit_p_func}), state, (&(uint16_t){{INTMAX4_UINT_16_MAX_VAL}})",
+            f"&(*{result_var}).Intmax4_INT_32_MIN_count, ZCBOR_CUSTOM_CAST_FP(zcbor_int32_{lit_p_func}), state, (&(int32_t){{INTMAX4_INT_32_MIN_VAL}})",
+            f"&(*{result_var}).Intmax4_INT_32_MAX_count, ZCBOR_CUSTOM_CAST_FP(zcbor_uint32_{lit_p_func}), state, (&(uint32_t){{INTMAX4_INT_32_MAX_VAL}})",
+            f"&(*{result_var}).Intmax4_UINT_32_MAX_count, ZCBOR_CUSTOM_CAST_FP(zcbor_uint32_{lit_p_func}), state, (&(uint32_t){{INTMAX4_UINT_32_MAX_VAL}})",
+            f"&(*{result_var}).Intmax4_INT_64_MIN_count, ZCBOR_CUSTOM_CAST_FP(zcbor_int64_{lit_p_func}), state, (&(int64_t){{INTMAX4_INT_64_MIN_VAL}})",
+            f"&(*{result_var}).Intmax4_INT_64_MAX_count, ZCBOR_CUSTOM_CAST_FP(zcbor_uint64_{lit_p_func}), state, (&(uint64_t){{INTMAX4_INT_64_MAX_VAL}})",
+            f"&(*{result_var}).Intmax4_UINT_64_MAX_count, ZCBOR_CUSTOM_CAST_FP(zcbor_uint64_{lit_p_func}), state, (&(uint64_t){{INTMAX4_UINT_64_MAX_VAL}}),",
+            f"zcbor_int16_{lit_func}(state, (INTMAX5_INT_8_MIN_PLUS1_VAL))",
+            f"zcbor_uint8_{lit_func}(state, (INTMAX5_INT_8_MAX_PLUS1_VAL))",
+            f"zcbor_uint16_{lit_func}(state, (INTMAX5_UINT_8_MAX_PLUS1_VAL))",
+            f"zcbor_int32_{lit_func}(state, (INTMAX5_INT_16_MIN_PLUS1_VAL))",
+            f"zcbor_uint16_{lit_func}(state, (INTMAX5_INT_16_MAX_PLUS1_VAL))",
+            f"zcbor_uint32_{lit_func}(state, (INTMAX5_UINT_16_MAX_PLUS1_VAL))",
+            f"zcbor_int64_{lit_func}(state, (INTMAX5_INT_32_MIN_PLUS1_VAL))",
+            f"zcbor_uint32_{lit_func}(state, (INTMAX5_INT_32_MAX_PLUS1_VAL))",
+            f"zcbor_uint64_{lit_func}(state, (INTMAX5_UINT_32_MAX_PLUS1_VAL))",
             f"zcbor_int16_{mode}(state, (&(*{result_var}).Intmax6_INT_8_PLUS1)",
             f"zcbor_int16_{mode}(state, (&(*{result_var}).Intmax6_UINT_8_PLUS1)",
             f"zcbor_int32_{mode}(state, (&(*{result_var}).Intmax6_INT_16_PLUS1)",
@@ -1371,20 +1408,41 @@ class TestIntSize(PopenTest, TempdTest):
             f"zcbor_uint{bit_size}_{mode}(state, (&(*{result_var}).DefaultInt_uint)",
         ]
 
+        if defines_arg == []:
+            # Create expected_output_code_lit for use when not using --defines
+            # Replace usage of defined constants with their literal values
+            expected_output_code_lit = []
+            for e in expected_output_code:
+                e2 = e
+                for n, v in expected_defines.items():
+                    e2 = e2.replace(n, v)
+                expected_output_code_lit.append(e2)
+
         output_c = (self.tempd / "src" / f"intmax_{mode}.c").read_text()
+        output_h = (self.tempd / "include" / f"intmax_{mode}.h").read_text()
         output_h_types = (self.tempd / "include" / "intmax_types.h").read_text()
 
         for e in expected_output_types:
             self.assertIn(e, output_h_types, f"Expected '{e}' in output_h_types")
-        for e in expected_output_code:
-            self.assertIn(e, output_c, f"Expected '{e}' in output_c")
+
+        if defines_arg == []:
+            for n, v in expected_defines.items():
+                self.assertNotIn(f"#define {n} ({v})", output_h, f"Expected no '{e}' in output_h")
+            for e in expected_output_code_lit:
+                self.assertIn(e, output_c, f"Expected '{e}' in output_c")
+        else:
+            for n, v in expected_defines.items():
+                self.assertIn(f"#define {n} ({v})", output_h, f"Expected '{e}' in output_h")
+            for e in expected_output_code:
+                self.assertIn(e, output_c, f"Expected '{e}' in output_c")
 
     def test_int_size(self):
         """Test that the correct integer types are generated for different bit sizes."""
 
         for mode in ("decode", "encode"):
-            for bit_size in (8, 16, 32, 64):
-                self.do_test_int_size(mode, bit_size)
+            for defines_arg in ([], ["--defines"]):
+                for bit_size in (8, 16, 32, 64):
+                    self.do_test_int_size(mode, defines_arg, bit_size)
 
 
 class TestCanonical(PopenTest):

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -208,11 +208,10 @@ def mult_or_none(it, default=None):
     return or_none(it, prod, default=default)
 
 
-def tmp_str_or_null(value):
-    """Assign the min_value variable."""
-    value_str = f'"{value}"' if value is not None else "NULL"
-    len_str = f"""sizeof({f'"{value}"'}) - 1, &tmp_str)"""
-    return f"(tmp_str.value = (uint8_t *){value_str}, tmp_str.len = {len_str}"
+def assign_tmp_str(value):
+    """Assign the `value` to a temporary string structure."""
+    assert value is not None, "Value cannot be None."
+    return f"(tmp_str.value = (uint8_t *){value}, tmp_str.len = sizeof({value}) - 1, &tmp_str)"
 
 
 def deref_if_not_null(access):
@@ -564,7 +563,7 @@ class CddlParser:
             # Name an integer by its expected value:
             or (
                 f"{self.type.lower()}{abs(self.value)}"
-                if self.type in ["UINT", "NINT"] and self.value is not None
+                if self.type in ["UINT", "NINT", "BOOL"] and self.value is not None
                 else None
             )
             # Name a type by its type name
@@ -2485,6 +2484,7 @@ class CodeGenerator(CddlXcoder):
         *,
         mode,
         entry_type_names,
+        add_defines=False,
         default_bit_size=defaults["default_bit_size"],
         default_max_qty_define="ZCBOR_DEFAULT_MAX_QTY",
         **kwargs,
@@ -2492,6 +2492,7 @@ class CodeGenerator(CddlXcoder):
         super(CodeGenerator, self).__init__(**kwargs)
         self.mode = mode
         self.entry_type_names = entry_type_names
+        self.add_defines = add_defines
         self.default_bit_size = default_bit_size
         self.default_max_qty_define = default_max_qty_define
 
@@ -2524,6 +2525,7 @@ class CodeGenerator(CddlXcoder):
             **(super().init_kwargs()),
             "mode": self.mode,
             "entry_type_names": self.entry_type_names,
+            "add_defines": self.add_defines,
             "default_bit_size": self.default_bit_size,
             "default_max_qty_define": self.default_max_qty_define,
         }
@@ -2933,9 +2935,9 @@ class CodeGenerator(CddlXcoder):
         elif not self.is_unambiguous_value():
             arg = deref_if_not_null(access)
         elif self.type in ["BSTR", "TSTR"]:
-            arg = tmp_str_or_null(self.value)
+            arg = assign_tmp_str(self.val_define_name_or_lit("VAL"))
         elif self.type in ["UINT", "INT", "NINT", "FLOAT", "BOOL"]:
-            value = val_to_str(self.value)
+            value = self.val_define_name_or_lit("VAL")
             arg = f"&({self.val_type_name()}){{{value}}}" if ptr_result else value
         else:
             assert False, "Should not come here."
@@ -3159,10 +3161,8 @@ class CodeGenerator(CddlXcoder):
         return self.xcode_single_func_prim()
 
     def xcode_tags(self):
-        return [
-            f"zcbor_tag_{'put' if (self.mode == 'encode') else 'expect'}(state, {tag})"
-            for tag in self.tags
-        ]
+        fn = f"zcbor_tag_{'put' if (self.mode == 'encode') else 'expect'}"
+        return [f"{fn}(state, {self.val_define_name_or_lit('TAG', i)})" for i in range(len(self.tags))]
 
     def value_suffix(self, value_str):
         """Appends ULL or LL if a value exceeding 32-bits is used"""
@@ -3179,10 +3179,117 @@ class CodeGenerator(CddlXcoder):
 
         return ""
 
-    def val_to_str_with_suffix(self, value):
+    def val_to_lit(self, value):
         """Convert value to string with appropriate suffix."""
         value_str = val_to_str(value)
-        return f"{value_str}{self.value_suffix(value_str)}"
+        literal = f"{value_str}{self.value_suffix(value_str)}"
+        return f'"{literal}"' if self.type in ["TSTR", "BSTR"] else literal
+
+    defines = {
+        "MIN_VAL": lambda m_self: m_self.min_value,
+        "MAX_VAL": lambda m_self: m_self.max_value,
+        "DEFAULT_VAL": lambda m_self: m_self.val_to_lit(m_self.default.value),
+        "VAL": lambda m_self: m_self.val_to_lit(m_self.value),
+        "MSK": lambda m_self: " | ".join(
+            f"(1 << {c.enum_var_name()})" for c in m_self.my_control_groups[m_self.bits.value].value
+        ),
+        "MIN_SIZE": lambda m_self: m_self.min_size,
+        "MAX_SIZE": lambda m_self: m_self.max_size,
+        "SIZE": lambda m_self: m_self.min_size,
+        "MIN_QTY": lambda m_self: m_self.min_qty,
+        "MAX_QTY": lambda m_self: (
+            m_self.max_qty if m_self.max_qty is not None else m_self.default_max_qty_define
+        ),
+        "QTY": lambda m_self: m_self.min_qty,
+        "TAG": lambda m_self, i: m_self.tags[i],
+        "NUM_BACKUPS": lambda m_self: m_self.num_backups(),
+    }
+
+    def val_define_name(self, val_type, i=None):
+        """Return the name to use for a #define for a value of this type."""
+        val_type_i = val_type if i is None else f"{val_type}{i}"
+        assert i is None or (val_type == "TAG" and isinstance(i, int)), f"Invalid i arg ({i})."
+        assert val_type in self.defines, f"Invalid define suffix: {val_type} with i: {i}."
+        return f"{self.var_name(with_prefix=True).upper()}_{val_type_i}"
+
+    def add_defines_condition(self):
+        """Whether to use #defines for values or literals directly in code."""
+        return self.add_defines
+
+    def val_define_name_or_lit(self, val_type, i=None):
+        """Return either the #define name or the literal value for a value of this type,
+        depending on configuration."""
+        if self.add_defines_condition():
+            return self.val_define_name(val_type, i)
+        else:
+            return self.val_define_value(val_type, i)
+
+    def val_define_value(self, val_type, i=None):
+        """Return the value to use for a #define for a value of this type."""
+        value_args = (self,) if i is None else (self, i)
+        value = self.defines[val_type](*value_args)
+        return value
+
+    def val_defines(self):
+        """Return all #defines needed for this element."""
+        if not self.add_defines_condition():
+            return []
+
+        defines = []
+
+        def _define(n, i=None):
+            return defines.append((self.val_define_name(n, i), self.val_define_value(n, i)))
+
+        if self.type in ["INT", "UINT", "NINT", "FLOAT", "BOOL"]:
+            if self.value is not None:
+                _define("VAL")
+            else:
+                if self.min_value is not None:
+                    _define("MIN_VAL")
+                if self.max_value is not None:
+                    _define("MAX_VAL")
+            if self.bits:
+                _define("MSK")
+        elif self.type in ["BSTR", "TSTR"]:
+            if self.value is not None:
+                _define("VAL")
+            if self.min_size is not None and self.min_size == self.max_size:
+                _define("SIZE")
+            else:
+                if self.min_size is not None:
+                    _define("MIN_SIZE")
+                if self.max_size is not None:
+                    _define("MAX_SIZE")
+        if self.count_var_condition():
+            if self.min_qty is not None and self.min_qty == self.max_qty:
+                _define("QTY")
+            else:
+                if self.min_qty is not None:
+                    _define("MIN_QTY")
+                _define("MAX_QTY")
+        if self.tags:
+            for i in range(len(self.tags)):
+                _define(f"TAG", i)
+        if self.default is not None:
+            _define("DEFAULT_VAL")
+        if self in (self.my_types[entry] for entry in self.entry_type_names):
+            _define("NUM_BACKUPS")
+        return defines
+
+    def val_defines_recursive(self):
+        """Return all #defines needed for this element and its children."""
+        defines = []
+        if self.type in ["LIST", "MAP", "GROUP", "UNION"]:
+            for child in self.value:
+                defines.extend(child.val_defines_recursive())
+        if self.type == "OTHER" and self.value not in self.entry_type_names:
+            defines.extend(self.my_types[self.value].val_defines_recursive())
+        if self.cbor is not None:
+            defines.extend(self.cbor.val_defines_recursive())
+        if self.key is not None:
+            defines.extend(self.key.val_defines_recursive())
+        defines.extend(self.val_defines())
+        return defines
 
     def range_checks(self, access):
         """Return the code needed to check the size/value bounds of this element."""
@@ -3198,33 +3305,24 @@ class CodeGenerator(CddlXcoder):
 
         if self.type in ["INT", "UINT", "NINT", "FLOAT", "BOOL"]:
             if min_val is not None and min_val == max_val:
-                range_checks.append(f"({access} == {self.val_to_str_with_suffix(min_val)})")
+                range_checks.append(f"({access} == {self.val_define_name_or_lit('VAL')})")
             else:
                 if min_val is not None:
-                    ineq_op = ">=" if self.min_value_inclusive else ">"
-                    range_checks.append(f"({access} {ineq_op} {self.val_to_str_with_suffix(min_val)})")
+                    op = ">=" if self.min_value_inclusive else ">"
+                    range_checks.append(f"({access} {op} {self.val_define_name_or_lit('MIN_VAL')})")
                 if max_val is not None:
-                    ineq_op = "<=" if self.max_value_inclusive else "<"
-                    range_checks.append(f"({access} {ineq_op} {self.val_to_str_with_suffix(max_val)})")
+                    op = "<=" if self.max_value_inclusive else "<"
+                    range_checks.append(f"({access} {op} {self.val_define_name_or_lit('MAX_VAL')})")
             if self.bits:
-                range_checks.append(
-                    f"!({access} & ~("
-                    + " | ".join(
-                        [
-                            f"(1 << {c.enum_var_name()})"
-                            for c in self.my_control_groups[self.bits.value].value
-                        ]
-                    )
-                    + "))"
-                )
+                range_checks.append(f"!({access} & ~({self.val_define_name_or_lit('MSK')}))")
         elif self.type in ["BSTR", "TSTR"]:
             if self.min_size is not None and self.min_size == self.max_size:
-                range_checks.append(f"({access}.len == {val_to_str(self.min_size)})")
+                range_checks.append(f"({access}.len == {self.val_define_name_or_lit('SIZE')})")
             else:
                 if self.min_size is not None:
-                    range_checks.append(f"({access}.len >= {val_to_str(self.min_size)})")
+                    range_checks.append(f"({access}.len >= {self.val_define_name_or_lit('MIN_SIZE')})")
                 if self.max_size is not None:
-                    range_checks.append(f"({access}.len <= {val_to_str(self.max_size)})")
+                    range_checks.append(f"({access}.len <= {self.val_define_name_or_lit('MAX_SIZE')})")
         elif self.type == "OTHER":
             if not self.my_types[self.value].single_func_impl_condition():
                 range_checks.extend(self.my_types[self.value].range_checks(access))
@@ -3306,17 +3404,18 @@ class CodeGenerator(CddlXcoder):
                 assign = not self.repeated_single_func_impl_condition()
                 default_assignment = None
                 if self.default is not None:
-                    default_value = (
-                        f"*({tmp_str_or_null(self.default.value)})"
+                    default_val = self.val_define_name_or_lit("DEFAULT_VAL")
+                    default_val_formatted = (
+                        f"*({assign_tmp_str(default_val)})"
                         if self.type in ["TSTR", "BSTR"]
-                        else self.val_to_str_with_suffix(self.default.value)
+                        else val_to_str(default_val)
                     )
                     access = self.val_access() if assign else self.repeated_val_access()
-                    default_assignment = f"({access} = {default_value})"
+                    default_assignment = f"({access} = {default_val_formatted})"
                 if assign:
                     decode_str = self.repeated_xcode(union_int)
                     return comma_operator(
-                        default_assignment, f"{self.present_var_access()} = {decode_str}", "1"
+                        default_assignment, f"{self.present_var_access()} = {decode_str}", "true"
                     )
                 func, *arguments = self.repeated_single_func(ptr_result=True)
                 return comma_operator(
@@ -3334,9 +3433,10 @@ class CodeGenerator(CddlXcoder):
 
             minmax = "_minmax" if self.mode == "encode" else ""
             mode = self.mode
+            equal = self.min_qty == self.max_qty and self.min_qty is not None
             return f"zcbor_multi_{mode}{minmax}(%s, %s, &%s, ZCBOR_CUSTOM_CAST_FP(%s), %s, %s)" % (
-                self.min_qty,
-                self.max_qty if self.max_qty is not None else self.default_max_qty_define,
+                self.val_define_name_or_lit("MIN_QTY" if not equal else "QTY"),
+                self.val_define_name_or_lit("MAX_QTY" if not equal else "QTY"),
                 self.count_var_access(),
                 func,
                 xcode_args("*" + arg if arg != "NULL" and self.result_len() != "0" else arg),
@@ -3406,6 +3506,7 @@ class CodeRenderer:
         self.sorted_types = dict()
         self.functions = dict()
         self.type_defs = dict()
+        self.defines = dict()
 
         if isinstance(modes, str):
             modes = [modes]
@@ -3421,6 +3522,7 @@ class CodeRenderer:
             self.functions[mode] = self.unique_funcs(mode)
             self.functions[mode] = self.used_funcs(mode)
             self.type_defs[mode] = self.unique_types(mode)
+            self.defines[mode] = self.used_defines(mode)
 
         self.version = __version__
 
@@ -3495,6 +3597,20 @@ and
                 out_types.append(func_type)
         return list(reversed(out_types))
 
+    def used_defines(self, mode):
+        """Return a list of #defines for all defined types, with unused #defines removed."""
+        full_code = "".join([func_type[0] for func_type in self.functions[mode]])
+        chosen = dict()
+        defines = list(chain(*(xcoder.val_defines_recursive() for xcoder in self.sorted_types[mode])))
+
+        for name, body in defines:
+            if name in full_code or name.endswith("NUM_BACKUPS"):
+                if name not in chosen:
+                    chosen[name] = body
+                elif chosen[name] != body:
+                    raise ValueError(f"Two different '#define {name}': ({body} != {chosen[name]}).")
+        return list(sorted(f"#define {name} ({body})" for name, body in chosen.items()))
+
     def render_forward_declaration(self, xcoder, mode):
         """Render a single decoding function with signature and body."""
         return f"""
@@ -3566,7 +3682,7 @@ static bool {xcoder.func_name}(
         return f"""
 {xcoder.public_xcode_func_sig()}
 {{
-	zcbor_state_t states[{xcoder.num_backups() + 2}];
+	zcbor_state_t states[{xcoder.val_define_name_or_lit("NUM_BACKUPS")} + ZCBOR_EXTRA_STATES];
 {self.render_arg_check(((func_name, "states", func_arg),))}
 	return zcbor_entry_function(payload, payload_len, (void *){func_arg}, payload_len_out, states,
 		(zcbor_decoder_t *)ZCBOR_CUSTOM_CAST_FP({func_name}), sizeof(states) / sizeof(zcbor_state_t), {elem_count});
@@ -3626,7 +3742,7 @@ do { \\
 #ifdef __cplusplus
 extern "C" {{
 #endif
-
+{((linesep * 2) + (linesep).join(self.defines[mode]) + (linesep)) if self.defines[mode] else ""}
 {(linesep * 2).join([f"{xcoder.public_xcode_func_sig()};" for xcoder in self.entry_types[mode]])}
 
 
@@ -3991,6 +4107,15 @@ from the corresponding union members.""",
 Can be a string or a path to a file. If interpreted as a path to an existing file,
 the file's contents will be used.""",
     )
+    code_parser.add_argument(
+        "--defines",
+        required=False,
+        action="store_true",
+        default=False,
+        help="""Make #defines for all magic numbers in generated code, and place them in the
+generated header file. This is off by default because it may create naming conflicts that don't
+show up otherwise.""",
+    )
     code_parser.set_defaults(process=process_code)
 
     validate_parent_parser = ArgumentParser(add_help=False)
@@ -4157,6 +4282,7 @@ def process_code(args):
                 mode=mode,
                 cddl_string=cddl_contents,
                 entry_type_names=args.entry_types,
+                add_defines=args.defines,
                 default_bit_size=args.default_bit_size,
                 short_names=args.short_names,
                 default_max_qty_define=default_max_qty_define,


### PR DESCRIPTION
and use them in generated code.

Fixes #517 