### PR TITLE
zcbor_decode.c: Fix bug in zcbor_any_skip()

### DIFF
--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -1703,7 +1703,7 @@ bool zcbor_any_skip(zcbor_state_t *state, void *result)
 		case ZCBOR_MAJOR_TYPE_BSTR:
 		case ZCBOR_MAJOR_TYPE_TSTR:
 			/* 'value' is the length of the BSTR or TSTR. */
-			ZCBOR_FAIL_IF(!str_overflow_check(state, (size_t)value));
+			ZCBOR_FAIL_IF(!str_overflow_check(&state_copy, (size_t)value));
 			(state_copy.payload) += value;
 			break;
 		case ZCBOR_MAJOR_TYPE_MAP:

--- a/tests/unit/test1_unit_tests/src/main.c
+++ b/tests/unit/test1_unit_tests/src/main.c
@@ -1572,6 +1572,17 @@ ZTEST(zcbor_unit_tests, test_any_skip)
 }
 
 
+ZTEST(zcbor_unit_tests, test_any_skip_str_overflow)
+{
+	uint8_t payload[] = {0xd9, 0x12, 0x34, 0x45, 'h', 'e', 'l', 'l'}; // Indicates a string of length 5, but only 4 bytes of data.
+	ZCBOR_STATE_D(state_d, 0, payload, sizeof(payload), 1, 0);
+
+	bool ret = zcbor_any_skip(state_d, NULL);
+	zassert_false(ret, "err: %d\n", zcbor_peek_error(state_d));
+	zassert_equal(ZCBOR_ERR_NO_PAYLOAD, zcbor_peek_error(state_d), NULL);
+}
+
+
 ZTEST(zcbor_unit_tests, test_pexpect)
 {
 	uint8_t payload[100];


### PR DESCRIPTION
where it doesn't catch a string overflow if the payload is shorter than indicated in the string header.

Fixes #584