### PR TITLE
requirements: pin cbor2 to <6.0.0

### DIFF
--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -1,3 +1,3 @@
-cbor2>=5.4.2.post1
+cbor2>=5.4.2.post1,<6.0.0
 pyyaml>=5.4.1
 regex>=2022.3.15


### PR DESCRIPTION
CBORDecodeValueError got replaced with CBORDecodeError, so make sure that old version of cbor2 is used.

This is an alternative to #577.