### PR TITLE
black.sh: Add --fast and -v

### DIFF
--- a/scripts/black.sh
+++ b/scripts/black.sh
@@ -1,1 +1,1 @@
-black $(dirname "$0")/.. -l 105
+black $(dirname "$0")/.. -l 105 --fast -v


### PR DESCRIPTION
To avoid the warning that "Python 3.14 cannot parse code formatted for Python 3.15", and -v to show what black infers from pyproject.toml.