### PR TITLE
zcbor.py: Use the DEFAULT_MAX_QTY define in the generated code

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -19,6 +19,10 @@
     In certain specific cases, the type of an argument to a `cbor_decode_*` or `cbor_decode_*` can change when regenerating the code, requiring changes in your non-generated code.
     More commonly, struct members will change to use smaller int types.
 
+  * Certain CDDL expressions with double quantifiers and parentheses (single-member groups) would previously be generated with a maximum count of default-max-qty^n (where n is the number of nested quantifiers). This has now been changed to always be default-max-qty.
+    Example: `foo = +(+bar)`
+    With default-max-qty of 3, the above would previously have a max count of 9, but is now 3.
+
 
 # zcbor v. 0.9.0
 

--- a/samples/pet/include/pet_decode.h
+++ b/samples/pet/include/pet_decode.h
@@ -5,7 +5,6 @@
  *
  * Generated using zcbor version 0.9.99
  * https://github.com/NordicSemiconductor/zcbor
- * Generated with a --default-max-qty of 3
  */
 
 #ifndef PET_DECODE_H__
@@ -19,10 +18,6 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#if DEFAULT_MAX_QTY != 3
-#error "The type file was generated with a different default_max_qty than this file"
 #endif
 
 

--- a/samples/pet/include/pet_encode.h
+++ b/samples/pet/include/pet_encode.h
@@ -5,7 +5,6 @@
  *
  * Generated using zcbor version 0.9.99
  * https://github.com/NordicSemiconductor/zcbor
- * Generated with a --default-max-qty of 3
  */
 
 #ifndef PET_ENCODE_H__
@@ -19,10 +18,6 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#if DEFAULT_MAX_QTY != 3
-#error "The type file was generated with a different default_max_qty than this file"
 #endif
 
 

--- a/samples/pet/include/pet_types.h
+++ b/samples/pet/include/pet_types.h
@@ -5,7 +5,6 @@
  *
  * Generated using zcbor version 0.9.99
  * https://github.com/NordicSemiconductor/zcbor
- * Generated with a --default-max-qty of 3
  */
 
 #ifndef PET_TYPES_H__
@@ -22,15 +21,14 @@ extern "C" {
 
 /** Which value for --default-max-qty this file was created with.
  *
- *  The define is used in the other generated file to do a build-time
- *  compatibility check.
+ *  This can be safely edited.
  *
  *  See `zcbor --help` for more information about --default-max-qty
  */
-#define DEFAULT_MAX_QTY 3
+#define ZCBOR_PET_DEFAULT_MAX_QTY 3
 
 struct Pet {
-	struct zcbor_string names[3];
+	struct zcbor_string names[ZCBOR_PET_DEFAULT_MAX_QTY];
 	size_t names_count;
 	struct zcbor_string birthday;
 	enum {

--- a/samples/pet/pet.cmake
+++ b/samples/pet/pet.cmake
@@ -5,7 +5,6 @@
 #
 # Generated using zcbor version 0.9.99
 # https://github.com/NordicSemiconductor/zcbor
-# Generated with a --default-max-qty of 3
 #
 
 add_library(pet)

--- a/samples/pet/src/pet_decode.c
+++ b/samples/pet/src/pet_decode.c
@@ -5,7 +5,6 @@
  *
  * Generated using zcbor version 0.9.99
  * https://github.com/NordicSemiconductor/zcbor
- * Generated with a --default-max-qty of 3
  */
 
 #include <stdint.h>
@@ -15,10 +14,6 @@
 #include "zcbor_decode.h"
 #include "pet_decode.h"
 #include "zcbor_print.h"
-
-#if DEFAULT_MAX_QTY != 3
-#error "The type file was generated with a different default_max_qty than this file"
-#endif
 
 #define ZCBOR_CUSTOM_CAST_FP(func) _Generic((func), \
 	bool(*)(zcbor_state_t *, struct Pet *): ((zcbor_decoder_t *)func), \
@@ -41,7 +36,7 @@ static bool decode_Pet(
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = (((zcbor_list_start_decode(state) && ((((zcbor_list_start_decode(state) && ((zcbor_multi_decode(1, 3, &(*result).names_count, ZCBOR_CUSTOM_CAST_FP(zcbor_tstr_decode), state, (*&(*result).names), sizeof(struct zcbor_string))) || (zcbor_list_map_end_force_decode(state), false)) && zcbor_list_end_decode(state)))
+	bool res = (((zcbor_list_start_decode(state) && ((((zcbor_list_start_decode(state) && ((zcbor_multi_decode(1, ZCBOR_PET_DEFAULT_MAX_QTY, &(*result).names_count, ZCBOR_CUSTOM_CAST_FP(zcbor_tstr_decode), state, (*&(*result).names), sizeof(struct zcbor_string))) || (zcbor_list_map_end_force_decode(state), false)) && zcbor_list_end_decode(state)))
 	&& ((zcbor_bstr_decode(state, (&(*result).birthday)))
 	&& ((((((*result).birthday.len == 8)) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false))) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false)))
 	&& ((((zcbor_uint_decode(state, &(*result).species_choice, sizeof((*result).species_choice)))) && ((((((*result).species_choice == Pet_species_cat_c) && ((1)))
@@ -76,5 +71,5 @@ int cbor_decode_Pet(
 	}
 
 	return zcbor_entry_function(payload, payload_len, (void *)result, payload_len_out, states,
-		(zcbor_decoder_t *)ZCBOR_CUSTOM_CAST_FP(decode_Pet), sizeof(states) / sizeof(zcbor_state_t), 1);
+		(zcbor_decoder_t *)ZCBOR_CUSTOM_CAST_FP(decode_Pet), sizeof(states) / sizeof(zcbor_state_t), ZCBOR_LARGE_ELEM_COUNT);
 }

--- a/samples/pet/src/pet_encode.c
+++ b/samples/pet/src/pet_encode.c
@@ -5,7 +5,6 @@
  *
  * Generated using zcbor version 0.9.99
  * https://github.com/NordicSemiconductor/zcbor
- * Generated with a --default-max-qty of 3
  */
 
 #include <stdint.h>
@@ -15,10 +14,6 @@
 #include "zcbor_encode.h"
 #include "pet_encode.h"
 #include "zcbor_print.h"
-
-#if DEFAULT_MAX_QTY != 3
-#error "The type file was generated with a different default_max_qty than this file"
-#endif
 
 #define ZCBOR_CUSTOM_CAST_FP(func) _Generic((func), \
 	bool(*)(zcbor_state_t *, const struct Pet *): ((zcbor_encoder_t *)func), \
@@ -41,7 +36,7 @@ static bool encode_Pet(
 {
 	zcbor_log("%s\r\n", __func__);
 
-	bool res = (((zcbor_list_start_encode(state, 3) && ((((zcbor_list_start_encode(state, 3) && ((zcbor_multi_encode_minmax(1, 3, &(*input).names_count, ZCBOR_CUSTOM_CAST_FP(zcbor_tstr_encode), state, (*&(*input).names), sizeof(struct zcbor_string))) || (zcbor_list_map_end_force_encode(state), false)) && zcbor_list_end_encode(state, 3)))
+	bool res = (((zcbor_list_start_encode(state, 3) && ((((zcbor_list_start_encode(state, 0) && ((zcbor_multi_encode_minmax(1, ZCBOR_PET_DEFAULT_MAX_QTY, &(*input).names_count, ZCBOR_CUSTOM_CAST_FP(zcbor_tstr_encode), state, (*&(*input).names), sizeof(struct zcbor_string))) || (zcbor_list_map_end_force_encode(state), false)) && zcbor_list_end_encode(state, 0)))
 	&& (((((((*input).birthday.len == 8)) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false))) || (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false))
 	&& (zcbor_bstr_encode(state, (&(*input).birthday))))
 	&& ((((*input).species_choice == Pet_species_cat_c) ? ((zcbor_uint8_put(state, (1))))
@@ -77,5 +72,5 @@ int cbor_encode_Pet(
 	}
 
 	return zcbor_entry_function(payload, payload_len, (void *)input, payload_len_out, states,
-		(zcbor_decoder_t *)ZCBOR_CUSTOM_CAST_FP(encode_Pet), sizeof(states) / sizeof(zcbor_state_t), 1);
+		(zcbor_decoder_t *)ZCBOR_CUSTOM_CAST_FP(encode_Pet), sizeof(states) / sizeof(zcbor_state_t), 0);
 }

--- a/tests/encode/test3_corner_cases/src/main.c
+++ b/tests/encode/test3_corner_cases/src/main.c
@@ -454,7 +454,7 @@ ZTEST(cbor_encode_test3, test_optional)
 	struct Optional optional7 = {.boolval = true, .optbool_present = true,
 				.opttwo_present = true, .manduint = 2,
 				.multi8_count = 3};
-	uint8_t output[10];
+	uint8_t output[20];
 	size_t out_len;
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Optional(output,
@@ -885,7 +885,7 @@ ZTEST(cbor_encode_test3, test_range)
 		.multi0to10 = {0},
 	};
 
-	uint8_t output[25];
+	uint8_t output[50];
 	size_t out_len;
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Range(output, sizeof(output), &input1,
@@ -1210,7 +1210,7 @@ ZTEST(cbor_encode_test3, test_floats)
 
 	struct Floats input;
 	size_t num_encode;
-	uint8_t output[70];
+	uint8_t output[80];
 
 	input.float_16 = (float)0.0;
 	input.float_32 = (float)0.0;
@@ -1485,7 +1485,7 @@ ZTEST(cbor_encode_test3, test_intmax)
 	struct Intmax2 intput2;
 	struct Intmax4 intput4;
 	size_t num_encode;
-	uint8_t output[60];
+	uint8_t output[70];
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_encode_Intmax1(output,
 		sizeof(output), NULL, &num_encode), NULL);

--- a/tests/scripts/test_repo_files.py
+++ b/tests/scripts/test_repo_files.py
@@ -334,7 +334,6 @@ class TestSamples(TestCase):
                 f.readline()  # discard
                 self.assertIn("Generated using zcbor version", f.readline())
                 self.assertIn("https://github.com/NordicSemiconductor/zcbor", f.readline())
-                self.assertIn("Generated with a --default-max-qty of", f.readline())
 
 
 class TestDocs(TestCase, LinkTester):

--- a/tests/scripts/test_zcbor.py
+++ b/tests/scripts/test_zcbor.py
@@ -1105,7 +1105,6 @@ file header"""
 #
 # Generated using zcbor version {p_VERSION.read_text(encoding="utf-8")}
 # https://github.com/NordicSemiconductor/zcbor
-# Generated with a --default-max-qty of 5
 #""".splitlines()
         exp_c_header = f"""/*
  * Sample
@@ -1114,11 +1113,10 @@ file header"""
  *
  * Generated using zcbor version {p_VERSION.read_text(encoding="utf-8")}
  * https://github.com/NordicSemiconductor/zcbor
- * Generated with a --default-max-qty of 5
  */""".splitlines()
         self.assertEqual(
             exp_cmake_header,
-            (self.tempd / "pet.cmake").read_text(encoding="utf-8").splitlines()[:9],
+            (self.tempd / "pet.cmake").read_text(encoding="utf-8").splitlines()[:8],
         )
         for p in (
             self.tempd / "src" / "pet_decode.c",
@@ -1127,7 +1125,7 @@ file header"""
             self.tempd / "include" / "pet_encode.h",
             self.tempd / "include" / "pet_types.h",
         ):
-            self.assertEqual(exp_c_header, p.read_text(encoding="utf-8").splitlines()[:9])
+            self.assertEqual(exp_c_header, p.read_text(encoding="utf-8").splitlines()[:8])
 
     def test_file_header(self):
         self.do_test_file_header()
@@ -1516,7 +1514,6 @@ class TestExceptions(TestCase):
             zcbor.CodeGenerator.from_cddl(
                 cddl_string=cddl_string,
                 mode="decode",
-                default_max_qty=16,
                 entry_type_names=["test"],
                 default_bit_size=32,
             )


### PR DESCRIPTION
This involved changing some logic in zcbor.py that uses the actual default_max_qty value for calculations.

Addresses #507 