### PR TITLE
bump to cbor2>=6.0.0

### DIFF
--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -1,3 +1,3 @@
-cbor2>=5.4.2.post1
+cbor2>=6.0.0
 pyyaml>=5.4.1
 regex>=2022.3.15

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -20,7 +20,7 @@ from cbor2 import (
     dumps,
     CBORTag,
     CBORDecoder,
-    CBORDecodeValueError,
+    CBORDecodeError,
     CBORDecodeEOF,
     undefined,
 )
@@ -147,13 +147,13 @@ def counter(reset=False):
 def strict_load(f):
     """Strict variety of cbor2.load that ensures all data is consumed by a single CBOR element."""
     dec = CBORDecoder(f)
-    obj = dec.decode()  # Raises CBORDecodeEOF or CBORDecodeValueError on failure.
+    obj = dec.decode()  # Raises CBORDecodeEOF or CBORDecodeError on failure.
     try:
         dec.read(1)
     except CBORDecodeEOF:
         return obj
     else:
-        raise CBORDecodeValueError("Data not fully decoded.")
+        raise CBORDecodeError("Data not fully decoded.")
 
 
 def strict_loads(b):
@@ -2451,7 +2451,7 @@ CBOR-formatted bstr, all elements must be bstrs. If not, it is a programmer erro
         elif isinstance(obj, bytes):
             try:
                 bstr_obj = self._to_yaml_obj(strict_loads(obj))
-            except (CBORDecodeValueError, CBORDecodeEOF):
+            except (CBORDecodeError, CBORDecodeEOF):
                 bstr_obj = obj.hex()
             return {"zcbor_bstr": bstr_obj}
         elif isinstance(obj, CBORTag):


### PR DESCRIPTION
CBORDecodeValueError was replaced with CBORDecodeError in 6.0 version.