### PR TITLE
use CBORDecodeError instead of CBORDecodeValueError

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -108,7 +108,17 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.15']
-    name: Merge tests 2 - Python (${{ matrix.python-version }}) functional tests (Ubuntu)
+        cbor2-version: ["", "<6.0.0"]
+        exclude:
+          - python-version: '3.10'
+            cbor2-version: "<6.0.0"
+          - python-version: '3.11'
+            cbor2-version: "<6.0.0"
+          - python-version: '3.12'
+            cbor2-version: "<6.0.0"
+          - python-version: '3.13'
+            cbor2-version: "<6.0.0"
+    name: Merge tests 2 - Python (${{ matrix.python-version }}) functional tests (Ubuntu) with cbor2 ${{ matrix.cbor2-version != '' && matrix.cbor2-version || 'latest' }}
     steps:
     - name: Checkout the code
       uses: actions/checkout@v5
@@ -123,6 +133,10 @@ jobs:
       uses: ./.github/actions/install_zcbor
       with:
         zcbor_package: 'setup_install'
+
+    - name: Install cbor2
+      if: ${{ matrix.cbor2-version != '' }}
+      run: pip install "cbor2${{ matrix.cbor2-version }}"
 
     - name: Run python tests
       working-directory: tests/scripts

--- a/__init__.py
+++ b/__init__.py
@@ -15,5 +15,6 @@ from .zcbor.zcbor import (
     CodeGenerator,
     CodeRenderer,
     format_parsing_error,
+    zfrozendict,
     main,
 )

--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -1,3 +1,3 @@
-cbor2>=5.4.2.post1,<6.0.0
+cbor2>=5.4.2.post1
 pyyaml>=5.4.1
 regex>=2022.3.15

--- a/tests/scripts/test_zcbor.py
+++ b/tests/scripts/test_zcbor.py
@@ -275,6 +275,26 @@ def loads(string):
     return cbor2.loads(string)
 
 
+def make_mutable(obj):
+    """Convert cbor2 6.x immutable types to mutable equivalents.
+
+    cbor2 6.x returns frozendict and tuple for maps and arrays inside tagged
+    structures. This wrapper converts them back to dict and list so the decoded
+    objects can be mutated (needed by tests that modify and re-encode CBOR).
+    """
+    if isinstance(obj, cbor2.CBORTag):
+        return cbor2.CBORTag(obj.tag, make_mutable(obj.value))
+    elif isinstance(obj, (dict, zcbor.zfrozendict)):
+        return {k: make_mutable(v) for k, v in obj.items()}
+    elif isinstance(obj, (list, tuple)):
+        return [make_mutable(v) for v in obj]
+    return obj
+
+
+def mutable_loads(string):
+    return make_mutable(loads(string))
+
+
 class TestEx0Manifest14(TestManifest):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -457,7 +477,7 @@ class TestEx1Manifest14(TestManifest):
 
     def test_cbor_pen(self):
         data = bytes.fromhex(p_test_vectors14[1].read_text(encoding="utf-8").replace("\n", ""))
-        struct = loads(data)
+        struct = mutable_loads(data)
         struct2 = loads(struct.value[3])  # manifest
         struct3 = loads(struct2[3])  # common sequence
         struct4 = loads(struct3[4])  # override params
@@ -474,10 +494,9 @@ class TestEx1Manifest14(TestManifest):
 class TestEx1InvManifest14(TestManifest):
     def test_inv0(self):
         data = bytes.fromhex(p_test_vectors14[1].read_text(encoding="utf-8").replace("\n", ""))
-        struct = loads(data)
+        struct = mutable_loads(data)
         struct2 = loads(struct.value[2])  # authentication
-        struct3 = loads(struct2[1])
-        struct3.tag = 99999  # invalid tag for COSE_Sign1
+        struct3 = cbor2.CBORTag(99999, loads(struct2[1]).value)  # invalid tag for COSE_Sign1
         struct2[1] = dumps(struct3)
         struct.value[2] = dumps(struct2)
         data = dumps(struct)
@@ -490,7 +509,7 @@ class TestEx1InvManifest14(TestManifest):
 
     def test_inv1(self):
         data = bytes.fromhex(p_test_vectors14[1].read_text(encoding="utf-8").replace("\n", ""))
-        struct = loads(data)
+        struct = mutable_loads(data)
         struct2 = loads(struct.value[3])  # manifest
         struct2[1] += 1  # invalid manifest version
         struct.value[3] = dumps(struct2)
@@ -504,7 +523,7 @@ class TestEx1InvManifest14(TestManifest):
 
     def test_inv2(self):
         data = bytes.fromhex(p_test_vectors14[1].read_text(encoding="utf-8").replace("\n", ""))
-        struct = loads(data)
+        struct = mutable_loads(data)
         struct.value[23] = b""  # Invalid integrated payload key
         data = dumps(struct)
         try:
@@ -518,7 +537,7 @@ class TestEx1InvManifest14(TestManifest):
 
     def test_inv3(self):
         data = bytes.fromhex(p_test_vectors14[1].read_text(encoding="utf-8").replace("\n", ""))
-        struct = loads(data)
+        struct = mutable_loads(data)
         struct2 = loads(struct.value[3])  # manifest
         struct3 = loads(struct2[3])  # common sequence
         struct4 = loads(struct3[4])  # override params
@@ -664,7 +683,7 @@ class TestEx5Manifest14(TestManifest):
 class TestEx5InvManifest14(TestManifest):
     def test_invalid_rep_policy(self):
         data = bytes.fromhex(p_test_vectors14[5].read_text(encoding="utf-8").replace("\n", ""))
-        struct = loads(data)
+        struct = mutable_loads(data)
         struct2 = loads(struct.value[3])  # manifest
         struct3 = loads(struct2[10])  # suit_validate
         struct3[3] += 16  # invalid Rep_Policy

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -20,7 +20,7 @@ from cbor2 import (
     dumps,
     CBORTag,
     CBORDecoder,
-    CBORDecodeValueError,
+    CBORDecodeError,
     CBORDecodeEOF,
     undefined,
 )
@@ -147,13 +147,13 @@ def counter(reset=False):
 def strict_load(f):
     """Strict variety of cbor2.load that ensures all data is consumed by a single CBOR element."""
     dec = CBORDecoder(f)
-    obj = dec.decode()  # Raises CBORDecodeEOF or CBORDecodeValueError on failure.
+    obj = dec.decode()  # Raises CBORDecodeEOF or CBORDecodeError on failure.
     try:
         dec.read(1)
     except CBORDecodeEOF:
         return obj
     else:
-        raise CBORDecodeValueError("Data not fully decoded.")
+        raise CBORDecodeError("Data not fully decoded.")
 
 
 def strict_loads(b):
@@ -2451,7 +2451,7 @@ CBOR-formatted bstr, all elements must be bstrs. If not, it is a programmer erro
         elif isinstance(obj, bytes):
             try:
                 bstr_obj = self._to_yaml_obj(strict_loads(obj))
-            except (CBORDecodeValueError, CBORDecodeEOF):
+            except CBORDecodeError:
                 bstr_obj = obj.hex()
             return {"zcbor_bstr": bstr_obj}
         elif isinstance(obj, CBORTag):

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -9,7 +9,7 @@ from regex import compile, S, M
 from pprint import pformat, pprint
 from os import path, linesep, makedirs
 from collections import defaultdict, namedtuple
-from collections.abc import Hashable
+from collections.abc import Hashable, Mapping
 from typing import NamedTuple
 from argparse import ArgumentParser, ArgumentTypeError, RawDescriptionHelpFormatter
 from datetime import datetime
@@ -24,6 +24,18 @@ from cbor2 import (
     CBORDecodeEOF,
     undefined,
 )
+import cbor2
+import builtins
+
+if hasattr(cbor2, "frozendict"):
+    from cbor2 import frozendict as zfrozendict
+elif hasattr(cbor2, "FrozenDict"):
+    from cbor2 import FrozenDict as zfrozendict
+elif hasattr(builtins, "frozendict"):
+    from builtins import frozendict as zfrozendict
+else:
+    assert False, "Couldn't find a frozendict implementation."
+
 from yaml import safe_load as yaml_load, dump as yaml_dump
 from json import loads as json_load, dumps as json_dump
 from io import BytesIO
@@ -2075,10 +2087,22 @@ class DataTranslator(CddlXcoder):
         "BSTR": (bytes,),
         "NIL": (type(None),),
         "UNDEF": (type(undefined),),
-        "ANY": (int, float, str, bytes, type(None), type(undefined), bool, list, dict),
+        "ANY": (
+            int,
+            float,
+            str,
+            bytes,
+            type(None),
+            type(undefined),
+            bool,
+            list,
+            tuple,
+            dict,
+            zfrozendict,
+        ),
         "BOOL": (bool,),
         "LIST": (tuple, list),
-        "MAP": (dict,),
+        "MAP": (dict, zfrozendict),
     }
 
     def _expected_type(self):
@@ -2090,7 +2114,7 @@ class DataTranslator(CddlXcoder):
         if self.type not in ["OTHER", "GROUP", "UNION"]:
             exp_type = self._expected_type()
             self._decode_assert(
-                type(obj) in exp_type,
+                isinstance(obj, exp_type),
                 lambda: f"{str(self)}: Wrong type ({type(obj)}) of {str(obj)}, expected {str(exp_type)}",
             )
 
@@ -2435,7 +2459,7 @@ CBOR-formatted bstr, all elements must be bstrs. If not, it is a programmer erro
         """inverse of _from_yaml_obj"""
         if isinstance(obj, list) or isinstance(obj, tuple):
             return [self._to_yaml_obj(elem) for elem in obj]
-        elif isinstance(obj, dict):
+        elif isinstance(obj, (dict, zfrozendict)):
             retval = dict()
             i = 0
             for key, val in obj.items():
@@ -2489,7 +2513,13 @@ CBOR-formatted bstr, all elements must be bstrs. If not, it is a programmer erro
         """CBOR object => JSON str"""
         self.validate_obj(obj)
         json_obj = self._to_yaml_obj(obj) if yaml_compat else obj
-        return json_dump(json_obj)
+
+        def zfrozendict_to_dict(obj):
+            if isinstance(obj, zfrozendict):
+                return dict(obj)
+            raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
+
+        return json_dump(json_obj, default=zfrozendict_to_dict)
 
     def str_to_json(self, cbor_str, yaml_compat=False):
         """CBOR bytestring => JSON str"""


### PR DESCRIPTION
CBORDecodeValueError was dropped in 6.0 version. Use CBORDecodeError,
which was a parent class and still exists in 6.0 version. This makes
this change backwards compatible.

Replace 'except (CBORDecodeValueError, CBORDecodeEOF)' with
'except (CBORDecodeError)', as CBORDecodeError is a parent class for
CBORDecodeEOF, so it is catched as well.