### PR TITLE
zcbor.py: Fix a small bug in union_type() 

### DIFF
--- a/tests/cases/corner_cases.cddl
+++ b/tests/cases/corner_cases.cddl
@@ -476,3 +476,4 @@ UnionDefault = [
 ]
 
 OptUnion = [foo: ?((FooA: 1) / (FooB: 2) / (FooC: Three))]
+CountUnion = (+1) / nil

--- a/tests/decode/test5_corner_cases/CMakeLists.txt
+++ b/tests/decode/test5_corner_cases/CMakeLists.txt
@@ -75,6 +75,7 @@ set(py_command
     AmbigList
     UnionDefault
     OptUnion
+    CountUnion
   --decode
   --git-sha-header
   --short-names

--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -2796,4 +2796,25 @@ ZTEST(cbor_decode_test5, test_opt_union)
 }
 
 
+ZTEST(cbor_decode_test5, test_count_union)
+{
+	uint8_t count_union_payload1[] = {0xf6};
+	uint8_t count_union_payload2[] = {1, 1};
+
+	struct CountUnion_r result;
+	size_t num_decode;
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_CountUnion(count_union_payload1,
+		sizeof(count_union_payload1), &result, &num_decode), NULL);
+	zassert_equal(sizeof(count_union_payload1), num_decode, NULL);
+	zassert_equal(CountUnion_nil_c, result.CountUnion_choice, NULL);
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_CountUnion(count_union_payload2,
+		sizeof(count_union_payload2), &result, &num_decode), NULL);
+	zassert_equal(sizeof(count_union_payload2), num_decode, NULL);
+	zassert_equal(CountUnion_uint1_c, result.CountUnion_choice, NULL);
+	zassert_equal(2, result.uint1_count, NULL);
+}
+
+
 ZTEST_SUITE(cbor_decode_test5, NULL, NULL, NULL, NULL, NULL);

--- a/tests/encode/test3_corner_cases/CMakeLists.txt
+++ b/tests/encode/test3_corner_cases/CMakeLists.txt
@@ -63,6 +63,7 @@ set(py_command
   Choice5
   OptList
   UnionDefault
+  CountUnion
   -e
   ${bit_arg}
   --short-names

--- a/tests/encode/test3_corner_cases/src/main.c
+++ b/tests/encode/test3_corner_cases/src/main.c
@@ -1975,5 +1975,25 @@ ZTEST(cbor_encode_test3, test_union_default)
 }
 
 
+ZTEST(cbor_encode_test3, test_count_union)
+{
+	uint8_t count_union_exp_payload1[] = {0xf6};
+	uint8_t count_union_exp_payload2[] = {1, 1};
+
+	struct CountUnion_r input;
+	uint8_t payload[6];
+
+	input.CountUnion_choice = CountUnion_nil_c;
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_CountUnion(payload,
+		sizeof(payload), &input, NULL));
+	zassert_mem_equal(payload, count_union_exp_payload1, sizeof(count_union_exp_payload1));
+
+	input.CountUnion_choice = CountUnion_uint1_c;
+	input.uint1_count = 2;
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_CountUnion(payload,
+		sizeof(payload), &input, NULL));
+	zassert_mem_equal(payload, count_union_exp_payload2, sizeof(count_union_exp_payload2));
+}
+
 
 ZTEST_SUITE(cbor_encode_test3, NULL, NULL, NULL, NULL, NULL);

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -2867,7 +2867,7 @@ class CodeGenerator(CddlXcoder):
         """Type declaration for unions."""
         cdecl = list()
         for child in self.value:
-            if not child.is_unambiguous_repeated():
+            if not child.is_unambiguous():
                 cdecl.extend(child.construct_declaration(child.single_var_type(), anonymous=True))
         return self.enclose("union", cdecl)
 

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -2716,14 +2716,6 @@ class CodeGenerator(CddlXcoder):
         decl = [line for child in self.value for line in child.full_declaration()]
         return decl
 
-    def child_single_declarations(self):
-        """Declaration of the variables of all children."""
-        decl = list()
-        for child in self.value:
-            if not child.is_unambiguous_repeated():
-                decl.extend(child.single_declaration())
-        return decl
-
     def simple_func_condition(self):
         if self.range_check_condition():
             return True
@@ -2873,11 +2865,11 @@ class CodeGenerator(CddlXcoder):
 
     def union_type(self):
         """Type declaration for unions."""
-        declaration = self.enclose("union", self.child_single_declarations())
-        return declaration
-
-    def single_declaration(self):
-        return self.construct_declaration(self.single_var_type(), anonymous=True)
+        cdecl = list()
+        for child in self.value:
+            if not child.is_unambiguous_repeated():
+                cdecl.extend(child.construct_declaration(child.single_var_type(), anonymous=True))
+        return self.enclose("union", cdecl)
 
     def repeated_declaration(self):
         """Declaration of the repeated part of this element."""


### PR DESCRIPTION
where _count variable could be missing if the element is unambiguous
otherwise.