### PR TITLE
zcbor.py: Fix a naming bug where some CDDL would always fail

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -38,6 +38,9 @@
     Example: `foo = +(+bar)`
     With default-max-qty of 3, the above would previously have a max count of 9, but is now 3.
 
+  * The naming logic has been somewhat refactored. Regenerate if needed.
+    E.g. the application of '_r' to type names has been changed.
+
 
 # zcbor v. 0.9.0
 

--- a/include/zcbor_print.h
+++ b/include/zcbor_print.h
@@ -27,7 +27,7 @@ extern "C" {
 #define zcbor_trace_raw(state) do { \
 	if (state != NULL) { \
 		zcbor_do_print("rem: %zu, cur: 0x%x, ec: 0x%zx, err: %d",\
-			(size_t)state->payload_end - (size_t)state->payload, *state->payload, state->elem_count, \
+			(size_t)state->payload_end - (size_t)state->payload, (state->payload ? *state->payload : 0), state->elem_count, \
 			state->constant_state ? state->constant_state->error : 0); \
 	} \
 } while(0)

--- a/tests/cases/corner_cases.cddl
+++ b/tests/cases/corner_cases.cddl
@@ -488,6 +488,14 @@ map2 = {"2": int}
 
 TwoMaps = [ ?map1, map2 ]
 
+InnerPair = (left: int, right: int)
+InnerPairOpt = ?(left: int, right: int)
+WrapListGroup = [InnerPair]
+WrapListGroupOpt1 = [inner1: ?InnerPair]
+WrapListGroupOpt2 = [inner2: InnerPairOpt]
+WrapListGroupOptMult = ?[*(inner: InnerPair)]
+OptCbor = [?(cbor: bstr .cbor int)]
+
 ; Optional float with range: decode must restore state when range check fails.
 OptFloatThenInt = [
 	?optfloat: float .ge 1.0 .le 10.0,

--- a/tests/decode/test5_corner_cases/CMakeLists.txt
+++ b/tests/decode/test5_corner_cases/CMakeLists.txt
@@ -78,6 +78,11 @@ set(py_command
     CountUnion
     Tags
     TwoMaps
+    WrapListGroup
+    WrapListGroupOpt1
+    WrapListGroupOpt2
+    WrapListGroupOptMult
+    OptCbor
     OptFloatUnion
     OptFloatThenInt
   --decode

--- a/tests/decode/test5_corner_cases/src/main.c
+++ b/tests/decode/test5_corner_cases/src/main.c
@@ -243,7 +243,7 @@ ZTEST(cbor_decode_test5, test_tagged_union)
 	const uint8_t payload_tagged_union2[] = {0xD9, 0x09, 0x29, 0x10};
 	const uint8_t payload_tagged_union3_inv[] = {0xD9, 0x10, 0xE1, 0x10};
 
-	struct TaggedUnion_r result;
+	struct TaggedUnion result;
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_TaggedUnion(payload_tagged_union1,
 		sizeof(payload_tagged_union1), &result, &decode_len));
@@ -684,7 +684,7 @@ ZTEST(cbor_decode_test5, test_union)
 		0x03, 0x23, 0x03, 0x23, 0x03, 0x23}; /* Too many */
 	size_t decode_len;
 
-	struct Union_r union_r;
+	struct Union union_r;
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_Union(payload_union1, sizeof(payload_union1),
 				&union_r, NULL), NULL);
 	zassert_equal(Union_Group_m_c, union_r.Union_choice, NULL);
@@ -2512,11 +2512,11 @@ ZTEST(cbor_decode_test5, test_nested_choices)
 			0xf6,
 		END
 	};
-	struct Choice1_r result1;
-	struct Choice2_r result2;
-	struct Choice3_r result3;
-	struct Choice4_r result4;
-	struct Choice5_r result5;
+	struct Choice1 result1;
+	struct Choice2 result2;
+	struct Choice3 result3;
+	struct Choice4 result4;
+	struct Choice5 result5;
 
 	size_t num_decode;
 
@@ -2801,7 +2801,7 @@ ZTEST(cbor_decode_test5, test_count_union)
 	uint8_t count_union_payload1[] = {0xf6};
 	uint8_t count_union_payload2[] = {1, 1};
 
-	struct CountUnion_r result;
+	struct CountUnion result;
 	size_t num_decode;
 
 	zassert_equal(ZCBOR_SUCCESS, cbor_decode_CountUnion(count_union_payload1,
@@ -2995,6 +2995,83 @@ ZTEST(cbor_decode_test5, test_opt_float_union)
 	int res = cbor_decode_OptFloatUnion(invalid_float_payload,
 		sizeof(invalid_float_payload), &result, &num_decode);
 	zassert_equal(ARR_ERR1, res, "%s\n", zcbor_error_str(res));
+}
+
+
+ZTEST(cbor_decode_test5, test_wrap_list_group_opt)
+{
+	uint8_t present_payload[] = {LIST(2), 0x01, 0x02, END};
+	uint8_t absent_payload[] = {LIST(0), END};
+	struct WrapListGroupOpt1 result1;
+	struct InnerPairOpt result2;
+	size_t num_decode;
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_WrapListGroupOpt1(present_payload,
+		sizeof(present_payload), &result1, &num_decode), NULL);
+	zassert_equal(sizeof(present_payload), num_decode, NULL);
+	zassert_true(result1.inner1_present);
+	zassert_equal(1, result1.inner1.left, NULL);
+	zassert_equal(2, result1.inner1.right, NULL);
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_WrapListGroupOpt2(present_payload,
+		sizeof(present_payload), &result2, &num_decode), NULL);
+	zassert_equal(sizeof(present_payload), num_decode, NULL);
+	zassert_true(result2.InnerPairOpt_present);
+	zassert_equal(1, result2.InnerPairOpt.left, NULL);
+	zassert_equal(2, result2.InnerPairOpt.right, NULL);
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_WrapListGroupOpt1(absent_payload,
+		sizeof(absent_payload), &result1, &num_decode), NULL);
+	zassert_equal(sizeof(absent_payload), num_decode, NULL);
+	zassert_false(result1.inner1_present);
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_WrapListGroupOpt2(absent_payload,
+		sizeof(absent_payload), &result2, &num_decode), NULL);
+	zassert_equal(sizeof(absent_payload), num_decode, NULL);
+	zassert_false(result2.InnerPairOpt_present);
+}
+
+
+ZTEST(cbor_decode_test5, test_wrap_list_group_opt_mult)
+{
+	uint8_t present_payload[] = {LIST(4), 0x01, 0x02, 0x03, 0x04, END};
+	struct WrapListGroupOptMult result;
+	size_t num_decode;
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_WrapListGroupOptMult(present_payload,
+		sizeof(present_payload), &result, &num_decode), NULL);
+	zassert_equal(sizeof(present_payload), num_decode, NULL);
+	zassert_true(result.WrapListGroupOptMult_present);
+	zassert_equal(2, result.WrapListGroupOptMult.inner_count, NULL);
+	zassert_equal(1, result.WrapListGroupOptMult.inner[0].left, NULL);
+	zassert_equal(2, result.WrapListGroupOptMult.inner[0].right, NULL);
+	zassert_equal(3, result.WrapListGroupOptMult.inner[1].left, NULL);
+	zassert_equal(4, result.WrapListGroupOptMult.inner[1].right, NULL);
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_WrapListGroupOptMult(NULL,
+		0, &result, &num_decode), NULL);
+	zassert_equal(0, num_decode, NULL);
+	zassert_false(result.WrapListGroupOptMult_present);
+}
+
+
+ZTEST(cbor_decode_test5, test_opt_cbor)
+{
+	uint8_t present_payload[] = {LIST(1), 0x42, 0x18, 0x2A, END}; /* bstr containing int 42 */
+	uint8_t absent_payload[] = {LIST(0), END};
+	struct OptCbor result;
+	size_t num_decode;
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_OptCbor(present_payload,
+		sizeof(present_payload), &result, &num_decode), NULL);
+	zassert_equal(sizeof(present_payload), num_decode, NULL);
+	zassert_true(result.cbor_present);
+	zassert_equal(42, result.cbor.cbor_cbor, NULL);
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_decode_OptCbor(absent_payload,
+		sizeof(absent_payload), &result, &num_decode), NULL);
+	zassert_equal(sizeof(absent_payload), num_decode, NULL);
+	zassert_false(result.cbor_present);
 }
 
 

--- a/tests/decode/test9_manifest14/src/main.c
+++ b/tests/decode/test9_manifest14/src/main.c
@@ -78,8 +78,8 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_common_sequence)
 	struct SUIT_Manifest manifest;
 	struct SUIT_Common_Sequence common_sequence;
 	struct SUIT_Command_Sequence command_sequence;
-	struct SUIT_Parameters_r *parameter;
-	struct SUIT_Condition_r *condition;
+	struct SUIT_Parameters *parameter;
+	struct SUIT_Condition *condition;
 	size_t out_len;
 	uint8_t exp_vendor_id[] = {
 		0xfa, 0x6b, 0x4a, 0x53, 0xd5, 0xad, 0x5f, 0xdf,
@@ -194,8 +194,8 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_common_sequence_as_command_sequence)
 	struct SUIT_Manifest manifest;
 	struct SUIT_Common_Sequence common_sequence;
 	struct SUIT_Command_Sequence command_sequence;
-	struct SUIT_Parameters_r *parameter;
-	struct SUIT_Condition_r *condition;
+	struct SUIT_Parameters *parameter;
+	struct SUIT_Condition *condition;
 	size_t out_len;
 	uint8_t exp_vendor_id[] = {
 		0xfa, 0x6b, 0x4a, 0x53, 0xd5, 0xad, 0x5f, 0xdf,
@@ -309,8 +309,8 @@ ZTEST(cbor_decode_test9, test_suit14_ex0_validate_run)
 	struct SUIT_Envelope envelope;
 	struct SUIT_Manifest manifest;
 	struct SUIT_Command_Sequence command_sequence;
-	struct SUIT_Condition_r *condition;
-	struct SUIT_Directive_r *directive;
+	struct SUIT_Condition *condition;
+	struct SUIT_Directive *directive;
 	size_t out_len;
 	uint32_t exp_rep_policy1 = (
 		(1 << suit_reporting_bits_suit_send_record_success_c)

--- a/tests/encode/test1_suit/src/main.c
+++ b/tests/encode/test1_suit/src/main.c
@@ -264,7 +264,7 @@ void test_command_sequence(struct zcbor_string *sequence_str,
 		NULL);
 
 	for (uint32_t i = 0; i < sequence1.SUIT_Command_Sequence_union_count; i++) {
-		struct SUIT_Directive_r *directive;
+		struct SUIT_Directive *directive;
 		bool directive_present;
 		directive = &sequence1
 			.SUIT_Command_Sequence_union[i]

--- a/tests/encode/test3_corner_cases/CMakeLists.txt
+++ b/tests/encode/test3_corner_cases/CMakeLists.txt
@@ -65,6 +65,11 @@ set(py_command
   UnionDefault
   CountUnion
   Tags
+  WrapListGroup
+  WrapListGroupOpt1
+  WrapListGroupOpt2
+  WrapListGroupOptMult
+  OptCbor
   OptFloatUnion
   OptFloatThenInt
   -e

--- a/tests/encode/test3_corner_cases/src/main.c
+++ b/tests/encode/test3_corner_cases/src/main.c
@@ -117,7 +117,7 @@ ZTEST(cbor_encode_test3, test_tagged_union)
 
 	uint8_t output[5];
 
-	struct TaggedUnion_r input;
+	struct TaggedUnion input;
 	input.TaggedUnion_choice = TaggedUnion_t4321bool_c;
 	input.t4321bool = true;
 
@@ -507,12 +507,12 @@ ZTEST(cbor_encode_test3, test_union)
 		0x03, 0x23, 0x03, 0x23, 0x03, 0x23
 	};
 
-	struct Union_r union1 = {.Union_choice = Union_Group_m_c};
-	struct Union_r union2 = {.Union_choice = Union_MultiGroup_m_c, .MultiGroup_m.MultiGroup_count = 1};
-	struct Union_r union3 = {.Union_choice = Union_uint3_l_c};
-	struct Union_r union4 = {.Union_choice = Union_hello_tstr_c};
-	struct Union_r union5 = {.Union_choice = Union_MultiGroup_m_c, .MultiGroup_m.MultiGroup_count = 6};
-	struct Union_r union6_inv = {.Union_choice = Union_MultiGroup_m_c, .MultiGroup_m.MultiGroup_count = 7};
+	struct Union union1 = {.Union_choice = Union_Group_m_c};
+	struct Union union2 = {.Union_choice = Union_MultiGroup_m_c, .MultiGroup_m.MultiGroup_count = 1};
+	struct Union union3 = {.Union_choice = Union_uint3_l_c};
+	struct Union union4 = {.Union_choice = Union_hello_tstr_c};
+	struct Union union5 = {.Union_choice = Union_MultiGroup_m_c, .MultiGroup_m.MultiGroup_count = 6};
+	struct Union union6_inv = {.Union_choice = Union_MultiGroup_m_c, .MultiGroup_m.MultiGroup_count = 7};
 
 	uint8_t output[15];
 	size_t out_len;
@@ -1803,11 +1803,11 @@ ZTEST(cbor_encode_test3, test_nested_choices)
 			0xf6,
 		END
 	};
-	struct Choice1_r input1 = {.Choice1_choice = Choice1_nil_c};
-	struct Choice2_r input2 = {.Choice2_choice = Choice2_nil_c};
-	struct Choice3_r input3 = {.Choice3_choice = Choice3_nil_c};
-	struct Choice4_r input4 = {.Choice4_choice = Choice4_nil_c};
-	struct Choice5_r input5 = {.Choice5_choice = Choice5_nil_c};
+	struct Choice1 input1 = {.Choice1_choice = Choice1_nil_c};
+	struct Choice2 input2 = {.Choice2_choice = Choice2_nil_c};
+	struct Choice3 input3 = {.Choice3_choice = Choice3_nil_c};
+	struct Choice4 input4 = {.Choice4_choice = Choice4_nil_c};
+	struct Choice5 input5 = {.Choice5_choice = Choice5_nil_c};
 
 	uint8_t payload[50];
 
@@ -1980,7 +1980,7 @@ ZTEST(cbor_encode_test3, test_count_union)
 	uint8_t count_union_exp_payload1[] = {0xf6};
 	uint8_t count_union_exp_payload2[] = {1, 1};
 
-	struct CountUnion_r input;
+	struct CountUnion input;
 	uint8_t payload[6];
 
 	input.CountUnion_choice = CountUnion_nil_c;
@@ -2120,6 +2120,110 @@ ZTEST(cbor_encode_test3, test_opt_float_union)
 
 	zassert_equal(ZCBOR_ERR_WRONG_RANGE, cbor_encode_OptFloatUnion(output,
 		sizeof(output), &input3_inv, &out_len));
+}
+
+
+ZTEST(cbor_encode_test3, test_wrap_list_group)
+{
+	const uint8_t exp_payload[] = {LIST(2), 0x01, 0x02, END};
+	struct InnerPair input = {.left = 1, .right = 2};
+	uint8_t output[10];
+	size_t out_len;
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_WrapListGroup(output,
+		sizeof(output), &input, &out_len), NULL);
+	zassert_equal(sizeof(exp_payload), out_len, NULL);
+	zassert_mem_equal(exp_payload, output, out_len, NULL);
+}
+
+
+ZTEST(cbor_encode_test3, test_wrap_list_group_opt)
+{
+	const uint8_t exp_present[] = {LIST(2), 0x01, 0x02, END};
+	const uint8_t exp_absent[] = {LIST(0), END};
+	struct WrapListGroupOpt1 input1 = {
+		.inner1_present = true,
+		.inner1 = {.left = 1, .right = 2},
+	};
+	struct InnerPairOpt input2 = {
+		.InnerPairOpt_present = true,
+		.InnerPairOpt = {.left = 1, .right = 2},
+	};
+	uint8_t output[10];
+	size_t out_len;
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_WrapListGroupOpt1(output,
+		sizeof(output), &input1, &out_len), NULL);
+	zassert_equal(sizeof(exp_present), out_len, NULL);
+	zassert_mem_equal(exp_present, output, out_len, NULL);
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_WrapListGroupOpt2(output,
+		sizeof(output), &input2, &out_len), NULL);
+	zassert_equal(sizeof(exp_present), out_len, NULL);
+	zassert_mem_equal(exp_present, output, out_len, NULL);
+
+	input1.inner1_present = false;
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_WrapListGroupOpt1(output,
+		sizeof(output), &input1, &out_len), NULL);
+	zassert_equal(sizeof(exp_absent), out_len, NULL);
+	zassert_mem_equal(exp_absent, output, out_len, NULL);
+
+	input2.InnerPairOpt_present = false;
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_WrapListGroupOpt2(output,
+		sizeof(output), &input2, &out_len), NULL);
+	zassert_equal(sizeof(exp_absent), out_len, NULL);
+	zassert_mem_equal(exp_absent, output, out_len, NULL);
+}
+
+
+ZTEST(cbor_encode_test3, test_wrap_list_group_opt_mult)
+{
+	const uint8_t exp_present[] = {LIST(4), 0x01, 0x02, 0x03, 0x04, END};
+	struct WrapListGroupOptMult input = {
+		.WrapListGroupOptMult_present = true,
+		.WrapListGroupOptMult = {
+			.inner_count = 2,
+			.inner = {{.left = 1, .right = 2}, {.left = 3, .right = 4}},
+		},
+	};
+	uint8_t output[12];
+	size_t out_len;
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_WrapListGroupOptMult(output,
+		sizeof(output), &input, &out_len), NULL);
+	zassert_equal(sizeof(exp_present), out_len, NULL);
+	zassert_mem_equal(exp_present, output, out_len, NULL);
+
+	input.WrapListGroupOptMult_present = false;
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_WrapListGroupOptMult(output,
+		sizeof(output), &input, &out_len), NULL);
+	zassert_equal(0, out_len, NULL);
+}
+
+
+ZTEST(cbor_encode_test3, test_opt_cbor)
+{
+	const uint8_t exp_present[] = {LIST(1), 0x42, 0x18, 0x2A, END};
+	const uint8_t exp_absent[] = {LIST(0), END};
+	struct OptCbor input = {
+		.cbor_present = true,
+		.cbor = {
+			.cbor_cbor = 42,
+		},
+	};
+	uint8_t output[10];
+	size_t out_len;
+
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_OptCbor(output,
+		sizeof(output), &input, &out_len), NULL);
+	zassert_equal(sizeof(exp_present), out_len, NULL);
+	zassert_mem_equal(exp_present, output, out_len, NULL);
+
+	input.cbor_present = false;
+	zassert_equal(ZCBOR_SUCCESS, cbor_encode_OptCbor(output,
+		sizeof(output), &input, &out_len), NULL);
+	zassert_equal(sizeof(exp_absent), out_len, NULL);
+	zassert_mem_equal(exp_absent, output, out_len, NULL);
 }
 
 

--- a/tests/fuzz/fuzz_everything.c
+++ b/tests/fuzz/fuzz_everything.c
@@ -4,7 +4,7 @@
 bool fuzz_one_input(const uint8_t *data, size_t size)
 {
     size_t payload_len_out = 0;
-    struct EverythingUnion_r result;
+    struct EverythingUnion result;
     bool ret = cbor_decode_EverythingUnion(data, size,
                                &result,
                                &payload_len_out);

--- a/zcbor/zcbor.py
+++ b/zcbor/zcbor.py
@@ -2658,10 +2658,10 @@ class CodeGenerator(CddlXcoder):
 
     def raw_type_name(self):
         """Base name if this element needs to declare a type."""
-        return "struct %s" % self.id()
+        return "struct %s" % self.var_func_name(with_prefix=True)
 
     def enum_type_name(self):
-        return "enum %s" % self.id()
+        return "enum %s" % self.var_func_name(with_prefix=True)
 
     def bit_size(self):
         """The bit width of the integers as represented in code."""
@@ -2748,13 +2748,11 @@ class CodeGenerator(CddlXcoder):
         I.e. the part that happens multiple times if the element has a quantifier.
         not including things like the "count" or "present" variable.
         """
+        if self.repeated_type_def_condition():
+            return self.raw_type_name() + "_r"
         if self.self_repeated_multi_var_condition():
-            name = self.raw_type_name()
-            if self.val_type_name() == name:
-                name = name + "_r"
-        else:
-            name = self.val_type_name()
-        return name
+            return self.raw_type_name()
+        return self.val_type_name()
 
     def full_type_name(self):
         """Name of the type for this element."""


### PR DESCRIPTION
because of naming collisions.