### PR TITLE
feat: Add custom float precision support for YAML conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ The following data types are supported by CBOR, but not by YAML (or JSON which i
  2. map keys other than text string: In YAML, such key value pairs are represented as `{"zcbor_keyval<unique int>": {"key": <key, not text>, "val": <value>}}`.
  3. tags: In cbor2, tags are represented by a special type, `cbor2.CBORTag`. In YAML, these are represented as `{"zcbor_tag": <tag number>, "zcbor_tag_val": <tagged data>}`.
  4. undefined: In cbor2, undefined has its own value `cbor2.types.undefined`. In YAML, undefined is represented as: `["zcbor_undefined"]`.
+ 5. floats: In cbor2, floats are always encoded as float64, unless the value can be losslessly represented as float16 or float32. In YAML, a specific float precision can be forced by using `{"zcbor_float16": <value>}`, `{"zcbor_float32": <value>}`, or `{"zcbor_float64": <value>}`.
 
 You can see an example of the conversions in [tests/cases/yaml_compatibility.yaml](tests/cases/yaml_compatibility.yaml) and its CDDL file [tests/cases/yaml_compatibility.cddl](tests/cases/yaml_compatibility.cddl).
 

--- a/tests/cases/yaml_float_compatibility.cddl
+++ b/tests/cases/yaml_float_compatibility.cddl
@@ -1,0 +1,7 @@
+; Test 2: Floating point types
+float_types_t = [
+    small_float: float16,        ; 16-bit float -> 3 bytes CBOR (0xf9 + 2)
+    mediun_float: float32,       ; 32-bit float -> 5 bytes CBOR (0xfa + 4)
+    large_float: float64,        ; 64-bit float -> 9 bytes CBOR (0xfb + 8)
+    undef_float: float,          
+]   

--- a/tests/cases/yaml_float_compatibility.yaml
+++ b/tests/cases/yaml_float_compatibility.yaml
@@ -1,0 +1,5 @@
+# float_types_t = [small_float: float16, medium_float: float32, large_float: float64]
+- zcbor_float16: 3.14                # small_float (π approximation)
+- zcbor_float32: 2.71828             # medium_float (e approximation)
+- zcbor_float64: 3.141592653589793   # large_float (π full precision)
+- 2.71                               # undef_float (e approximation, YAML native)

--- a/tests/scripts/test_zcbor.py
+++ b/tests/scripts/test_zcbor.py
@@ -50,6 +50,8 @@ p_map_bstr_cddl = Path(p_cases, "map_bstr.cddl")
 p_map_bstr_yaml = Path(p_cases, "map_bstr.yaml")
 p_yaml_compat_cddl = Path(p_cases, "yaml_compatibility.cddl")
 p_yaml_compat_yaml = Path(p_cases, "yaml_compatibility.yaml")
+p_yaml_float_compat_cddl = Path(p_cases, "yaml_float_compatibility.cddl")
+p_yaml_float_compat_yaml = Path(p_cases, "yaml_float_compatibility.yaml")
 p_pet_cddl = Path(p_cases, "pet.cddl")
 p_README = Path(p_root, "README.md")
 p_prelude = Path(p_root, "zcbor", "prelude.cddl")
@@ -1231,6 +1233,122 @@ class TestYamlCompatibility(PopenTest):
             stdout1,
         )
         self.assertEqual(safe_load(stdout2), safe_load(p_yaml_compat_yaml.read_text(encoding="utf-8")))
+
+
+class TestYamlFloatCompatibility(PopenTest):
+    def test_yaml_float_compatibility(self):
+        # Validate without --yaml-compatibility must fail.
+        self.popen_test(
+            [
+                "zcbor",
+                "validate",
+                "-c",
+                p_yaml_float_compat_cddl,
+                "-i",
+                p_yaml_float_compat_yaml,
+                "-t",
+                "float_types_t",
+            ],
+            exp_retcode=1,
+        )
+        # Validate with --yaml-compatibility must succeed.
+        self.popen_test(
+            [
+                "zcbor",
+                "validate",
+                "-c",
+                p_yaml_float_compat_cddl,
+                "-i",
+                p_yaml_float_compat_yaml,
+                "-t",
+                "float_types_t",
+                "--yaml-compatibility",
+            ]
+        )
+        # Convert YAML->CBOR->YAML roundtrip.
+        stdout1, _ = self.popen_test(
+            [
+                "zcbor",
+                "convert",
+                "-c",
+                p_yaml_float_compat_cddl,
+                "-i",
+                p_yaml_float_compat_yaml,
+                "-o",
+                "-",
+                "-t",
+                "float_types_t",
+                "--yaml-compatibility",
+            ]
+        )
+        stdout2, _ = self.popen_test(
+            [
+                "zcbor",
+                "convert",
+                "-c",
+                p_yaml_float_compat_cddl,
+                "-i",
+                "-",
+                "-o",
+                "-",
+                "--output-as",
+                "yaml",
+                "-t",
+                "float_types_t",
+                "--yaml-compatibility",
+            ],
+            stdout1,
+        )
+        # cbor2.loads() converts each float value in CBOR to a Python float value, which is a double-precision float.
+        # The precision specified in the CDDL and contained in the CBOR hex string
+        # as float16 (0xf9), float32 (0xfa), or float64 (0xfb) is not preserved during conversion.
+        result = safe_load(stdout2)
+        original = safe_load(p_yaml_float_compat_yaml.read_text(encoding="utf-8"))
+        # Extract the float values from the original YAML for comparison.
+        expected_values = []
+        for d in original:
+            if isinstance(d, dict):
+                value = next(iter(d.values()))  # {zcbor_float16: 1.0} -> 1.0
+            else:
+                value = d  # plain floats
+            expected_values.append(value)
+        # check if the number of floats is the same
+        self.assertEqual(len(expected_values), len(result))
+        # check if the float values are approximately equal (considering precision loss)
+        for expected_val, result_val in zip(expected_values, result):
+            self.assertAlmostEqual(expected_val, result_val, places=2)
+
+
+class TestFloatYamlCompat(TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        try:
+            self.cddl_res = zcbor.DataTranslator.from_cddl(
+                cddl_string=p_prelude.read_text(encoding="utf-8")
+                + "\n"
+                + p_yaml_float_compat_cddl.read_text(encoding="utf-8"),
+                default_max_qty=16,
+            )
+        except zcbor.CddlParsingError as e:
+            print(zcbor.format_parsing_error(e))
+            raise
+
+    # CBOR bytes must contain correct precision markers (0xf9, 0xfa, 0xfb).
+    def test_float_conversion(self):
+        cddl = self.cddl_res.my_types["float_types_t"]
+        test_yaml = (
+            "[{zcbor_float16: 1.0}, {zcbor_float32: 1.0}, {zcbor_float64: 1.0}, {zcbor_float32: 1.0}]"
+        )
+
+        cbor_bytes = cddl.from_yaml(test_yaml, yaml_compat=True)
+        # float16 marker
+        self.assertIn(b"\xf9", cbor_bytes)
+        # float32 marker
+        self.assertIn(b"\xfa", cbor_bytes)
+        # float64 marker
+        self.assertIn(b"\xfb", cbor_bytes)
+        # undefined float in cddl, should be encoded as float32 ad defined in YAML
+        self.assertIn(b"\xfa", cbor_bytes)
 
 
 class TestIntmax(CornerCaseTest):

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -34,6 +34,7 @@ import sys
 from textwrap import wrap, indent
 from codecs import decode as codec_decode
 from math import prod
+import struct
 
 regex_cache = {}
 indentation = "\t"
@@ -73,6 +74,68 @@ defaults = {
 UINT_MAX = {8: UINT8_MAX, 16: UINT16_MAX, 32: UINT32_MAX, 64: UINT64_MAX}
 INT_MIN = {8: INT8_MIN, 16: INT16_MIN, 32: INT32_MIN, 64: INT64_MIN}
 INT_MAX = {8: INT8_MAX, 16: INT16_MAX, 32: INT32_MAX, 64: INT64_MAX}
+
+
+# ============================================================================
+# Custom Float Precision Support for YAML Conversion
+# ============================================================================
+# These classes allow YAML files to specify float16/float32 precision using
+# zcbor_float16 and zcbor_float32 tags, overriding cbor2's default float64.
+class Float16:
+    """Wrapper for float16 (half precision) CBOR encoding (0xf9 + 2 bytes)"""
+
+    def __init__(self, value):
+        self.value = float(value)
+
+    def __repr__(self):
+        return f"Float16({self.value})"
+
+
+class Float32:
+    """Wrapper for float32 (single precision) CBOR encoding (0xfa + 4 bytes)"""
+
+    def __init__(self, value):
+        self.value = float(value)
+
+    def __repr__(self):
+        return f"Float32({self.value})"
+
+
+class Float64:
+    """Wrapper for float64 (double precision) CBOR encoding (0xfb + 8 bytes)"""
+
+    def __init__(self, value):
+        self.value = float(value)
+
+    def __repr__(self):
+        return f"Float64({self.value})"
+
+
+def _custom_float_encoder(encoder, value):
+    """
+    Custom CBOR encoder for Float16/Float32/Float64 wrappers.
+
+    Without this, cbor2.dumps() auto-optimizes floats (e.g., 0.5 becomes float16).
+    This encoder intercepts Float16/Float32/Float64 objects and encodes them
+    with the correct CBOR type markers (0xf9/0xfa/0xfb).
+    """
+    if isinstance(value, Float16):
+        # Encode as float16: 0xf9 + 2 bytes
+        f16_bytes = struct.pack(">e", value.value)
+        encoder.write(b"\xf9" + f16_bytes)
+    elif isinstance(value, Float32):
+        # Encode as float32: 0xfa + 4 bytes
+        f32_bytes = struct.pack(">f", value.value)
+        encoder.write(b"\xfa" + f32_bytes)
+    elif isinstance(value, Float64):
+        # Encode as float64: 0xfb + 8 bytes
+        f64_bytes = struct.pack(">d", value.value)
+        encoder.write(b"\xfb" + f64_bytes)
+    else:
+        raise TypeError(f"Cannot encode type {type(value)}: {value}")
+
+
+# ============================================================================
 
 
 class CddlParsingError(Exception):
@@ -2070,7 +2133,7 @@ class DataTranslator(CddlXcoder):
         "UINT": (int,),
         "INT": (int,),
         "NINT": (int,),
-        "FLOAT": (float,),
+        "FLOAT": (float, Float16, Float32, Float64),
         "TSTR": (str,),
         "BSTR": (bytes,),
         "NIL": (type(None),),
@@ -2089,6 +2152,7 @@ class DataTranslator(CddlXcoder):
         """Check that the decoded object has the correct type."""
         if self.type not in ["OTHER", "GROUP", "UNION"]:
             exp_type = self._expected_type()
+
             self._decode_assert(
                 type(obj) in exp_type,
                 lambda: f"{str(self)}: Wrong type ({type(obj)}) of {str(obj)}, expected {str(exp_type)}",
@@ -2418,6 +2482,14 @@ CBOR-formatted bstr, all elements must be bstrs. If not, it is a programmer erro
                 return bstr
             elif ["zcbor_tag", "zcbor_tag_val"] == list(obj.keys()):
                 return CBORTag(obj["zcbor_tag"], self._from_yaml_obj(obj["zcbor_tag_val"], can))
+            # ============ Float Precision Support ============
+            elif ["zcbor_float16"] == list(obj.keys()):
+                return Float16(float(obj["zcbor_float16"]))
+            elif ["zcbor_float32"] == list(obj.keys()):
+                return Float32(float(obj["zcbor_float32"]))
+            elif ["zcbor_float64"] == list(obj.keys()):
+                return Float64(float(obj["zcbor_float64"]))
+            # =================================================
             retval = dict()
             for key, val in obj.items():
                 if isinstance(key, str) and getrp(r"zcbor_keyval\d+").fullmatch(key) is not None:
@@ -2466,7 +2538,7 @@ CBOR-formatted bstr, all elements must be bstrs. If not, it is a programmer erro
         yaml_obj = yaml_load(yaml_str)
         obj = self._from_yaml_obj(yaml_obj, canonical) if yaml_compat else yaml_obj
         self.validate_obj(obj)
-        return dumps(obj, canonical=canonical)
+        return dumps(obj, canonical=canonical, default=_custom_float_encoder)
 
     def obj_to_yaml(self, obj, yaml_compat=False):
         """CBOR object => YAML str"""
@@ -2483,7 +2555,7 @@ CBOR-formatted bstr, all elements must be bstrs. If not, it is a programmer erro
         json_obj = json_load(json_str)
         obj = self._from_yaml_obj(json_obj, canonical) if yaml_compat else json_obj
         self.validate_obj(obj)
-        return dumps(obj, canonical=canonical)
+        return dumps(obj, canonical=canonical, default=_custom_float_encoder)
 
     def obj_to_json(self, obj, yaml_compat=False):
         """CBOR object => JSON str"""


### PR DESCRIPTION
## Problem:
YAML has no native way to express float precision. CBOR distinguishes between `float16` (0xf9, 3 bytes), `float32` (0xfa, 5 bytes), and `float64` (0xfb, 9 bytes), but `cbor2` always encodes Python floats as float64 or auto-optimizes to the smallest representation. When a CDDL schema specifies `float16` or `float32`, there was no way to control the encoded precision from YAML input, see Issue #575 . 

## Solution: 
Extends zcbor's existing `--yaml-compatibility` mechanism (already used for `zcbor_bstr`, `zcbor_tag`, `zcbor_undefined`) with three new YAML dict wrappers:

```yaml
- zcbor_float16: 3.14       # → CBOR float16 (0xf9 + 2 bytes)
- zcbor_float32: 2.71828     # → CBOR float32 (0xfa + 4 bytes)
- zcbor_float64: 3.14159     # → CBOR float64 (0xfb + 8 bytes)
```
`zcbor_float64` is needed to explicitly force float64 encoding, since `cbor2` may auto-optimize values down to float16 even when the CDDL schema requires float64.

## Changes:

* add:  `Float16`, `Float32`, `Float64` wrapper classes  and  `_custom_float_encoder()` to zcbor.py 
* add:  `yaml_float_compatibility.cddl` CDDL schema and `yaml_float_compatibility.yaml` file to `tests/cases`
* add: pytest  `TestYamlFloatCompatibility` and `TestFloatYamlCompat`

Signed-off-by: Elobit <dev.info@elobit.net>