### PR TITLE
tests: Remove CONFIG_STD_C11 since it is deprecated.

### DIFF
--- a/tests/decode/test2_suit/prj.conf
+++ b/tests/decode/test2_suit/prj.conf
@@ -6,5 +6,3 @@
 
 CONFIG_ZTEST=y
 CONFIG_ZTEST_STACK_SIZE=16384
-# To avoid issues with c99 and -Wpedantic
-CONFIG_STD_C11=y

--- a/tests/decode/test5_corner_cases/prj.conf
+++ b/tests/decode/test5_corner_cases/prj.conf
@@ -6,5 +6,3 @@
 
 CONFIG_ZTEST=y
 CONFIG_ZTEST_STACK_SIZE=4096
-# To avoid issues with c99 and -Wpedantic
-CONFIG_STD_C11=y

--- a/tests/encode/test4_senml/prj.conf
+++ b/tests/encode/test4_senml/prj.conf
@@ -6,5 +6,3 @@
 
 CONFIG_ZTEST=y
 CONFIG_ZTEST_STACK_SIZE=4096
-# To avoid issues with c99 and -Wpedantic
-CONFIG_STD_C11=y

--- a/tests/unit/test1_unit_tests/prj.conf
+++ b/tests/unit/test1_unit_tests/prj.conf
@@ -6,5 +6,3 @@
 
 CONFIG_ZTEST=y
 CONFIG_ZTEST_STACK_SIZE=4096
-# To avoid issues with c99 and -Wpedantic
-CONFIG_STD_C11=y


### PR DESCRIPTION
Zephyr now requires C17 as a minimum.